### PR TITLE
FIX: Benchmark instances

### DIFF
--- a/routetools/_ports.py
+++ b/routetools/_ports.py
@@ -79,7 +79,7 @@ DICT_PORTS = {
         "city": "New York",
         "country": "United States",
     },
-    "USNYCswopp": {
+    "USNYS": {  # New York SWOPP3 port, different from USNYC
         "lat": 40.6,
         "lon": -69.0,  # As defined by SWOPP3
         "city": "New York",
@@ -112,7 +112,7 @@ DICT_INSTANCES = {
         "PAONX-USNYC": {"date_start": "2023-01-01T00:00:00"},
         "USNYC-PAONX": {"date_start": "2023-01-01T00:00:00"},
         # SWOPP3
-        "ESSDR-USNYCswopp": {"date_start": "2023-01-01T00:00:00"},
-        "USLAX-JPTYO": {"date_start": "2023-01-01T00:00:00"},
+        "ESSDR-USNYS": {"date_start": "2024-01-01T00:00:00"},
+        "USLAX-JPTYO": {"date_start": "2024-01-01T00:00:00"},
     },
 }

--- a/routetools/_ports.py
+++ b/routetools/_ports.py
@@ -99,20 +99,17 @@ DICT_PORTS = {
     },
 }
 DICT_INSTANCES = {
-    "route_days": 10,
-    "instances": {
-        "DEHAM-USNYC": {"date_start": "2023-01-01T00:00:00"},
-        "USNYC-DEHAM": {"date_start": "2023-01-01T00:00:00"},
-        "EGHRG-MYKUL": {"date_start": "2023-01-01T00:00:00"},
-        "MYKUL-EGHRG": {"date_start": "2023-01-01T00:00:00"},
-        "EGPSD-ESALG": {"date_start": "2023-01-01T00:00:00"},
-        "ESALG-EGPSD": {"date_start": "2023-01-01T00:00:00"},
-        "PABLB-PECLL": {"date_start": "2023-01-01T00:00:00"},
-        "PECLL-PABLB": {"date_start": "2023-01-01T00:00:00"},
-        "PAONX-USNYC": {"date_start": "2023-01-01T00:00:00"},
-        "USNYC-PAONX": {"date_start": "2023-01-01T00:00:00"},
-        # SWOPP3
-        "ESSDR-USNYS": {"date_start": "2024-01-01T00:00:00"},
-        "USLAX-JPTYO": {"date_start": "2024-01-01T00:00:00"},
-    },
+    "DEHAM-USNYC": {"date_start": "2023-01-01T00:00:00"},
+    "USNYC-DEHAM": {"date_start": "2023-01-01T00:00:00"},
+    "EGHRG-MYKUL": {"date_start": "2023-01-01T00:00:00"},
+    "MYKUL-EGHRG": {"date_start": "2023-01-01T00:00:00"},
+    "EGPSD-ESALG": {"date_start": "2023-01-01T00:00:00"},
+    "ESALG-EGPSD": {"date_start": "2023-01-01T00:00:00"},
+    "PABLB-PECLL": {"date_start": "2023-01-01T00:00:00"},
+    "PECLL-PABLB": {"date_start": "2023-01-01T00:00:00"},
+    "PAONX-USNYC": {"date_start": "2023-01-01T00:00:00"},
+    "USNYC-PAONX": {"date_start": "2023-01-01T00:00:00"},
+    # SWOPP3
+    "ESSDR-USNYS": {"date_start": "2024-01-01T00:00:00"},
+    "USLAX-JPTYO": {"date_start": "2024-01-01T00:00:00"},
 }

--- a/routetools/benchmark.py
+++ b/routetools/benchmark.py
@@ -188,6 +188,9 @@ def load_benchmark_instance(
     instance_name: str,
     date_start: str = "2023-01-08",
     vel_ship: int = 6,
+    use_currents: bool = True,
+    use_waves: bool = True,
+    route_days: int = 10,
     bounding_border: int = 10,
     data_path: str = "./data",
 ) -> dict[str, Any]:
@@ -202,6 +205,13 @@ def load_benchmark_instance(
         Start date for the benchmark instance, by default "2023-01-08".
     vel_ship : int, optional
         Velocity of the ship in knots, by default 6.
+    use_currents : bool, optional
+        Whether to use ocean currents data, by default True.
+    use_waves : bool, optional
+        Whether to use ocean waves data, by default True.
+    route_days : int, optional
+        Number of days of ocean data to load. If the route goes for
+        longer, it will repeat the last day. By default 10.
     bounding_border: int, optional
         Border size for bounding box, by default 10.
     data_path : str, optional
@@ -224,6 +234,9 @@ def load_benchmark_instance(
         vel_ship=vel_ship,
         data_path=data_path,
         bounding_border=bounding_border,
+        use_currents=use_currents,
+        use_waves=use_waves,
+        route_days=route_days,
     )
 
     # Load ocean and land data

--- a/routetools/wrr_bench/load.py
+++ b/routetools/wrr_bench/load.py
@@ -140,7 +140,7 @@ def load_real_instance(
         or name_alt in DICT_INSTANCES
         or re.match(r"^[A-Z]{5}-[A-Z]{5}$", name_instance)
     ):
-        raise AssertionError(f"Instance {name_instance} not found")
+        raise KeyError(f"Instance {name_instance} not found")
 
     # Initialize the dictionary containing the instance configuration
     # Adds default parameters to avoid missing information

--- a/routetools/wrr_bench/load.py
+++ b/routetools/wrr_bench/load.py
@@ -99,8 +99,6 @@ def load_real_instance(
     dict
         Dictionary containing the instance configuration.
     """
-    assert name_instance in DICT_INSTANCES, f"Instance {name_instance} not found"
-
     # TODO: Add the valid land file to the data_path
     if land_resolution == "1km":
         land_file_name = "earth-seas-1km-valid.geo.json"
@@ -134,6 +132,15 @@ def load_real_instance(
     # Else, find if the reverse name works
     elif name_alt in DICT_INSTANCES:
         dict_instance.update(DICT_INSTANCES[name_alt])
+
+    # If neither the direct name nor the alternate (reversed) name exist,
+    # and the provided name is not a port-to-port code, it's an error.
+    if not (
+        name_instance in DICT_INSTANCES
+        or name_alt in DICT_INSTANCES
+        or re.match(r"^[A-Z]{5}-[A-Z]{5}$", name_instance)
+    ):
+        raise AssertionError(f"Instance {name_instance} not found")
 
     # Initialize the dictionary containing the instance configuration
     # Adds default parameters to avoid missing information

--- a/routetools/wrr_bench/load.py
+++ b/routetools/wrr_bench/load.py
@@ -60,6 +60,7 @@ def load_real_instance(
     vel_ship: float | None = None,
     use_currents: bool = True,
     use_waves: bool = True,
+    route_days: int = 10,
 ) -> dict:
     """
     Load instance configuration and prepare data and parameters to optimize.
@@ -89,23 +90,22 @@ def load_real_instance(
         Whether to use ocean currents data, by default True
     use_waves : bool, optional
         Whether to use ocean waves data, by default True
+    route_days : int, optional
+        Number of days worth of data. If the route goes for longer,
+        it will repeat the last day, by default 10
 
     Returns
     -------
     dict
         Dictionary containing the instance configuration.
     """
-    dict_all_instances: dict = DICT_INSTANCES["instances"]
-
-    assert name_instance in dict_all_instances, f"Instance {name_instance} not found"
+    assert name_instance in DICT_INSTANCES, f"Instance {name_instance} not found"
 
     # TODO: Add the valid land file to the data_path
     if land_resolution == "1km":
         land_file_name = "earth-seas-1km-valid.geo.json"
     else:
         land_file_name = "earth-seas-2km5-valid.geo.json"
-
-    route_days = DICT_INSTANCES["route_days"]
 
     dict_instance = {}
 
@@ -129,11 +129,11 @@ def load_real_instance(
         name_alt = name_instance
 
     # Find if the instance is defined inside the dictionary, as is
-    if name_instance in dict_all_instances:
-        dict_instance.update(dict_all_instances[name_instance])
+    if name_instance in DICT_INSTANCES:
+        dict_instance.update(DICT_INSTANCES[name_instance])
     # Else, find if the reverse name works
-    elif name_alt in dict_all_instances:
-        dict_instance.update(dict_all_instances[name_alt])
+    elif name_alt in DICT_INSTANCES:
+        dict_instance.update(DICT_INSTANCES[name_alt])
 
     # Initialize the dictionary containing the instance configuration
     # Adds default parameters to avoid missing information

--- a/scripts/swopp_demo.py
+++ b/scripts/swopp_demo.py
@@ -8,9 +8,9 @@ from routetools.plot import plot_curve
 
 
 def main(
-    instance_name: str = "ESSDR-USNYC",
-    date_start: str = "2023-01-08",
-    vel_ship: int = 4,
+    instance_name: str = "ESSDR-USNYS",
+    date_start: str = "2024-01-01",
+    vel_ship: int = 4,  # 8 knots
     data_path: str = "./data",
     penalty: float = 1e6,
     K: int = 10,

--- a/tests/test_benchmark_load.py
+++ b/tests/test_benchmark_load.py
@@ -137,3 +137,55 @@ def test_load_benchmark_for_all_instances(tmp_path, instance_name):
         )
     # Basic smoke checks
     assert_basic_output(out)
+
+
+@pytest.mark.parametrize(
+    "use_currents,use_waves,route_days,expected_vars",
+    [
+        (True, True, 3, ["currents", "waves"]),
+        (True, False, 4, ["currents"]),
+        (False, True, 5, ["waves"]),
+        (False, False, 2, []),
+    ],
+)
+def test_load_files_called_with_expected_parameters(
+    monkeypatch, use_currents, use_waves, route_days, expected_vars
+):
+    """Ensure `load_real_instance` calls `load_files` with list_dates
+    length == route_days
+    and weather_variables matching the requested flags.
+    """
+    from routetools.wrr_bench import load as load_mod
+
+    captured = {}
+
+    def fake_load_files(list_dates, data_path="./data", weather_variables=None):
+        # record inputs for assertions
+        captured["list_dates"] = list_dates
+        captured["weather_variables"] = (
+            list(weather_variables) if weather_variables is not None else []
+        )
+        # return empty dict so downstream code receives None for datasets
+        return {}
+
+    monkeypatch.setattr(load_mod, "load_files", fake_load_files)
+
+    # pick an instance that exists in DICT_INSTANCES
+    instance_name = next(iter(DICT_INSTANCES.keys()))
+
+    # Call the loader; it should invoke our fake_load_files
+    load_mod.load_real_instance(
+        instance_name,
+        date_start="2023-01-01",
+        data_path="./data",
+        use_currents=use_currents,
+        use_waves=use_waves,
+        route_days=route_days,
+        vel_ship=10.0,
+    )
+
+    # Assertions
+    assert "list_dates" in captured
+    assert len(captured["list_dates"]) == route_days
+    # weather_variables should match expected_vars (order: currents then waves)
+    assert captured.get("weather_variables", []) == expected_vars

--- a/tests/test_benchmark_load.py
+++ b/tests/test_benchmark_load.py
@@ -1,7 +1,13 @@
+import json
+import warnings
+from pathlib import Path
+
+import numpy as np
 import pytest
 
 from routetools._ports import DICT_INSTANCES
 from routetools.benchmark import LandBenchmark, load_benchmark_instance
+from routetools.wrr_bench.ocean import data_zero
 
 
 def assert_basic_output(out):
@@ -29,22 +35,105 @@ def assert_basic_output(out):
     assert isinstance(out["land"], LandBenchmark)
 
 
-def test_load_benchmark_instance_basic(monkeypatch):
+def test_load_benchmark_instance_basic(tmp_path):
     """Basic smoke test using the first configured instance.
 
-    Monkeypatch `load_files` to avoid reading netCDF files and let `Ocean`
-    construct synthetic zero datasets.
+    Create minimal NetCDF files under a temporary `data_path` and call the
+    loader with that `data_path` so no monkeypatching is required.
     """
-    monkeypatch.setattr("routetools.wrr_bench.load.load_files", lambda *a, **k: {})
+    data_dir = Path(tmp_path) / "data"
+    (data_dir / "currents").mkdir(parents=True)
+    (data_dir / "waves").mkdir(parents=True)
+    # Create a minimal geojson land file that the loader can read
+    land_geo = {
+        "type": "GeometryCollection",
+        "geometries": [
+            {
+                "type": "Polygon",
+                "coordinates": [
+                    [[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]]
+                ],
+            }
+        ],
+    }
+    with open(data_dir / "earth-seas-2km5-valid.geo.json", "w") as f:
+        json.dump(land_geo, f)
+
     instance_name = next(iter(DICT_INSTANCES.keys()))
-    out = load_benchmark_instance(instance_name)
+    date_start = DICT_INSTANCES[instance_name].get("date_start", "2023-01-01")
+    date_base = date_start.split("T")[0]
+    for day in range(15):
+        d = np.datetime64(date_base) + np.timedelta64(day, "D")
+        datestr = str(d)
+        ds_c = data_zero(bounding_box=None, data_vars=("vo", "uo"))
+        ds_w = data_zero(bounding_box=None, data_vars=("height", "direction"))
+        # Reduce to a single timestamp per file (use the file date) so that
+        # concatenated datasets have evenly spaced times
+        ds_c = ds_c.isel(time=0).expand_dims(time=[np.datetime64(datestr)])
+        ds_w = ds_w.isel(time=0).expand_dims(time=[np.datetime64(datestr)])
+        ds_c.to_netcdf(data_dir / "currents" / f"{datestr}.nc", engine="scipy")
+        ds_w.to_netcdf(data_dir / "waves" / f"{datestr}.nc", engine="scipy")
+
+    # Suppress netCDF4 C-extension ABI RuntimeWarning (may be raised on import)
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="numpy.ndarray size changed, may indicate binary incompatibility",
+            category=RuntimeWarning,
+        )
+        out = load_benchmark_instance(
+            instance_name, date_start=date_base, data_path=str(data_dir), route_days=15
+        )
     assert_basic_output(out)
 
 
 @pytest.mark.parametrize("instance_name", list(DICT_INSTANCES.keys()))
-def test_load_benchmark_for_all_instances(monkeypatch, instance_name):
+def test_load_benchmark_for_all_instances(tmp_path, instance_name):
     """Run load_benchmark_instance for every configured instance (smoke test)."""
-    monkeypatch.setattr("routetools.wrr_bench.load.load_files", lambda *a, **k: {})
-    out = load_benchmark_instance(instance_name)
+    data_dir = Path(tmp_path) / "data"
+    (data_dir / "currents").mkdir(parents=True)
+    (data_dir / "waves").mkdir(parents=True)
+    # Create a minimal geojson land file that the loader can read
+    land_geo = {
+        "type": "GeometryCollection",
+        "geometries": [
+            {
+                "type": "Polygon",
+                "coordinates": [
+                    [[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]]
+                ],
+            }
+        ],
+    }
+    with open(data_dir / "earth-seas-2km5-valid.geo.json", "w") as f:
+        json.dump(land_geo, f)
+
+    date_start = DICT_INSTANCES[instance_name].get("date_start", "2023-01-01")
+    date_base = date_start.split("T")[0]
+    for day in range(15):
+        d = np.datetime64(date_base) + np.timedelta64(day, "D")
+        datestr = str(d)
+        ds_c = data_zero(bounding_box=None, data_vars=("vo", "uo"))
+        ds_w = data_zero(bounding_box=None, data_vars=("height", "direction"))
+        # Reduce to a single timestamp per file (use the file date) so that
+        # concatenated datasets have evenly spaced times
+        ds_c = ds_c.isel(time=0).expand_dims(time=[np.datetime64(datestr)])
+        ds_w = ds_w.isel(time=0).expand_dims(time=[np.datetime64(datestr)])
+        ds_c.to_netcdf(data_dir / "currents" / f"{datestr}.nc", engine="scipy")
+        ds_w.to_netcdf(data_dir / "waves" / f"{datestr}.nc", engine="scipy")
+
+    # Suppress netCDF4 C-extension ABI RuntimeWarning (may be raised on import)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="numpy.ndarray size changed, may indicate binary incompatibility",
+            category=RuntimeWarning,
+        )
+        out = load_benchmark_instance(
+            instance_name, date_start=date_base, data_path=str(data_dir), route_days=15
+        )
     # Basic smoke checks
     assert_basic_output(out)

--- a/tests/test_benchmark_load.py
+++ b/tests/test_benchmark_load.py
@@ -7,6 +7,7 @@ import pytest
 
 from routetools._ports import DICT_INSTANCES
 from routetools.benchmark import LandBenchmark, load_benchmark_instance
+from routetools.wrr_bench import load as load_mod
 from routetools.wrr_bench.ocean import data_zero
 
 
@@ -171,7 +172,6 @@ def test_load_files_called_with_expected_parameters(
     length == route_days
     and weather_variables matching the requested flags.
     """
-    from routetools.wrr_bench import load as load_mod
 
     captured = {}
 

--- a/tests/test_benchmark_load.py
+++ b/tests/test_benchmark_load.py
@@ -71,12 +71,19 @@ def test_load_benchmark_instance_basic(tmp_path):
         # concatenated datasets have evenly spaced times
         ds_c = ds_c.isel(time=0).expand_dims(time=[np.datetime64(datestr)])
         ds_w = ds_w.isel(time=0).expand_dims(time=[np.datetime64(datestr)])
-        ds_c.to_netcdf(data_dir / "currents" / f"{datestr}.nc", engine="scipy")
-        ds_w.to_netcdf(data_dir / "waves" / f"{datestr}.nc", engine="scipy")
+        # Writing with netCDF4 may emit a RuntimeWarning on import in some
+        # environments; suppress that specific warning around the write.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="numpy.ndarray size changed, "
+                "may indicate binary incompatibility",
+                category=RuntimeWarning,
+            )
+            ds_c.to_netcdf(data_dir / "currents" / f"{datestr}.nc", engine="netcdf4")
+            ds_w.to_netcdf(data_dir / "waves" / f"{datestr}.nc", engine="netcdf4")
 
     # Suppress netCDF4 C-extension ABI RuntimeWarning (may be raised on import)
-    import warnings
-
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
@@ -121,8 +128,17 @@ def test_load_benchmark_for_all_instances(tmp_path, instance_name):
         # concatenated datasets have evenly spaced times
         ds_c = ds_c.isel(time=0).expand_dims(time=[np.datetime64(datestr)])
         ds_w = ds_w.isel(time=0).expand_dims(time=[np.datetime64(datestr)])
-        ds_c.to_netcdf(data_dir / "currents" / f"{datestr}.nc", engine="scipy")
-        ds_w.to_netcdf(data_dir / "waves" / f"{datestr}.nc", engine="scipy")
+        # Writing with netCDF4 may emit a RuntimeWarning on import in some
+        # environments; suppress that specific warning around the write.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="numpy.ndarray size changed, "
+                "may indicate binary incompatibility",
+                category=RuntimeWarning,
+            )
+            ds_c.to_netcdf(data_dir / "currents" / f"{datestr}.nc", engine="netcdf4")
+            ds_w.to_netcdf(data_dir / "waves" / f"{datestr}.nc", engine="netcdf4")
 
     # Suppress netCDF4 C-extension ABI RuntimeWarning (may be raised on import)
 

--- a/tests/test_benchmark_load.py
+++ b/tests/test_benchmark_load.py
@@ -165,7 +165,7 @@ def test_load_benchmark_for_all_instances(tmp_path, instance_name):
     ],
 )
 def test_load_files_called_with_expected_parameters(
-    monkeypatch, use_currents, use_waves, route_days, expected_vars
+    monkeypatch, tmp_path, use_currents, use_waves, route_days, expected_vars
 ):
     """Ensure `load_real_instance` calls `load_files` with list_dates
     length == route_days
@@ -186,6 +186,24 @@ def test_load_files_called_with_expected_parameters(
 
     monkeypatch.setattr(load_mod, "load_files", fake_load_files)
 
+    # create a minimal data dir with the expected land geojson
+    # so Ocean can be instantiated
+    data_dir = Path(tmp_path) / "data"
+    (data_dir).mkdir(parents=True)
+    land_geo = {
+        "type": "GeometryCollection",
+        "geometries": [
+            {
+                "type": "Polygon",
+                "coordinates": [
+                    [[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]]
+                ],
+            }
+        ],
+    }
+    with open(data_dir / "earth-seas-2km5-valid.geo.json", "w") as f:
+        json.dump(land_geo, f)
+
     # pick an instance that exists in DICT_INSTANCES
     instance_name = next(iter(DICT_INSTANCES.keys()))
 
@@ -193,7 +211,7 @@ def test_load_files_called_with_expected_parameters(
     load_mod.load_real_instance(
         instance_name,
         date_start="2023-01-01",
-        data_path="./data",
+        data_path=str(data_dir),
         use_currents=use_currents,
         use_waves=use_waves,
         route_days=route_days,

--- a/tests/test_benchmark_load.py
+++ b/tests/test_benchmark_load.py
@@ -1,0 +1,50 @@
+import pytest
+
+from routetools._ports import DICT_INSTANCES
+from routetools.benchmark import LandBenchmark, load_benchmark_instance
+
+
+def assert_basic_output(out):
+    # Check presence of keys
+    for key in (
+        "lat_start",
+        "lon_start",
+        "lat_end",
+        "lon_end",
+        "src",
+        "dst",
+        "data",
+        "vectorfield",
+        "wavefield",
+        "land",
+    ):
+        assert key in out
+
+    # src/dst shapes
+    assert hasattr(out["src"], "shape") and out["src"].shape == (2,)
+    assert hasattr(out["dst"], "shape") and out["dst"].shape == (2,)
+
+    # data and callables
+    assert callable(out["vectorfield"]) and callable(out["wavefield"])
+    assert isinstance(out["land"], LandBenchmark)
+
+
+def test_load_benchmark_instance_basic(monkeypatch):
+    """Basic smoke test using the first configured instance.
+
+    Monkeypatch `load_files` to avoid reading netCDF files and let `Ocean`
+    construct synthetic zero datasets.
+    """
+    monkeypatch.setattr("routetools.wrr_bench.load.load_files", lambda *a, **k: {})
+    instance_name = next(iter(DICT_INSTANCES.keys()))
+    out = load_benchmark_instance(instance_name)
+    assert_basic_output(out)
+
+
+@pytest.mark.parametrize("instance_name", list(DICT_INSTANCES.keys()))
+def test_load_benchmark_for_all_instances(monkeypatch, instance_name):
+    """Run load_benchmark_instance for every configured instance (smoke test)."""
+    monkeypatch.setattr("routetools.wrr_bench.load.load_files", lambda *a, **k: {})
+    out = load_benchmark_instance(instance_name)
+    # Basic smoke checks
+    assert_basic_output(out)


### PR DESCRIPTION
- Removes `route_days` from `DICT_INSTANCES`, making it an explicit argument. This is very important, as it controls the amount of data loaded.
- Fixes an error with `"USNYCswopp"` code, as the library restricts codes to 5 letters (which I agree with). The new code is `"USNYS"` and it is explained in a comment.
- Included tests on this part, to ensure consistency.