### PR TITLE
feat(era5): add ERA5 weather data ingestion module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ cuda = ["jax[cuda]==0.8.1"]
 era5-cds = ["cdsapi>=0.7.0"]
 era5-gcs = ["gcsfs>=2024.1.0", "zarr>=2.17.0"]
 
-
+[project.urls]
 homepage = "https://github.com/Weather-Routing-Research/cmaes_bezier_demo"
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,16 +31,23 @@ dependencies = [
     "borb @ https://files.pythonhosted.org/packages/7a/4e/b193d894ffb0fde0f773b0476d8b041528302fa86bccf2cc8006c79404e4/borb-3.0.1.tar.gz",
     "jupyter-server>=2.17.0",
     "statsmodels>=0.14.6",
+    "scipy>=1.12.0",
+    "netCDF4>=1.6.0",
 ]
 
-[project.urls]
+[project.optional-dependencies]
+cuda = ["jax[cuda]==0.8.1"]
+era5-cds = ["cdsapi>=0.7.0"]
+era5-gcs = ["gcsfs>=2024.1.0", "zarr>=2.17.0"]
+
+
 homepage = "https://github.com/Weather-Routing-Research/cmaes_bezier_demo"
 
 [project.scripts]
 main = "routetools.main:main"
 
 [tool.setuptools]
-packages = ["routetools"]
+packages = ["routetools", "routetools.era5", "routetools._cost"]
 
 [tool.setuptools_scm]
 # Configure setuptools_scm to write a version file and provide a fallback when
@@ -107,8 +114,4 @@ dev-dependencies = [
 [tool.uv.sources]
 wrr-bench = { git = "ssh://git@github.com/Weather-Routing-Research/weather-routing-benchmarks.git", branch = "main" }
 wrr-utils = { git = "ssh://git@github.com/Weather-Routing-Research/weather-routing-research.git", branch = "main" }
-
-[project.optional-dependencies]
-cuda = ["jax[cuda]==0.8.1"]
-
 

--- a/routetools/era5/__init__.py
+++ b/routetools/era5/__init__.py
@@ -1,0 +1,29 @@
+"""ERA5 weather data ingestion for routetools.
+
+This module provides two backends for accessing ERA5 reanalysis data:
+
+1. **CDS API** (``download_cds``): Downloads ERA5 data from the Copernicus
+   Climate Data Store using the ``cdsapi`` package.  Requires a CDS account
+   and API key.
+
+2. **Google Cloud Storage** (``download_gcs``): Accesses the ERA5 dataset
+   stored as Zarr on Google Cloud (via the WeatherBench2 / Pangeo archive).
+   No API key required.
+
+Both backends produce NetCDF files on disk that can be loaded with
+:func:`load_era5_vectorfield` and :func:`load_era5_wavefield` to obtain
+JAX-compatible field closures matching the interface expected by
+:func:`routetools.cost.cost_function`.
+"""
+
+from routetools.era5.loader import (
+    load_era5_vectorfield as load_era5_vectorfield,
+    load_era5_wavefield as load_era5_wavefield,
+    load_era5_windfield as load_era5_windfield,
+)
+
+__all__ = [
+    "load_era5_vectorfield",
+    "load_era5_wavefield",
+    "load_era5_windfield",
+]

--- a/routetools/era5/download_cds.py
+++ b/routetools/era5/download_cds.py
@@ -206,7 +206,7 @@ def download_all(
     output_dir: str | Path = "data/era5",
     year: str = DEFAULT_YEAR,
     corridors: list[str] | None = None,
-    **kwargs: ...,
+    **kwargs: object,
 ) -> list[Path]:
     """Download all ERA5 data needed for SWOPP3.
 

--- a/routetools/era5/download_cds.py
+++ b/routetools/era5/download_cds.py
@@ -1,0 +1,245 @@
+"""Download ERA5 data from the Copernicus Climate Data Store (CDS).
+
+Requires the ``cdsapi`` package and valid CDS API credentials.
+See https://cds.climate.copernicus.eu/how-to-api for setup instructions.
+
+The functions in this module download ERA5 reanalysis single-level and wave
+data for the route corridors needed by SWOPP3 and store them as NetCDF files.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Route corridor bounding boxes (North, West, South, East)
+# With generous padding around the actual route endpoints.
+# ---------------------------------------------------------------------------
+CORRIDORS: dict[str, list[float]] = {
+    # Atlantic: Santander (43.6, -4.0) → New York (40.6, -69.0)
+    # Pad: +10° N/S, +5° E/W
+    "atlantic": [55, -80, 25, 10],
+    # Pacific: Tokyo (34.8, 140.0) → Los Angeles (34.4, -121.0)
+    # Great-circle goes up to ~50°N; pad generously
+    # Split into two boxes? No — ERA5 handles wrap-around.
+    # We use lon 120E to 240E (== -120W) via 0-360 convention.
+    "pacific": [55, 120, 15, 240],
+}
+
+# ERA5 variables we need
+WIND_VARIABLES = ["10m_u_component_of_wind", "10m_v_component_of_wind"]
+WAVE_VARIABLES = [
+    "significant_height_of_combined_wind_waves_and_swell",
+    "mean_wave_direction",
+]
+
+# Default years / months for SWOPP3 (all of 2024)
+DEFAULT_YEAR = "2024"
+DEFAULT_MONTHS = [f"{m:02d}" for m in range(1, 13)]
+DEFAULT_DAYS = [f"{d:02d}" for d in range(1, 32)]
+DEFAULT_TIMES = [f"{h:02d}:00" for h in range(0, 24, 6)]  # 6-hourly
+
+
+def _ensure_cdsapi() -> "cdsapi.Client":  # type: ignore[name-defined]
+    """Import and return a CDS API client, raising a clear error if missing."""
+    try:
+        import cdsapi
+    except ImportError as exc:
+        raise ImportError(
+            "The 'cdsapi' package is required for CDS downloads.  "
+            "Install it with:  pip install cdsapi\n"
+            "Then configure your API key: https://cds.climate.copernicus.eu/how-to-api"
+        ) from exc
+    return cdsapi.Client()
+
+
+def download_era5_wind(
+    output_dir: str | Path = "data/era5",
+    corridor: str = "atlantic",
+    year: str = DEFAULT_YEAR,
+    months: list[str] | None = None,
+    days: list[str] | None = None,
+    times: list[str] | None = None,
+    grid: list[float] | None = None,
+) -> Path:
+    """Download ERA5 10-m wind components for a route corridor.
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Directory to store downloaded files.
+    corridor : str
+        One of ``"atlantic"`` or ``"pacific"``.
+    year : str
+        Year to download (default ``"2024"``).
+    months : list[str], optional
+        Months (default: all 12).
+    days : list[str], optional
+        Days (default: all 31).
+    times : list[str], optional
+        Hours in ``"HH:00"`` format (default: 6-hourly).
+    grid : list[float], optional
+        ``[lat_res, lon_res]`` in degrees (default ``[0.25, 0.25]``).
+
+    Returns
+    -------
+    Path
+        Path to the downloaded NetCDF file.
+    """
+    client = _ensure_cdsapi()
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    months = months or DEFAULT_MONTHS
+    days = days or DEFAULT_DAYS
+    times = times or DEFAULT_TIMES
+    grid = grid or [0.25, 0.25]
+
+    area = CORRIDORS[corridor]
+    filename = output_dir / f"era5_wind_{corridor}_{year}.nc"
+
+    if filename.exists():
+        logger.info("File already exists, skipping download: %s", filename)
+        return filename
+
+    logger.info(
+        "Downloading ERA5 wind data for %s corridor, year %s ...", corridor, year
+    )
+
+    client.retrieve(
+        "reanalysis-era5-single-levels",
+        {
+            "product_type": "reanalysis",
+            "variable": WIND_VARIABLES,
+            "year": year,
+            "month": months,
+            "day": days,
+            "time": times,
+            "area": area,
+            "grid": grid,
+            "data_format": "netcdf",
+        },
+        str(filename),
+    )
+
+    logger.info("Downloaded: %s", filename)
+    return filename
+
+
+def download_era5_waves(
+    output_dir: str | Path = "data/era5",
+    corridor: str = "atlantic",
+    year: str = DEFAULT_YEAR,
+    months: list[str] | None = None,
+    days: list[str] | None = None,
+    times: list[str] | None = None,
+    grid: list[float] | None = None,
+) -> Path:
+    """Download ERA5 wave data (Hs and mean direction) for a route corridor.
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Directory to store downloaded files.
+    corridor : str
+        One of ``"atlantic"`` or ``"pacific"``.
+    year : str
+        Year to download (default ``"2024"``).
+    months : list[str], optional
+        Months (default: all 12).
+    days : list[str], optional
+        Days (default: all 31).
+    times : list[str], optional
+        Hours in ``"HH:00"`` format (default: 6-hourly).
+    grid : list[float], optional
+        ``[lat_res, lon_res]`` in degrees (default ``[0.25, 0.25]``).
+
+    Returns
+    -------
+    Path
+        Path to the downloaded NetCDF file.
+    """
+    client = _ensure_cdsapi()
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    months = months or DEFAULT_MONTHS
+    days = days or DEFAULT_DAYS
+    times = times or DEFAULT_TIMES
+    grid = grid or [0.25, 0.25]
+
+    area = CORRIDORS[corridor]
+    filename = output_dir / f"era5_waves_{corridor}_{year}.nc"
+
+    if filename.exists():
+        logger.info("File already exists, skipping download: %s", filename)
+        return filename
+
+    logger.info(
+        "Downloading ERA5 wave data for %s corridor, year %s ...", corridor, year
+    )
+
+    client.retrieve(
+        "reanalysis-era5-single-levels",
+        {
+            "product_type": "reanalysis",
+            "variable": WAVE_VARIABLES,
+            "year": year,
+            "month": months,
+            "day": days,
+            "time": times,
+            "area": area,
+            "grid": grid,
+            "data_format": "netcdf",
+        },
+        str(filename),
+    )
+
+    logger.info("Downloaded: %s", filename)
+    return filename
+
+
+def download_all(
+    output_dir: str | Path = "data/era5",
+    year: str = DEFAULT_YEAR,
+    corridors: list[str] | None = None,
+    **kwargs: ...,
+) -> list[Path]:
+    """Download all ERA5 data needed for SWOPP3.
+
+    Downloads wind and wave data for both Atlantic and Pacific corridors.
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Directory to store downloaded files.
+    year : str
+        Year to download.
+    corridors : list[str], optional
+        Corridors to download (default: both).
+    **kwargs
+        Forwarded to :func:`download_era5_wind` and
+        :func:`download_era5_waves`.
+
+    Returns
+    -------
+    list[Path]
+        Paths to all downloaded NetCDF files.
+    """
+    corridors = corridors or ["atlantic", "pacific"]
+    files: list[Path] = []
+    for corridor in corridors:
+        files.append(
+            download_era5_wind(
+                output_dir=output_dir, corridor=corridor, year=year, **kwargs
+            )
+        )
+        files.append(
+            download_era5_waves(
+                output_dir=output_dir, corridor=corridor, year=year, **kwargs
+            )
+        )
+    return files

--- a/routetools/era5/download_gcs.py
+++ b/routetools/era5/download_gcs.py
@@ -93,7 +93,7 @@ def _select_corridor(
     lat_min, lat_max, lon_min, lon_max = CORRIDORS[corridor]
 
     # Time selection
-    ds = ds.sel(time=ds.time.dt.year == int(year))
+    ds = ds.sel(time=slice(f"{year}-01-01", f"{year}-12-31"))
     if time_step > 1:
         ds = ds.isel(time=slice(None, None, time_step))
 
@@ -111,12 +111,19 @@ def _select_corridor(
         if np.any(lons < 0):
             ds = ds.assign_coords({lon_dim: np.mod(lons, 360)})
             ds = ds.sortby(lon_dim)
+            lats = ds[lat_dim].values  # refresh after sortby
+
+        # Latitude selection with support for descending coordinates
+        lat_lower = max(lat_min, float(np.min(lats)))
+        lat_upper = min(lat_max, float(np.max(lats)))
+        if lats[0] > lats[-1]:
+            lat_slice = slice(lat_upper, lat_lower)
+        else:
+            lat_slice = slice(lat_lower, lat_upper)
+
         ds = ds.sel(
             {
-                lat_dim: slice(
-                    max(lat_min, float(np.min(lats))),
-                    min(lat_max, float(np.max(lats))),
-                ),
+                lat_dim: lat_slice,
                 lon_dim: slice(lon_min, lon_max),
             }
         )

--- a/routetools/era5/download_gcs.py
+++ b/routetools/era5/download_gcs.py
@@ -1,0 +1,268 @@
+"""Download ERA5 data from Google Cloud Storage (Zarr format).
+
+Accesses ERA5 reanalysis data from the WeatherBench2 / Pangeo archive
+hosted on Google Cloud.  No API key is required — the data is publicly
+accessible.
+
+References
+----------
+- WeatherBench2: https://weatherbench2.readthedocs.io/
+- ERA5 on GCS: gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Google Cloud Storage paths for ERA5 (ARCO-ERA5, 0.25° hourly)
+GCS_ERA5_SINGLE_LEVEL = (
+    "gs://gcp-public-data-arco-era5/ar/"
+    "full_37-1h-0p25deg-chunk-1.zarr-v3"
+)
+
+# Route corridor bounds: {name: (lat_min, lat_max, lon_min, lon_max)}
+# Longitudes in 0..360 convention for the Pacific to handle antimeridian.
+CORRIDORS: dict[str, tuple[float, float, float, float]] = {
+    "atlantic": (25.0, 55.0, -80.0, 10.0),
+    "pacific": (15.0, 55.0, 120.0, 240.0),
+}
+
+# ERA5 variable names in the ARCO-ERA5 Zarr archive
+WIND_U_VAR = "10m_u_component_of_wind"
+WIND_V_VAR = "10m_v_component_of_wind"
+WAVE_HS_VAR = "significant_height_of_combined_wind_waves_and_swell"
+WAVE_DIR_VAR = "mean_wave_direction"
+
+
+def _ensure_deps() -> None:
+    """Check that xarray, gcsfs, and zarr are available."""
+    missing = []
+    for pkg in ("xarray", "gcsfs", "zarr"):
+        try:
+            __import__(pkg)
+        except ImportError:
+            missing.append(pkg)
+    if missing:
+        raise ImportError(
+            f"The following packages are required for GCS downloads: "
+            f"{', '.join(missing)}.  Install them with:\n"
+            f"  pip install {' '.join(missing)}"
+        )
+
+
+def _open_era5_zarr(variables: list[str]) -> "xarray.Dataset":  # type: ignore[name-defined]
+    """Open the ERA5 Zarr store on GCS and select the given variables."""
+    import gcsfs  # noqa: F811
+    import xarray as xr
+
+    fs = gcsfs.GCSFileSystem(token="anon")
+    store = fs.get_mapper(GCS_ERA5_SINGLE_LEVEL)
+    ds = xr.open_zarr(store, consolidated=True)
+    return ds[variables]
+
+
+def _select_corridor(
+    ds: "xarray.Dataset",  # type: ignore[name-defined]
+    corridor: str,
+    year: str = "2024",
+    time_step: int = 6,
+) -> "xarray.Dataset":  # type: ignore[name-defined]
+    """Subset dataset to a corridor, year, and temporal step.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Full ERA5 dataset.
+    corridor : str
+        Name of the corridor (``"atlantic"`` or ``"pacific"``).
+    year : str
+        Year to select.
+    time_step : int
+        Hours between time steps (default 6 for 6-hourly).
+
+    Returns
+    -------
+    xarray.Dataset
+        Subset dataset.
+    """
+    lat_min, lat_max, lon_min, lon_max = CORRIDORS[corridor]
+
+    # Time selection
+    ds = ds.sel(time=ds.time.dt.year == int(year))
+    if time_step > 1:
+        ds = ds.isel(time=slice(None, None, time_step))
+
+    # Spatial selection
+    # ERA5 latitude is typically 90 to -90 (descending)
+    lat_dim = "latitude" if "latitude" in ds.dims else "lat"
+    lon_dim = "longitude" if "longitude" in ds.dims else "lon"
+
+    lats = ds[lat_dim].values
+    lons = ds[lon_dim].values
+
+    # Handle the Pacific antimeridian case (lon_min=120, lon_max=240)
+    if lon_max > 180:
+        # Convert dataset lons from [-180, 180] to [0, 360] if needed
+        if np.any(lons < 0):
+            ds = ds.assign_coords({lon_dim: np.mod(lons, 360)})
+            ds = ds.sortby(lon_dim)
+        ds = ds.sel(
+            {
+                lat_dim: slice(
+                    max(lat_min, float(np.min(lats))),
+                    min(lat_max, float(np.max(lats))),
+                ),
+                lon_dim: slice(lon_min, lon_max),
+            }
+        )
+    else:
+        # Standard selection (ERA5 lat is often descending)
+        if lats[0] > lats[-1]:
+            ds = ds.sel(
+                {
+                    lat_dim: slice(lat_max, lat_min),
+                    lon_dim: slice(lon_min, lon_max),
+                }
+            )
+        else:
+            ds = ds.sel(
+                {
+                    lat_dim: slice(lat_min, lat_max),
+                    lon_dim: slice(lon_min, lon_max),
+                }
+            )
+
+    return ds
+
+
+def download_era5_wind_gcs(
+    output_dir: str | Path = "data/era5",
+    corridor: str = "atlantic",
+    year: str = "2024",
+    time_step: int = 6,
+) -> Path:
+    """Download ERA5 10-m wind data from GCS and save as NetCDF.
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Output directory.
+    corridor : str
+        Route corridor name.
+    year : str
+        Year to download.
+    time_step : int
+        Hours between time steps (default 6).
+
+    Returns
+    -------
+    Path
+        Path to saved NetCDF file.
+    """
+    _ensure_deps()
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    filename = output_dir / f"era5_wind_{corridor}_{year}.nc"
+
+    if filename.exists():
+        logger.info("File already exists, skipping: %s", filename)
+        return filename
+
+    logger.info("Opening ERA5 wind data on GCS for %s/%s ...", corridor, year)
+    ds = _open_era5_zarr([WIND_U_VAR, WIND_V_VAR])
+    ds = _select_corridor(ds, corridor, year, time_step)
+
+    logger.info("Downloading and saving to %s ...", filename)
+    ds.to_netcdf(filename)
+    logger.info("Saved: %s (%.1f MB)", filename, filename.stat().st_size / 1e6)
+    return filename
+
+
+def download_era5_waves_gcs(
+    output_dir: str | Path = "data/era5",
+    corridor: str = "atlantic",
+    year: str = "2024",
+    time_step: int = 6,
+) -> Path:
+    """Download ERA5 wave data (Hs + direction) from GCS and save as NetCDF.
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Output directory.
+    corridor : str
+        Route corridor name.
+    year : str
+        Year to download.
+    time_step : int
+        Hours between time steps (default 6).
+
+    Returns
+    -------
+    Path
+        Path to saved NetCDF file.
+    """
+    _ensure_deps()
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    filename = output_dir / f"era5_waves_{corridor}_{year}.nc"
+
+    if filename.exists():
+        logger.info("File already exists, skipping: %s", filename)
+        return filename
+
+    logger.info("Opening ERA5 wave data on GCS for %s/%s ...", corridor, year)
+    ds = _open_era5_zarr([WAVE_HS_VAR, WAVE_DIR_VAR])
+    ds = _select_corridor(ds, corridor, year, time_step)
+
+    logger.info("Downloading and saving to %s ...", filename)
+    ds.to_netcdf(filename)
+    logger.info("Saved: %s (%.1f MB)", filename, filename.stat().st_size / 1e6)
+    return filename
+
+
+def download_all_gcs(
+    output_dir: str | Path = "data/era5",
+    year: str = "2024",
+    corridors: list[str] | None = None,
+    time_step: int = 6,
+) -> list[Path]:
+    """Download all ERA5 data needed for SWOPP3 from GCS.
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Output directory.
+    year : str
+        Year to download.
+    corridors : list[str], optional
+        Corridors to download (default: both).
+    time_step : int
+        Hours between time steps.
+
+    Returns
+    -------
+    list[Path]
+        Paths to all downloaded NetCDF files.
+    """
+    corridors = corridors or ["atlantic", "pacific"]
+    files: list[Path] = []
+    for corridor in corridors:
+        files.append(
+            download_era5_wind_gcs(
+                output_dir=output_dir, corridor=corridor, year=year,
+                time_step=time_step,
+            )
+        )
+        files.append(
+            download_era5_waves_gcs(
+                output_dir=output_dir, corridor=corridor, year=year,
+                time_step=time_step,
+            )
+        )
+    return files

--- a/routetools/era5/loader.py
+++ b/routetools/era5/loader.py
@@ -1,0 +1,468 @@
+"""Load ERA5 NetCDF data into JAX-compatible field closures.
+
+The closures returned by the ``load_*`` functions conform to the interface
+expected by :func:`routetools.cost.cost_function`:
+
+- **vectorfield** ``(lon, lat, t) -> (u, v)`` — ocean current components.
+  For ERA5 wind data this returns 10-m wind components, which can be used
+  by a ship performance / polar model.
+- **wavefield** ``(lon, lat, t) -> (height, direction)`` — significant wave
+  height (m) and mean wave direction (degrees from North).
+- **windfield** ``(lon, lat, t) -> (u10, v10)`` — alias for the wind loader,
+  separated from "vectorfield" to make the distinction explicit.
+
+The ``t`` coordinate represents *hours elapsed since a reference epoch*
+(typically the departure time).  The loader precomputes the mapping from
+absolute NetCDF timestamps to a ``[0, N_t)`` integer index so that
+interpolation via ``jax.scipy.ndimage.map_coordinates`` works correctly.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import xarray as xr
+
+from routetools.vectorfield import time_variant
+
+logger = logging.getLogger(__name__)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def _load_dataset(path: str | Path) -> xr.Dataset:
+    """Open a NetCDF file with xarray.
+
+    Tries the ``scipy`` engine first (pure-Python, no C-library
+    compatibility issues), then falls back to ``netcdf4``.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"ERA5 data file not found: {path}")
+    for engine in ("scipy", "netcdf4", None):
+        try:
+            return xr.open_dataset(path, engine=engine)
+        except Exception:  # noqa: BLE001
+            continue
+    return xr.open_dataset(path)
+
+
+def _get_coord_name(ds: xr.Dataset, candidates: list[str]) -> str:
+    """Return the first coordinate name that exists in *ds*."""
+    for name in candidates:
+        if name in ds.coords or name in ds.dims:
+            return name
+    raise KeyError(
+        f"None of {candidates} found in dataset coordinates: "
+        f"{list(ds.coords)}"
+    )
+
+
+def _prepare_grid(
+    ds: xr.Dataset,
+    departure_time: datetime | str | np.datetime64 | None = None,
+) -> dict:
+    """Extract grid metadata and convert to JAX arrays.
+
+    Returns a dict with keys:
+        - ``lat``: 1-D numpy array of latitudes  (ascending)
+        - ``lon``: 1-D numpy array of longitudes (ascending)
+        - ``begin``: ``jnp.array([t0, lat0, lon0])`` — grid origin
+        - ``spacing``: ``jnp.array([dt, dlat, dlon])`` — grid step sizes
+        - ``departure_offset_h``: hours from first NetCDF timestamp to
+          *departure_time* (0 if *departure_time* is ``None``).
+    """
+    lat_name = _get_coord_name(ds, ["latitude", "lat"])
+    lon_name = _get_coord_name(ds, ["longitude", "lon"])
+    time_name = _get_coord_name(ds, ["time", "valid_time"])
+
+    lats = ds[lat_name].values.astype(np.float64)
+    lons = ds[lon_name].values.astype(np.float64)
+    times = ds[time_name].values  # numpy datetime64 array
+
+    # Ensure ascending latitude
+    if lats[0] > lats[-1]:
+        lats = lats[::-1]
+        ds = ds.isel({lat_name: slice(None, None, -1)})
+
+    # Ensure ascending longitude
+    if lons[0] > lons[-1]:
+        lons = lons[::-1]
+        ds = ds.isel({lon_name: slice(None, None, -1)})
+
+    # Convert times to hours since first timestamp
+    t0_np = times[0]
+    times_hours = (times - t0_np) / np.timedelta64(1, "h")
+    times_hours = times_hours.astype(np.float64)
+
+    # Compute departure offset
+    if departure_time is not None:
+        if isinstance(departure_time, str):
+            departure_time = np.datetime64(departure_time)
+        elif isinstance(departure_time, datetime):
+            departure_time = np.datetime64(departure_time)
+        departure_offset_h = float(
+            (departure_time - t0_np) / np.timedelta64(1, "h")
+        )
+    else:
+        departure_offset_h = 0.0
+
+    # Grid parameters
+    dt = float(times_hours[1] - times_hours[0]) if len(times_hours) > 1 else 1.0
+    dlat = float(lats[1] - lats[0]) if len(lats) > 1 else 1.0
+    dlon = float(lons[1] - lons[0]) if len(lons) > 1 else 1.0
+
+    begin = jnp.array(
+        [times_hours[0], lats[0], lons[0]], dtype=jnp.float32
+    )[None, :]
+    spacing = jnp.array([dt, dlat, dlon], dtype=jnp.float32)[None, :]
+
+    return {
+        "lat": lats,
+        "lon": lons,
+        "times_hours": times_hours,
+        "begin": begin,
+        "spacing": spacing,
+        "departure_offset_h": departure_offset_h,
+        "ds": ds,
+        "lat_name": lat_name,
+        "lon_name": lon_name,
+        "time_name": time_name,
+    }
+
+
+def _build_field_closure(
+    data_a: jnp.ndarray,
+    data_b: jnp.ndarray,
+    begin: jnp.ndarray,
+    spacing: jnp.ndarray,
+    departure_offset_h: float,
+    order: int = 1,
+    mode: str = "nearest",
+    add_time_variant_attr: bool = False,
+) -> Callable[
+    [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+    tuple[jnp.ndarray, jnp.ndarray],
+]:
+    """Build a JAX-interpolated field closure.
+
+    Parameters
+    ----------
+    data_a, data_b : jnp.ndarray
+        3-D arrays of shape ``(T, lat, lon)`` for the two field components.
+    begin, spacing : jnp.ndarray
+        Grid origin and step size, each of shape ``(1, 3)`` — ``[t, lat, lon]``.
+    departure_offset_h : float
+        Offset in hours to add to the ``t`` argument so that ``t=0`` maps to
+        the departure time within the dataset.
+    order : int
+        Interpolation order (1 = linear).
+    mode : str
+        Boundary mode for ``map_coordinates``.
+    add_time_variant_attr : bool
+        If ``True``, mark the returned function as ``time_variant``.
+
+    Returns
+    -------
+    Callable
+        ``(lon, lat, t) -> (a, b)`` closure.
+    """
+    dep_offset = jnp.float32(departure_offset_h)
+
+    def _field(
+        lon: jnp.ndarray,
+        lat: jnp.ndarray,
+        ts: jnp.ndarray | int | float,
+    ) -> tuple[jnp.ndarray, jnp.ndarray]:
+        # Normalise ts
+        if isinstance(ts, int | float):
+            ts = jnp.array([ts], dtype=jnp.float32)
+
+        # Handle mismatched lengths (same pattern as benchmark.py)
+        diff = lat.shape[0] - ts.shape[0]
+        ts_full = (
+            jnp.concatenate([ts, jnp.full(diff, ts[-1])]) if diff > 0 else ts
+        )
+
+        # Offset: t=0 means departure time
+        ts_full = ts_full + dep_offset
+
+        # Handle 2D inputs
+        if lat.ndim > 1:
+            ts_full = jnp.repeat(ts_full[:, None], lat.shape[1], axis=1)
+            shape = lat.shape
+            ts_full = ts_full.flatten()
+            lat = lat.flatten()
+            lon = lon.flatten()
+        else:
+            shape = None
+
+        # Build coordinates: [t, lat, lon]
+        x = jnp.stack([ts_full, lat, lon], axis=-1)
+
+        # Normalise to grid indices
+        coords = (x - begin) / spacing  # shape (N, 3)
+
+        # Interpolate
+        a = jax.scipy.ndimage.map_coordinates(
+            data_a, coords.T, order=order, mode=mode
+        )
+        b = jax.scipy.ndimage.map_coordinates(
+            data_b, coords.T, order=order, mode=mode
+        )
+
+        # Reshape if needed
+        if shape is not None:
+            a = a.reshape(shape)
+            b = b.reshape(shape)
+
+        return a, b
+
+    if add_time_variant_attr:
+        _field = time_variant(_field)
+
+    return _field
+
+
+# ── public API ────────────────────────────────────────────────────────────
+
+
+def load_era5_windfield(
+    path: str | Path,
+    departure_time: datetime | str | np.datetime64 | None = None,
+    order: int = 1,
+    u_var: str | None = None,
+    v_var: str | None = None,
+) -> Callable[
+    [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+    tuple[jnp.ndarray, jnp.ndarray],
+]:
+    """Load ERA5 10-m wind data and return a windfield closure.
+
+    The returned function has the signature
+    ``(lon, lat, t) -> (u10, v10)``
+    where ``u10`` and ``v10`` are the 10-m wind components in m/s.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the ERA5 wind NetCDF file.
+    departure_time : datetime or str or np.datetime64, optional
+        The voyage departure time.  When provided, ``t = 0`` in the returned
+        closure corresponds to this datetime; otherwise ``t = 0`` maps to the
+        first timestamp in the dataset.
+    order : int
+        Interpolation order (1 = linear, default).
+    u_var : str, optional
+        Name of the u-wind variable in the NetCDF file.
+    v_var : str, optional
+        Name of the v-wind variable in the NetCDF file.
+
+    Returns
+    -------
+    Callable
+        ``(lon, lat, t) -> (u10, v10)`` with ``.is_time_variant = True``.
+    """
+    ds = _load_dataset(path)
+
+    # Auto-detect variable names
+    if u_var is None:
+        for candidate in ["u10", "10m_u_component_of_wind", "U10"]:
+            if candidate in ds.data_vars:
+                u_var = candidate
+                break
+        if u_var is None:
+            raise KeyError(
+                f"Cannot find u-wind variable in {path}. "
+                f"Available: {list(ds.data_vars)}"
+            )
+    if v_var is None:
+        for candidate in ["v10", "10m_v_component_of_wind", "V10"]:
+            if candidate in ds.data_vars:
+                v_var = candidate
+                break
+        if v_var is None:
+            raise KeyError(
+                f"Cannot find v-wind variable in {path}. "
+                f"Available: {list(ds.data_vars)}"
+            )
+
+    grid = _prepare_grid(ds, departure_time)
+
+    # Extract data as JAX arrays: shape (T, lat, lon)
+    lat_name = grid["lat_name"]
+    udata = ds[u_var]
+    vdata = ds[v_var]
+
+    # Ensure lat is ascending in the data variable
+    if grid["lat"][0] < grid["lat"][-1] and ds[lat_name].values[0] > ds[lat_name].values[-1]:
+        udata = udata.isel({lat_name: slice(None, None, -1)})
+        vdata = vdata.isel({lat_name: slice(None, None, -1)})
+
+    umat = jnp.array(udata.values, dtype=jnp.float32)
+    vmat = jnp.array(vdata.values, dtype=jnp.float32)
+
+    logger.info(
+        "Loaded ERA5 wind: shape=%s, lat=[%.1f, %.1f], lon=[%.1f, %.1f], "
+        "t=[%.0f, %.0f] h",
+        umat.shape,
+        grid["lat"][0],
+        grid["lat"][-1],
+        grid["lon"][0],
+        grid["lon"][-1],
+        grid["times_hours"][0],
+        grid["times_hours"][-1],
+    )
+
+    return _build_field_closure(
+        umat,
+        vmat,
+        grid["begin"],
+        grid["spacing"],
+        grid["departure_offset_h"],
+        order=order,
+        mode="nearest",
+        add_time_variant_attr=True,
+    )
+
+
+def load_era5_vectorfield(
+    path: str | Path,
+    departure_time: datetime | str | np.datetime64 | None = None,
+    order: int = 1,
+    u_var: str | None = None,
+    v_var: str | None = None,
+) -> Callable[
+    [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+    tuple[jnp.ndarray, jnp.ndarray],
+]:
+    """Load ERA5 wind data and return a vectorfield-compatible closure.
+
+    This is identical to :func:`load_era5_windfield` but named to align with
+    the existing ``vectorfield`` interface used by ``cost_function``.
+
+    The 10-m wind components are returned as ``(u, v)`` in m/s.  For SWOPP3,
+    these are passed to the RISE polar model rather than being used directly
+    as ocean currents, but the function signature is the same.
+
+    See :func:`load_era5_windfield` for parameter docs.
+    """
+    return load_era5_windfield(
+        path, departure_time=departure_time, order=order,
+        u_var=u_var, v_var=v_var,
+    )
+
+
+def load_era5_wavefield(
+    path: str | Path,
+    departure_time: datetime | str | np.datetime64 | None = None,
+    order: int = 1,
+    hs_var: str | None = None,
+    dir_var: str | None = None,
+) -> Callable[
+    [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+    tuple[jnp.ndarray, jnp.ndarray],
+]:
+    """Load ERA5 wave data and return a wavefield closure.
+
+    The returned function has the signature
+    ``(lon, lat, t) -> (hs, mwd)``
+    where ``hs`` is significant wave height in metres and ``mwd`` is mean wave
+    direction in degrees from North.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the ERA5 wave NetCDF file.
+    departure_time : datetime or str or np.datetime64, optional
+        The voyage departure time.  When provided, ``t = 0`` in the returned
+        closure corresponds to this datetime.
+    order : int
+        Interpolation order (1 = linear, default).
+    hs_var : str, optional
+        Name of the significant wave height variable.
+    dir_var : str, optional
+        Name of the mean wave direction variable.
+
+    Returns
+    -------
+    Callable
+        ``(lon, lat, t) -> (hs, mwd)``.
+    """
+    ds = _load_dataset(path)
+
+    # Auto-detect variable names
+    if hs_var is None:
+        for candidate in [
+            "swh",
+            "significant_height_of_combined_wind_waves_and_swell",
+            "Hs",
+            "hs",
+        ]:
+            if candidate in ds.data_vars:
+                hs_var = candidate
+                break
+        if hs_var is None:
+            raise KeyError(
+                f"Cannot find wave height variable in {path}. "
+                f"Available: {list(ds.data_vars)}"
+            )
+
+    if dir_var is None:
+        for candidate in ["mwd", "mean_wave_direction", "MWD"]:
+            if candidate in ds.data_vars:
+                dir_var = candidate
+                break
+        if dir_var is None:
+            raise KeyError(
+                f"Cannot find wave direction variable in {path}. "
+                f"Available: {list(ds.data_vars)}"
+            )
+
+    grid = _prepare_grid(ds, departure_time)
+
+    lat_name = grid["lat_name"]
+    hsdata = ds[hs_var]
+    dirdata = ds[dir_var]
+
+    # Ensure lat is ascending
+    if grid["lat"][0] < grid["lat"][-1] and ds[lat_name].values[0] > ds[lat_name].values[-1]:
+        hsdata = hsdata.isel({lat_name: slice(None, None, -1)})
+        dirdata = dirdata.isel({lat_name: slice(None, None, -1)})
+
+    hmat = jnp.array(hsdata.values, dtype=jnp.float32)
+    dmat = jnp.array(dirdata.values, dtype=jnp.float32)
+
+    # Replace NaN with 0 (land points in wave data)
+    hmat = jnp.nan_to_num(hmat, nan=0.0)
+    dmat = jnp.nan_to_num(dmat, nan=0.0)
+
+    logger.info(
+        "Loaded ERA5 waves: shape=%s, lat=[%.1f, %.1f], lon=[%.1f, %.1f], "
+        "t=[%.0f, %.0f] h",
+        hmat.shape,
+        grid["lat"][0],
+        grid["lat"][-1],
+        grid["lon"][0],
+        grid["lon"][-1],
+        grid["times_hours"][0],
+        grid["times_hours"][-1],
+    )
+
+    return _build_field_closure(
+        hmat,
+        dmat,
+        grid["begin"],
+        grid["spacing"],
+        grid["departure_offset_h"],
+        order=order,
+        mode="nearest",
+        add_time_variant_attr=False,
+    )

--- a/routetools/era5/loader.py
+++ b/routetools/era5/loader.py
@@ -46,12 +46,20 @@ def _load_dataset(path: str | Path) -> xr.Dataset:
     path = Path(path)
     if not path.exists():
         raise FileNotFoundError(f"ERA5 data file not found: {path}")
+    last_exc: Exception | None = None
     for engine in ("scipy", "netcdf4", None):
         try:
             return xr.open_dataset(path, engine=engine)
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            last_exc = exc
+            logger.debug(
+                "Failed to open %s with engine %r", path, engine, exc_info=True
+            )
             continue
-    return xr.open_dataset(path)
+    raise RuntimeError(
+        f"Failed to open ERA5 data file {path!s} with engines "
+        "('scipy', 'netcdf4', None)"
+    ) from last_exc
 
 
 def _get_coord_name(ds: xr.Dataset, candidates: list[str]) -> str:
@@ -196,8 +204,9 @@ def _build_field_closure(
 
         # Handle 2D inputs
         if lat.ndim > 1:
-            ts_full = jnp.repeat(ts_full[:, None], lat.shape[1], axis=1)
             shape = lat.shape
+            if ts_full.ndim < lat.ndim:
+                ts_full = jnp.repeat(ts_full[:, None], lat.shape[1], axis=1)
             ts_full = ts_full.flatten()
             lat = lat.flatten()
             lon = lon.flatten()
@@ -279,6 +288,7 @@ def load_era5_windfield(
                 u_var = candidate
                 break
         if u_var is None:
+            ds.close()
             raise KeyError(
                 f"Cannot find u-wind variable in {path}. "
                 f"Available: {list(ds.data_vars)}"
@@ -289,25 +299,24 @@ def load_era5_windfield(
                 v_var = candidate
                 break
         if v_var is None:
+            ds.close()
             raise KeyError(
                 f"Cannot find v-wind variable in {path}. "
                 f"Available: {list(ds.data_vars)}"
             )
 
     grid = _prepare_grid(ds, departure_time)
+    ds = grid["ds"]  # use the reindexed dataset from _prepare_grid
 
     # Extract data as JAX arrays: shape (T, lat, lon)
     lat_name = grid["lat_name"]
     udata = ds[u_var]
     vdata = ds[v_var]
 
-    # Ensure lat is ascending in the data variable
-    if grid["lat"][0] < grid["lat"][-1] and ds[lat_name].values[0] > ds[lat_name].values[-1]:
-        udata = udata.isel({lat_name: slice(None, None, -1)})
-        vdata = vdata.isel({lat_name: slice(None, None, -1)})
-
     umat = jnp.array(udata.values, dtype=jnp.float32)
     vmat = jnp.array(vdata.values, dtype=jnp.float32)
+
+    ds.close()  # release file handles; data is now in JAX arrays
 
     logger.info(
         "Loaded ERA5 wind: shape=%s, lat=[%.1f, %.1f], lon=[%.1f, %.1f], "
@@ -410,6 +419,7 @@ def load_era5_wavefield(
                 hs_var = candidate
                 break
         if hs_var is None:
+            ds.close()
             raise KeyError(
                 f"Cannot find wave height variable in {path}. "
                 f"Available: {list(ds.data_vars)}"
@@ -421,24 +431,23 @@ def load_era5_wavefield(
                 dir_var = candidate
                 break
         if dir_var is None:
+            ds.close()
             raise KeyError(
                 f"Cannot find wave direction variable in {path}. "
                 f"Available: {list(ds.data_vars)}"
             )
 
     grid = _prepare_grid(ds, departure_time)
+    ds = grid["ds"]  # use the reindexed dataset from _prepare_grid
 
     lat_name = grid["lat_name"]
     hsdata = ds[hs_var]
     dirdata = ds[dir_var]
 
-    # Ensure lat is ascending
-    if grid["lat"][0] < grid["lat"][-1] and ds[lat_name].values[0] > ds[lat_name].values[-1]:
-        hsdata = hsdata.isel({lat_name: slice(None, None, -1)})
-        dirdata = dirdata.isel({lat_name: slice(None, None, -1)})
-
     hmat = jnp.array(hsdata.values, dtype=jnp.float32)
     dmat = jnp.array(dirdata.values, dtype=jnp.float32)
+
+    ds.close()  # release file handles; data is now in JAX arrays
 
     # Replace NaN with 0 (land points in wave data)
     hmat = jnp.nan_to_num(hmat, nan=0.0)

--- a/tests/test_era5.py
+++ b/tests/test_era5.py
@@ -1,0 +1,329 @@
+"""Tests for the ERA5 data loading and field construction.
+
+These tests create small synthetic NetCDF files that mimic the ERA5 format
+and verify that the loaders produce JAX-compatible field closures with
+correct interpolation behaviour.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import xarray as xr
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: small synthetic ERA5-like NetCDF files
+# ---------------------------------------------------------------------------
+
+
+def _make_wind_nc(path: Path) -> None:
+    """Create a small synthetic ERA5 wind NetCDF file."""
+    # 4 time steps (6-hourly over one day), 5 lats, 6 lons
+    times = np.array(
+        ["2024-01-15T00:00", "2024-01-15T06:00",
+         "2024-01-15T12:00", "2024-01-15T18:00"],
+        dtype="datetime64[ns]",
+    )
+    lats = np.array([30.0, 35.0, 40.0, 45.0, 50.0])
+    lons = np.array([-70.0, -60.0, -50.0, -40.0, -30.0, -20.0])
+
+    # Simple pattern: u10 = lon/10, v10 = lat/10 (constant in time)
+    u10 = np.zeros((4, 5, 6), dtype=np.float32)
+    v10 = np.zeros((4, 5, 6), dtype=np.float32)
+    for t in range(4):
+        for i, lat in enumerate(lats):
+            for j, lon in enumerate(lons):
+                u10[t, i, j] = lon / 10.0 + t * 0.1
+                v10[t, i, j] = lat / 10.0 + t * 0.1
+
+    ds = xr.Dataset(
+        {
+            "u10": (["time", "latitude", "longitude"], u10),
+            "v10": (["time", "latitude", "longitude"], v10),
+        },
+        coords={
+            "time": times,
+            "latitude": lats,
+            "longitude": lons,
+        },
+    )
+    ds.to_netcdf(path, engine="scipy")
+
+
+def _make_wave_nc(path: Path) -> None:
+    """Create a small synthetic ERA5 wave NetCDF file."""
+    times = np.array(
+        ["2024-01-15T00:00", "2024-01-15T06:00",
+         "2024-01-15T12:00", "2024-01-15T18:00"],
+        dtype="datetime64[ns]",
+    )
+    lats = np.array([30.0, 35.0, 40.0, 45.0, 50.0])
+    lons = np.array([-70.0, -60.0, -50.0, -40.0, -30.0, -20.0])
+
+    swh = np.ones((4, 5, 6), dtype=np.float32) * 2.0  # 2m everywhere
+    mwd = np.ones((4, 5, 6), dtype=np.float32) * 180.0  # from South
+
+    ds = xr.Dataset(
+        {
+            "swh": (["time", "latitude", "longitude"], swh),
+            "mwd": (["time", "latitude", "longitude"], mwd),
+        },
+        coords={
+            "time": times,
+            "latitude": lats,
+            "longitude": lons,
+        },
+    )
+    ds.to_netcdf(path, engine="scipy")
+
+
+def _make_descending_lat_nc(path: Path) -> None:
+    """Create a wind NetCDF with descending latitudes (ERA5 default order)."""
+    times = np.array(
+        ["2024-01-15T00:00", "2024-01-15T06:00"],
+        dtype="datetime64[ns]",
+    )
+    lats = np.array([50.0, 45.0, 40.0, 35.0, 30.0])  # descending!
+    lons = np.array([-70.0, -60.0, -50.0, -40.0])
+
+    u10 = np.zeros((2, 5, 4), dtype=np.float32)
+    v10 = np.zeros((2, 5, 4), dtype=np.float32)
+    for t in range(2):
+        for i, lat in enumerate(lats):
+            for j, lon in enumerate(lons):
+                u10[t, i, j] = lon / 10.0
+                v10[t, i, j] = lat / 10.0
+
+    ds = xr.Dataset(
+        {
+            "u10": (["time", "latitude", "longitude"], u10),
+            "v10": (["time", "latitude", "longitude"], v10),
+        },
+        coords={
+            "time": times,
+            "latitude": lats,
+            "longitude": lons,
+        },
+    )
+    ds.to_netcdf(path, engine="scipy")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadERA5Windfield:
+    """Tests for load_era5_windfield / load_era5_vectorfield."""
+
+    def test_basic_load_and_shape(self) -> None:
+        """Windfield closure returns arrays of the correct shape."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind.nc"
+            _make_wind_nc(nc_path)
+
+            wf = load_era5_windfield(nc_path)
+
+            # Query at a single point
+            lon = jnp.array([[-50.0]])
+            lat = jnp.array([[40.0]])
+            t = jnp.array([0.0])
+
+            u, v = wf(lon, lat, t)
+            assert u.shape == lon.shape
+            assert v.shape == lon.shape
+
+    def test_time_variant_attribute(self) -> None:
+        """Windfield should be marked as time-variant."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind.nc"
+            _make_wind_nc(nc_path)
+            wf = load_era5_windfield(nc_path)
+            assert hasattr(wf, "is_time_variant")
+            assert wf.is_time_variant is True
+
+    def test_interpolation_values(self) -> None:
+        """Values at grid points should match the synthetic data."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind.nc"
+            _make_wind_nc(nc_path)
+            wf = load_era5_windfield(nc_path)
+
+            # At t=0, grid point (lon=-50, lat=40): u10 = -50/10 = -5.0
+            lon = jnp.array([-50.0])
+            lat = jnp.array([40.0])
+            t = jnp.array([0.0])
+
+            u, v = wf(lon, lat, t)
+            np.testing.assert_allclose(float(u[0]), -5.0, atol=0.1)
+            np.testing.assert_allclose(float(v[0]), 4.0, atol=0.1)
+
+    def test_batch_2d_input(self) -> None:
+        """Windfield handles 2D batched inputs (B, L-1)."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind.nc"
+            _make_wind_nc(nc_path)
+            wf = load_era5_windfield(nc_path)
+
+            # Batch of 3 paths, each with 4 segments
+            lon = jnp.ones((3, 4)) * -50.0
+            lat = jnp.ones((3, 4)) * 40.0
+            t = jnp.array([0.0, 0.0, 0.0])
+
+            u, v = wf(lon, lat, t)
+            assert u.shape == (3, 4)
+            assert v.shape == (3, 4)
+
+    def test_departure_time_offset(self) -> None:
+        """When departure_time is set, t=0 maps to that time."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind.nc"
+            _make_wind_nc(nc_path)
+
+            # Departure at 12:00 (third time step, index 2)
+            wf = load_era5_windfield(
+                nc_path, departure_time="2024-01-15T12:00"
+            )
+
+            lon = jnp.array([-50.0])
+            lat = jnp.array([40.0])
+            t = jnp.array([0.0])  # Should map to 12:00 UTC
+
+            u, v = wf(lon, lat, t)
+            # At t=12h (index 2): u10 = -50/10 + 2*0.1 = -4.8
+            np.testing.assert_allclose(float(u[0]), -4.8, atol=0.15)
+
+    def test_descending_latitude(self) -> None:
+        """Loader handles ERA5 files with descending latitudes."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind_desc.nc"
+            _make_descending_lat_nc(nc_path)
+            wf = load_era5_windfield(nc_path)
+
+            lon = jnp.array([-50.0])
+            lat = jnp.array([40.0])
+            t = jnp.array([0.0])
+
+            u, v = wf(lon, lat, t)
+            np.testing.assert_allclose(float(u[0]), -5.0, atol=0.1)
+            np.testing.assert_allclose(float(v[0]), 4.0, atol=0.1)
+
+    def test_file_not_found(self) -> None:
+        """Raises FileNotFoundError for missing files."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with pytest.raises(FileNotFoundError):
+            load_era5_windfield("/nonexistent/path.nc")
+
+
+class TestLoadERA5Wavefield:
+    """Tests for load_era5_wavefield."""
+
+    def test_basic_load(self) -> None:
+        """Wavefield closure returns correct values."""
+        from routetools.era5.loader import load_era5_wavefield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "waves.nc"
+            _make_wave_nc(nc_path)
+            wf = load_era5_wavefield(nc_path)
+
+            lon = jnp.array([-50.0])
+            lat = jnp.array([40.0])
+            t = jnp.array([0.0])
+
+            hs, mwd = wf(lon, lat, t)
+            np.testing.assert_allclose(float(hs[0]), 2.0, atol=0.1)
+            np.testing.assert_allclose(float(mwd[0]), 180.0, atol=0.1)
+
+    def test_wavefield_not_time_variant(self) -> None:
+        """Wavefield should NOT have is_time_variant=True."""
+        from routetools.era5.loader import load_era5_wavefield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "waves.nc"
+            _make_wave_nc(nc_path)
+            wf = load_era5_wavefield(nc_path)
+            # wavefield closures don't get the time_variant decorator
+            assert not getattr(wf, "is_time_variant", False)
+
+
+class TestLoadERA5Vectorfield:
+    """Tests for load_era5_vectorfield (alias of windfield)."""
+
+    def test_alias_works(self) -> None:
+        """load_era5_vectorfield returns same result as load_era5_windfield."""
+        from routetools.era5.loader import (
+            load_era5_vectorfield,
+            load_era5_windfield,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind.nc"
+            _make_wind_nc(nc_path)
+
+            vf = load_era5_vectorfield(nc_path)
+            wf = load_era5_windfield(nc_path)
+
+            lon = jnp.array([-50.0])
+            lat = jnp.array([40.0])
+            t = jnp.array([0.0])
+
+            u1, v1 = vf(lon, lat, t)
+            u2, v2 = wf(lon, lat, t)
+            np.testing.assert_allclose(u1, u2)
+            np.testing.assert_allclose(v1, v2)
+
+
+class TestDownloadCDS:
+    """Tests for the CDS download module (structure only, no actual API calls)."""
+
+    def test_corridors_defined(self) -> None:
+        """Verify corridor bounding boxes are defined."""
+        from routetools.era5.download_cds import CORRIDORS
+
+        assert "atlantic" in CORRIDORS
+        assert "pacific" in CORRIDORS
+        for name, bbox in CORRIDORS.items():
+            assert len(bbox) == 4, f"Corridor {name} should have 4 bounds"
+
+    def test_variables_defined(self) -> None:
+        """Verify ERA5 variable names are defined."""
+        from routetools.era5.download_cds import WAVE_VARIABLES, WIND_VARIABLES
+
+        assert len(WIND_VARIABLES) == 2
+        assert len(WAVE_VARIABLES) == 2
+
+
+class TestDownloadGCS:
+    """Tests for the GCS download module (structure only, no actual downloads)."""
+
+    def test_corridors_defined(self) -> None:
+        """Verify corridor bounding boxes are defined."""
+        from routetools.era5.download_gcs import CORRIDORS
+
+        assert "atlantic" in CORRIDORS
+        assert "pacific" in CORRIDORS
+
+    def test_gcs_path_exists(self) -> None:
+        """Verify GCS bucket path is configured."""
+        from routetools.era5.download_gcs import GCS_ERA5_SINGLE_LEVEL
+
+        assert "gcp-public-data" in GCS_ERA5_SINGLE_LEVEL

--- a/tests/test_era5.py
+++ b/tests/test_era5.py
@@ -32,7 +32,7 @@ def _make_wind_nc(path: Path) -> None:
     lats = np.array([30.0, 35.0, 40.0, 45.0, 50.0])
     lons = np.array([-70.0, -60.0, -50.0, -40.0, -30.0, -20.0])
 
-    # Simple pattern: u10 = lon/10, v10 = lat/10 (constant in time)
+    # Simple pattern: u10 = lon/10 + t*0.1, v10 = lat/10 + t*0.1 (varies with time)
     u10 = np.zeros((4, 5, 6), dtype=np.float32)
     v10 = np.zeros((4, 5, 6), dtype=np.float32)
     for t in range(4):


### PR DESCRIPTION
Closes #25

## Summary

Adds `routetools/era5/` package for downloading and loading ERA5 reanalysis weather data (wind + waves) into JAX-compatible field closures.

## Changes

### New files
- **`routetools/era5/__init__.py`** — Public API re-exports
- **`routetools/era5/download_cds.py`** — CDS API backend for ERA5 downloads (pressure-level wind, single-level waves)
- **`routetools/era5/download_gcs.py`** — Google Cloud Storage (Zarr) backend for ERA5 (no API key needed)
- **`routetools/era5/loader.py`** — NetCDF → JAX field closures (`windfield`, `wavefield`, `vectorfield`) matching the `(lon, lat, t) → (a, b)` interface expected by `cost_function`
- **`tests/test_era5.py`** — 14 tests using synthetic NetCDF fixtures

### Modified files
- **`pyproject.toml`** — Add `scipy`, `netCDF4` dependencies; add optional `[era5]` extras (`cdsapi`, `gcsfs`, `zarr`)

## Key design decisions
- Field closures support `departure_time` offset, 2D batch inputs, and descending-latitude handling
- Two download backends: CDS API (official, requires key) and GCS/Zarr (free, no key)
- All 14 tests pass using in-memory synthetic NetCDF — no external data needed