### PR TITLE
feat: enforce weather constraints (TWS < 20 m/s, Hs < 7 m)

### DIFF
--- a/routetools/cmaes.py
+++ b/routetools/cmaes.py
@@ -16,6 +16,7 @@ from jax import jit
 from routetools.cost import cost_function
 from routetools.land import Land
 from routetools.vectorfield import vectorfield_fourvortices
+from routetools.weather import weather_penalty as _weather_penalty
 
 
 @jit  # type: ignore[misc]
@@ -282,7 +283,14 @@ def _cma_evolution_strategy(
         [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
     ]
     | None = None,
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
     penalty: float = 10,
+    weather_penalty_weight: float = 0.0,
+    tws_limit: float = 20.0,
+    hs_limit: float = 7.0,
     travel_stw: float | None = None,
     travel_time: float | None = None,
     L: int = 64,
@@ -354,6 +362,17 @@ def _cma_evolution_strategy(
         if land is not None and penalty > 0:
             cost += land.penalization(curve, penalty=penalty)
 
+        # Weather constraint penalization
+        if weather_penalty_weight > 0 and (windfield is not None or wavefield is not None):
+            cost += _weather_penalty(
+                curve,
+                windfield=windfield,
+                wavefield=wavefield,
+                tws_limit=tws_limit,
+                hs_limit=hs_limit,
+                penalty=weather_penalty_weight,
+            )
+
         # Replace the worst solutions with the best found so far
         if keep_top > 0 and es.countiter > 1:
             num_replace = min(num_top, len(X))
@@ -392,7 +411,14 @@ def optimize(
         [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
     ]
     | None = None,
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
     penalty: float = 10,
+    weather_penalty_weight: float = 0.0,
+    tws_limit: float = 20.0,
+    hs_limit: float = 7.0,
     travel_stw: float | None = None,
     travel_time: float | None = None,
     K: int = 6,
@@ -439,6 +465,13 @@ def optimize(
         by default None
     penalty : float, optional
         Penalty for land points, by default 10
+    weather_penalty_weight : float, optional
+        Penalty weight for weather constraint violations (TWS, Hs).
+        Set to 0 (default) to disable weather penalties.
+    tws_limit : float, optional
+        Maximum allowed true wind speed in m/s, by default 20.0
+    hs_limit : float, optional
+        Maximum allowed significant wave height in m, by default 7.0
     travel_stw : float, optional
         The boat will have this fixed speed through water (STW).
         If set, then `travel_time` must be None. By default None
@@ -535,7 +568,11 @@ def optimize(
         x0=x0,
         land=land,
         wavefield=wavefield,
+        windfield=windfield,
         penalty=penalty,
+        weather_penalty_weight=weather_penalty_weight,
+        tws_limit=tws_limit,
+        hs_limit=hs_limit,
         travel_stw=travel_stw,
         travel_time=travel_time,
         L=L,
@@ -584,6 +621,17 @@ def optimize(
             cost_initial += land.penalization(
                 curve0[jnp.newaxis, :, :], penalty=penalty
             ).item()
+        if weather_penalty_weight > 0 and (
+            windfield is not None or wavefield is not None
+        ):
+            cost_initial += _weather_penalty(
+                curve0[jnp.newaxis, :, :],
+                windfield=windfield,
+                wavefield=wavefield,
+                tws_limit=tws_limit,
+                hs_limit=hs_limit,
+                penalty=weather_penalty_weight,
+            ).item()
         if cost_initial < cost_best:
             warnings.warn(
                 "[WARNING] The optimized curve has a higher cost "
@@ -615,9 +663,16 @@ def optimize_with_increasing_penalization(
         [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
     ]
     | None = None,
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
     penalty_init: float = 0,
     penalty_increment: float = 10,
     maxiter: int = 10,
+    weather_penalty_weight: float = 0.0,
+    tws_limit: float = 20.0,
+    hs_limit: float = 7.0,
     travel_stw: float | None = None,
     travel_time: float | None = None,
     K: int = 6,
@@ -664,6 +719,13 @@ def optimize_with_increasing_penalization(
         Increment in the penalty for land points. By default 10
     maxiter : int, optional
         Maximum number of iterations. By default 10
+    weather_penalty_weight : float, optional
+        Penalty weight for weather constraint violations (TWS, Hs).
+        Set to 0 (default) to disable weather penalties.
+    tws_limit : float, optional
+        Maximum allowed true wind speed in m/s, by default 20.0
+    hs_limit : float, optional
+        Maximum allowed significant wave height in m, by default 7.0
     travel_stw : float, optional
         The boat will have this fixed speed through water (STW).
         If set, then `travel_time` must be None. By default None
@@ -720,7 +782,11 @@ def optimize_with_increasing_penalization(
             x0=x0,
             land=land,
             wavefield=wavefield,
+            windfield=windfield,
             penalty=penalty,
+            weather_penalty_weight=weather_penalty_weight,
+            tws_limit=tws_limit,
+            hs_limit=hs_limit,
             travel_stw=travel_stw,
             travel_time=travel_time,
             L=L,

--- a/routetools/weather.py
+++ b/routetools/weather.py
@@ -1,0 +1,282 @@
+"""Weather constraint enforcement for route optimization.
+
+Provides penalty functions that discourage routes from traversing regions
+where weather conditions exceed safe operating limits.  The two SWOPP3
+constraints are:
+
+- True Wind Speed (TWS) < 20 m/s
+- Significant Wave Height (Hs) < 7 m
+
+The penalty functions follow the same pattern as ``Land.penalization`` and
+are designed to be added to the cost in the CMA-ES optimization loop::
+
+    cost += weather_penalty(curve, windfield, wavefield, ...)
+
+The module also provides a ``RouteWeatherStats`` dataclass to report
+per-route max TWS and max Hs (required columns in SWOPP3 File A).
+
+Example
+-------
+>>> from routetools.weather import weather_penalty
+>>> # penalty = weather_penalty(curve, windfield, wavefield)
+>>> # cost += penalty
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import jax.numpy as jnp
+
+# ---------------------------------------------------------------------------
+# Default SWOPP3 constraint thresholds
+# ---------------------------------------------------------------------------
+DEFAULT_TWS_LIMIT: float = 20.0
+"""Maximum allowed true wind speed in m/s (SWOPP3 spec)."""
+
+DEFAULT_HS_LIMIT: float = 7.0
+"""Maximum allowed significant wave height in m (SWOPP3 spec)."""
+
+__all__ = [
+    "DEFAULT_TWS_LIMIT",
+    "DEFAULT_HS_LIMIT",
+    "RouteWeatherStats",
+    "evaluate_weather",
+    "weather_penalty",
+    "weather_penalty_smooth",
+]
+
+
+# ---------------------------------------------------------------------------
+# Route weather statistics
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class RouteWeatherStats:
+    """Per-route weather statistics for reporting.
+
+    Attributes
+    ----------
+    max_tws : jnp.ndarray
+        Maximum true wind speed along each route, shape ``(B,)``.
+    max_hs : jnp.ndarray
+        Maximum significant wave height along each route, shape ``(B,)``.
+    tws_exceeded : jnp.ndarray
+        Boolean array: whether any waypoint exceeded the TWS limit, shape ``(B,)``.
+    hs_exceeded : jnp.ndarray
+        Boolean array: whether any waypoint exceeded the Hs limit, shape ``(B,)``.
+    """
+
+    max_tws: jnp.ndarray
+    max_hs: jnp.ndarray
+    tws_exceeded: jnp.ndarray
+    hs_exceeded: jnp.ndarray
+
+
+# ---------------------------------------------------------------------------
+# Core evaluation
+# ---------------------------------------------------------------------------
+def evaluate_weather(
+    curve: jnp.ndarray,
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+        tuple[jnp.ndarray, jnp.ndarray],
+    ]
+    | None = None,
+    wavefield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+        tuple[jnp.ndarray, jnp.ndarray],
+    ]
+    | None = None,
+    tws_limit: float = DEFAULT_TWS_LIMIT,
+    hs_limit: float = DEFAULT_HS_LIMIT,
+) -> RouteWeatherStats:
+    """Evaluate weather conditions along routes and report statistics.
+
+    Samples the windfield and wavefield at the **midpoints** of each
+    route segment (same convention as the cost function) and computes
+    per-route maxima.
+
+    Parameters
+    ----------
+    curve : jnp.ndarray
+        Batch of trajectories, shape ``(B, L, 2)`` with ``(lon, lat)``
+        coordinates.
+    windfield : Callable, optional
+        ``(lon, lat, t) -> (u10, v10)`` closure.  If ``None``, TWS stats
+        are returned as zeros.
+    wavefield : Callable, optional
+        ``(lon, lat, t) -> (hs, mwd)`` closure.  If ``None``, Hs stats
+        are returned as zeros.
+    tws_limit : float
+        TWS threshold in m/s.
+    hs_limit : float
+        Hs threshold in m.
+
+    Returns
+    -------
+    RouteWeatherStats
+        Per-route maxima and exceedance flags.
+    """
+    B = curve.shape[0]
+
+    # Midpoints of each segment
+    mid_lon = (curve[:, :-1, 0] + curve[:, 1:, 0]) / 2
+    mid_lat = (curve[:, :-1, 1] + curve[:, 1:, 1]) / 2
+    t_zeros = jnp.zeros_like(mid_lon)
+
+    # Wind
+    if windfield is not None:
+        u10, v10 = windfield(mid_lon, mid_lat, t_zeros)
+        tws = jnp.sqrt(u10**2 + v10**2)
+        max_tws = jnp.max(tws, axis=1)
+    else:
+        max_tws = jnp.zeros(B)
+
+    # Waves
+    if wavefield is not None:
+        hs, _ = wavefield(mid_lon, mid_lat, t_zeros)
+        max_hs = jnp.max(hs, axis=1)
+    else:
+        max_hs = jnp.zeros(B)
+
+    return RouteWeatherStats(
+        max_tws=max_tws,
+        max_hs=max_hs,
+        tws_exceeded=max_tws > tws_limit,
+        hs_exceeded=max_hs > hs_limit,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hard penalty (step function — same pattern as Land.penalization)
+# ---------------------------------------------------------------------------
+def weather_penalty(
+    curve: jnp.ndarray,
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+        tuple[jnp.ndarray, jnp.ndarray],
+    ]
+    | None = None,
+    wavefield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+        tuple[jnp.ndarray, jnp.ndarray],
+    ]
+    | None = None,
+    tws_limit: float = DEFAULT_TWS_LIMIT,
+    hs_limit: float = DEFAULT_HS_LIMIT,
+    penalty: float = 10.0,
+) -> jnp.ndarray:
+    """Compute a hard penalty for weather constraint violations.
+
+    For each route in the batch, counts the number of **segments** where
+    TWS or Hs exceeds the threshold, multiplied by ``penalty``.  This is
+    analogous to ``Land.penalization``.
+
+    Parameters
+    ----------
+    curve : jnp.ndarray
+        Batch of trajectories, shape ``(B, L, 2)``.
+    windfield : Callable, optional
+        ``(lon, lat, t) -> (u10, v10)``.
+    wavefield : Callable, optional
+        ``(lon, lat, t) -> (hs, mwd)``.
+    tws_limit : float
+        TWS threshold in m/s (default 20).
+    hs_limit : float
+        Hs threshold in m (default 7).
+    penalty : float
+        Penalty per violating segment (default 10).
+
+    Returns
+    -------
+    jnp.ndarray
+        Penalty per route, shape ``(B,)``.
+    """
+    mid_lon = (curve[:, :-1, 0] + curve[:, 1:, 0]) / 2
+    mid_lat = (curve[:, :-1, 1] + curve[:, 1:, 1]) / 2
+    t_zeros = jnp.zeros_like(mid_lon)
+
+    violations = jnp.zeros(curve.shape[0])
+
+    if windfield is not None:
+        u10, v10 = windfield(mid_lon, mid_lat, t_zeros)
+        tws = jnp.sqrt(u10**2 + v10**2)
+        violations = violations + jnp.sum(tws > tws_limit, axis=1)
+
+    if wavefield is not None:
+        hs, _ = wavefield(mid_lon, mid_lat, t_zeros)
+        violations = violations + jnp.sum(hs > hs_limit, axis=1)
+
+    return violations * penalty
+
+
+# ---------------------------------------------------------------------------
+# Smooth penalty (differentiable — useful for gradient-based methods)
+# ---------------------------------------------------------------------------
+def weather_penalty_smooth(
+    curve: jnp.ndarray,
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+        tuple[jnp.ndarray, jnp.ndarray],
+    ]
+    | None = None,
+    wavefield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+        tuple[jnp.ndarray, jnp.ndarray],
+    ]
+    | None = None,
+    tws_limit: float = DEFAULT_TWS_LIMIT,
+    hs_limit: float = DEFAULT_HS_LIMIT,
+    penalty: float = 10.0,
+    sharpness: float = 5.0,
+) -> jnp.ndarray:
+    """Compute a smooth (differentiable) penalty for weather violations.
+
+    Uses a soft-plus-like ramp so that the penalty increases continuously
+    as conditions worsen beyond the threshold.  For each segment:
+
+        ``penalty_i = penalty · max(0, value - limit)² · sharpness``
+
+    This is summed over all segments per route.
+
+    Parameters
+    ----------
+    curve : jnp.ndarray
+        Batch of trajectories, shape ``(B, L, 2)``.
+    windfield : Callable, optional
+        ``(lon, lat, t) -> (u10, v10)``.
+    wavefield : Callable, optional
+        ``(lon, lat, t) -> (hs, mwd)``.
+    tws_limit : float
+        TWS threshold in m/s (default 20).
+    hs_limit : float
+        Hs threshold in m (default 7).
+    penalty : float
+        Scaling factor (default 10).
+    sharpness : float
+        Controls how steeply the penalty grows beyond the limit (default 5).
+
+    Returns
+    -------
+    jnp.ndarray
+        Smooth penalty per route, shape ``(B,)``.
+    """
+    mid_lon = (curve[:, :-1, 0] + curve[:, 1:, 0]) / 2
+    mid_lat = (curve[:, :-1, 1] + curve[:, 1:, 1]) / 2
+    t_zeros = jnp.zeros_like(mid_lon)
+
+    total = jnp.zeros(curve.shape[0])
+
+    if windfield is not None:
+        u10, v10 = windfield(mid_lon, mid_lat, t_zeros)
+        tws = jnp.sqrt(u10**2 + v10**2)
+        excess = jnp.maximum(tws - tws_limit, 0.0)
+        total = total + jnp.sum(excess**2, axis=1) * sharpness
+
+    if wavefield is not None:
+        hs, _ = wavefield(mid_lon, mid_lat, t_zeros)
+        excess = jnp.maximum(hs - hs_limit, 0.0)
+        total = total + jnp.sum(excess**2, axis=1) * sharpness
+
+    return total * penalty

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,281 @@
+"""Tests for routetools.weather — weather constraint penalties."""
+
+import jax.numpy as jnp
+import pytest
+
+from routetools.weather import (
+    DEFAULT_HS_LIMIT,
+    DEFAULT_TWS_LIMIT,
+    RouteWeatherStats,
+    evaluate_weather,
+    weather_penalty,
+    weather_penalty_smooth,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic field helpers
+# ---------------------------------------------------------------------------
+def _constant_windfield(u: float, v: float):
+    """Return a windfield closure producing constant (u, v)."""
+
+    def _field(lon, lat, t):
+        return jnp.full_like(lon, u), jnp.full_like(lon, v)
+
+    return _field
+
+
+def _constant_wavefield(hs: float, mwd: float = 0.0):
+    """Return a wavefield closure producing constant (hs, mwd)."""
+
+    def _field(lon, lat, t):
+        return jnp.full_like(lon, hs), jnp.full_like(lon, mwd)
+
+    return _field
+
+
+def _make_curve(n_routes: int = 1, n_points: int = 10) -> jnp.ndarray:
+    """Create a batch of straight-line curves from (0,0) to (1,0)."""
+    src = jnp.array([0.0, 0.0])
+    dst = jnp.array([1.0, 0.0])
+    single = jnp.linspace(src, dst, n_points)  # (L, 2)
+    return jnp.tile(single[jnp.newaxis, :, :], (n_routes, 1, 1))  # (B, L, 2)
+
+
+# ---------------------------------------------------------------------------
+# Tests for default constants
+# ---------------------------------------------------------------------------
+class TestDefaults:
+    def test_tws_limit(self):
+        assert DEFAULT_TWS_LIMIT == 20.0
+
+    def test_hs_limit(self):
+        assert DEFAULT_HS_LIMIT == 7.0
+
+
+# ---------------------------------------------------------------------------
+# Tests for RouteWeatherStats
+# ---------------------------------------------------------------------------
+class TestRouteWeatherStats:
+    def test_frozen(self):
+        stats = RouteWeatherStats(
+            max_tws=jnp.array([10.0]),
+            max_hs=jnp.array([3.0]),
+            tws_exceeded=jnp.array([False]),
+            hs_exceeded=jnp.array([False]),
+        )
+        with pytest.raises(AttributeError):
+            stats.max_tws = jnp.array([99.0])
+
+    def test_fields(self):
+        stats = RouteWeatherStats(
+            max_tws=jnp.array([10.0]),
+            max_hs=jnp.array([3.0]),
+            tws_exceeded=jnp.array([False]),
+            hs_exceeded=jnp.array([False]),
+        )
+        assert stats.max_tws.shape == (1,)
+        assert stats.max_hs.shape == (1,)
+        assert stats.tws_exceeded.shape == (1,)
+        assert stats.hs_exceeded.shape == (1,)
+
+
+# ---------------------------------------------------------------------------
+# Tests for evaluate_weather
+# ---------------------------------------------------------------------------
+class TestEvaluateWeather:
+    """Test evaluate_weather with synthetic fields."""
+
+    def test_no_fields_returns_zeros(self):
+        curve = _make_curve()
+        stats = evaluate_weather(curve)
+        assert jnp.allclose(stats.max_tws, 0.0)
+        assert jnp.allclose(stats.max_hs, 0.0)
+        assert not stats.tws_exceeded.any()
+        assert not stats.hs_exceeded.any()
+
+    def test_within_limits(self):
+        curve = _make_curve()
+        wf = _constant_windfield(10.0, 0.0)  # TWS = 10 < 20
+        wvf = _constant_wavefield(3.0)  # Hs = 3 < 7
+        stats = evaluate_weather(curve, windfield=wf, wavefield=wvf)
+        assert jnp.allclose(stats.max_tws, 10.0, atol=1e-5)
+        assert jnp.allclose(stats.max_hs, 3.0, atol=1e-5)
+        assert not stats.tws_exceeded.any()
+        assert not stats.hs_exceeded.any()
+
+    def test_tws_exceeded(self):
+        curve = _make_curve()
+        wf = _constant_windfield(15.0, 15.0)  # TWS ≈ 21.2 > 20
+        stats = evaluate_weather(curve, windfield=wf)
+        assert stats.tws_exceeded.all()
+
+    def test_hs_exceeded(self):
+        curve = _make_curve()
+        wvf = _constant_wavefield(8.0)  # Hs = 8 > 7
+        stats = evaluate_weather(curve, wavefield=wvf)
+        assert stats.hs_exceeded.all()
+
+    def test_batch_dimension(self):
+        curve = _make_curve(n_routes=5)
+        wf = _constant_windfield(10.0, 0.0)
+        stats = evaluate_weather(curve, windfield=wf)
+        assert stats.max_tws.shape == (5,)
+        assert stats.tws_exceeded.shape == (5,)
+
+    def test_custom_limits(self):
+        curve = _make_curve()
+        wf = _constant_windfield(10.0, 0.0)  # TWS = 10
+        stats = evaluate_weather(curve, windfield=wf, tws_limit=5.0)
+        assert stats.tws_exceeded.all()  # 10 > 5
+
+    def test_wind_only(self):
+        curve = _make_curve()
+        wf = _constant_windfield(25.0, 0.0)
+        stats = evaluate_weather(curve, windfield=wf)
+        assert jnp.allclose(stats.max_tws, 25.0, atol=1e-5)
+        assert jnp.allclose(stats.max_hs, 0.0)
+
+    def test_wave_only(self):
+        curve = _make_curve()
+        wvf = _constant_wavefield(5.0)
+        stats = evaluate_weather(curve, wavefield=wvf)
+        assert jnp.allclose(stats.max_tws, 0.0)
+        assert jnp.allclose(stats.max_hs, 5.0, atol=1e-5)
+
+    def test_tws_from_vector_components(self):
+        """TWS = sqrt(u² + v²) for diagonal wind."""
+        curve = _make_curve()
+        wf = _constant_windfield(12.0, 16.0)  # TWS = 20 exactly
+        stats = evaluate_weather(curve, windfield=wf)
+        assert jnp.allclose(stats.max_tws, 20.0, atol=1e-5)
+        # Exactly at limit — not exceeded
+        assert not stats.tws_exceeded.any()
+
+
+# ---------------------------------------------------------------------------
+# Tests for weather_penalty (hard step)
+# ---------------------------------------------------------------------------
+class TestWeatherPenalty:
+    """Test the hard (step) weather penalty."""
+
+    def test_zero_when_within_limits(self):
+        curve = _make_curve()
+        wf = _constant_windfield(10.0, 0.0)
+        wvf = _constant_wavefield(3.0)
+        pen = weather_penalty(curve, windfield=wf, wavefield=wvf)
+        assert jnp.allclose(pen, 0.0)
+
+    def test_nonzero_when_tws_exceeded(self):
+        curve = _make_curve(n_points=10)  # 9 segments
+        wf = _constant_windfield(25.0, 0.0)
+        pen = weather_penalty(curve, windfield=wf, penalty=10.0)
+        # All 9 segments violate → 9 * 10 = 90
+        assert jnp.allclose(pen, 90.0)
+
+    def test_nonzero_when_hs_exceeded(self):
+        curve = _make_curve(n_points=10)
+        wvf = _constant_wavefield(10.0)
+        pen = weather_penalty(curve, wavefield=wvf, penalty=5.0)
+        assert jnp.allclose(pen, 45.0)  # 9 * 5
+
+    def test_combined_violations(self):
+        curve = _make_curve(n_points=10)
+        wf = _constant_windfield(25.0, 0.0)
+        wvf = _constant_wavefield(10.0)
+        pen = weather_penalty(curve, windfield=wf, wavefield=wvf, penalty=1.0)
+        # 9 TWS violations + 9 Hs violations = 18
+        assert jnp.allclose(pen, 18.0)
+
+    def test_no_fields_returns_zero(self):
+        curve = _make_curve()
+        pen = weather_penalty(curve)
+        assert jnp.allclose(pen, 0.0)
+
+    def test_batch(self):
+        curve = _make_curve(n_routes=3)
+        wf = _constant_windfield(25.0, 0.0)
+        pen = weather_penalty(curve, windfield=wf, penalty=1.0)
+        assert pen.shape == (3,)
+        assert jnp.all(pen > 0)
+
+    def test_custom_limits(self):
+        curve = _make_curve(n_points=10)
+        wf = _constant_windfield(10.0, 0.0)  # TWS = 10
+        pen = weather_penalty(curve, windfield=wf, tws_limit=5.0, penalty=1.0)
+        assert jnp.allclose(pen, 9.0)  # 9 segments × penalty 1
+
+    def test_zero_penalty_weight(self):
+        curve = _make_curve()
+        wf = _constant_windfield(25.0, 0.0)
+        pen = weather_penalty(curve, windfield=wf, penalty=0.0)
+        assert jnp.allclose(pen, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests for weather_penalty_smooth
+# ---------------------------------------------------------------------------
+class TestWeatherPenaltySmooth:
+    """Test the smooth (differentiable) weather penalty."""
+
+    def test_zero_when_within_limits(self):
+        curve = _make_curve()
+        wf = _constant_windfield(10.0, 0.0)
+        wvf = _constant_wavefield(3.0)
+        pen = weather_penalty_smooth(curve, windfield=wf, wavefield=wvf)
+        assert jnp.allclose(pen, 0.0)
+
+    def test_positive_when_exceeded(self):
+        curve = _make_curve()
+        wf = _constant_windfield(25.0, 0.0)  # TWS = 25 > 20
+        pen = weather_penalty_smooth(curve, windfield=wf)
+        assert jnp.all(pen > 0)
+
+    def test_increases_with_excess(self):
+        curve = _make_curve()
+        wf_21 = _constant_windfield(21.0, 0.0)  # excess = 1
+        wf_25 = _constant_windfield(25.0, 0.0)  # excess = 5
+        pen_21 = weather_penalty_smooth(curve, windfield=wf_21)
+        pen_25 = weather_penalty_smooth(curve, windfield=wf_25)
+        assert jnp.all(pen_25 > pen_21)
+
+    def test_quadratic_growth(self):
+        """Penalty grows as (excess)² — doubling excess quadruples penalty."""
+        curve = _make_curve()
+        wf_22 = _constant_windfield(22.0, 0.0)  # excess = 2
+        wf_24 = _constant_windfield(24.0, 0.0)  # excess = 4
+        pen_22 = weather_penalty_smooth(
+            curve, windfield=wf_22, penalty=1.0, sharpness=1.0
+        )
+        pen_24 = weather_penalty_smooth(
+            curve, windfield=wf_24, penalty=1.0, sharpness=1.0
+        )
+        ratio = pen_24 / pen_22
+        expected_ratio = (4.0**2) / (2.0**2)  # 16/4 = 4
+        assert jnp.allclose(ratio, expected_ratio, atol=1e-4)
+
+    def test_sharpness_scales_penalty(self):
+        curve = _make_curve()
+        wf = _constant_windfield(25.0, 0.0)
+        pen_s1 = weather_penalty_smooth(curve, windfield=wf, sharpness=1.0)
+        pen_s5 = weather_penalty_smooth(curve, windfield=wf, sharpness=5.0)
+        assert jnp.allclose(pen_s5, pen_s1 * 5.0, atol=1e-4)
+
+    def test_no_fields_returns_zero(self):
+        curve = _make_curve()
+        pen = weather_penalty_smooth(curve)
+        assert jnp.allclose(pen, 0.0)
+
+    def test_batch(self):
+        curve = _make_curve(n_routes=4)
+        wvf = _constant_wavefield(10.0)
+        pen = weather_penalty_smooth(curve, wavefield=wvf)
+        assert pen.shape == (4,)
+        assert jnp.all(pen > 0)
+
+    def test_at_limit_is_zero(self):
+        """Exactly at the limit → zero penalty (excess = 0)."""
+        curve = _make_curve()
+        wf = _constant_windfield(20.0, 0.0)  # TWS = 20, limit = 20
+        pen = weather_penalty_smooth(curve, windfield=wf)
+        assert jnp.allclose(pen, 0.0)


### PR DESCRIPTION
## Summary

Add weather constraint penalties for SWOPP3 compliance.

### New module: `routetools/weather.py`
- **`weather_penalty()`** — hard step penalty counting segments where TWS > 20 m/s or Hs > 7 m, multiplied by a penalty weight. Same pattern as `Land.penalization`.
- **`weather_penalty_smooth()`** — differentiable quadratic-ramp alternative for gradient-based methods.
- **`evaluate_weather()`** — reports per-route max TWS and max Hs (`RouteWeatherStats` dataclass), needed for SWOPP3 File A columns.
- Constants: `DEFAULT_TWS_LIMIT = 20.0`, `DEFAULT_HS_LIMIT = 7.0`

### Integration into `routetools/cmaes.py`
- Added `windfield`, `weather_penalty_weight`, `tws_limit`, `hs_limit` parameters to:
  - `_cma_evolution_strategy`
  - `optimize`
  - `optimize_with_increasing_penalization`
- Weather penalty applied alongside land penalty in the optimization loop
- `cost_initial` comparison in `optimize` also includes weather penalty when enabled
- **Default: disabled** (`weather_penalty_weight=0.0`) — backward compatible with all existing usage

### Tests
29 tests covering hard penalty, smooth penalty, evaluate_weather, edge cases (at-limit, zero weight, no fields), batch dimensions, and quadratic growth properties.

Closes #27