### PR TITLE
feat: ERA5 weather data ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,32 @@ If your computer does not have a GPU, you can force JAX to use the CPU with `JAX
 JAX_PLATFORMS=cpu uv run scripts/single_run.py
 ```
 
+### ERA5 weather data pipeline
+
+The `routetools.era5` module provides real-world ERA5 wind and wave fields
+for weather routing.  Two download backends are available:
+
+- **GCS** (default) — Google Cloud archive, no API key required.
+- **CDS** — Copernicus Climate Data Store (requires `cdsapi` + API key).
+
+**1. Download ERA5 data** for the Atlantic corridor (USNYC ↔ DEHAM):
+
+```bash
+uv run scripts/download_era5.py --corridor atlantic --year 2023
+```
+
+This creates `data/era5/era5_wind_atlantic_2023.nc` and
+`data/era5/era5_waves_atlantic_2023.nc`.
+
+**2. Run the real-world benchmark** (New York → Hamburg, Jan 8 2023):
+
+```bash
+uv run scripts/era5_benchmark.py --departure 2023-01-08T00:00:00
+```
+
+See `scripts/download_era5.py --help` and `scripts/era5_benchmark.py --help`
+for all available options.
+
 ## Reproduce the results (paper)
 
 To reproduce the results from the paper, run the following command:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,15 @@ dependencies = [
     "borb @ https://files.pythonhosted.org/packages/7a/4e/b193d894ffb0fde0f773b0476d8b041528302fa86bccf2cc8006c79404e4/borb-3.0.1.tar.gz",
     "jupyter-server>=2.17.0",
     "statsmodels>=0.14.6",
+    "scipy>=1.12.0",
+    "netCDF4>=1.6.0",
     "opencv-python>=4.13.0.92",
-    "netcdf4>=1.7.4",
-    "dask>=2026.1.2",
 ]
+
+[project.optional-dependencies]
+cuda = ["jax[cuda]==0.8.1"]
+era5-cds = ["cdsapi>=0.7.0"]
+era5-gcs = ["gcsfs>=2024.1.0", "zarr>=2.17.0"]
 
 [project.urls]
 homepage = "https://github.com/Weather-Routing-Research/cmaes_bezier_demo"
@@ -41,7 +46,7 @@ homepage = "https://github.com/Weather-Routing-Research/cmaes_bezier_demo"
 main = "routetools.main:main"
 
 [tool.setuptools]
-packages = ["routetools"]
+packages = ["routetools", "routetools.era5", "routetools._cost", "routetools.wrr_bench"]
 
 [tool.setuptools_scm]
 # Configure setuptools_scm to write a version file and provide a fallback when
@@ -105,7 +110,5 @@ dev-dependencies = [
     "ipykernel",
 ]
 
-[project.optional-dependencies]
-cuda = ["jax[cuda]==0.8.1"]
 
 

--- a/routetools/era5/__init__.py
+++ b/routetools/era5/__init__.py
@@ -1,0 +1,31 @@
+"""ERA5 weather data ingestion for routetools.
+
+This module provides two backends for accessing ERA5 reanalysis data:
+
+1. **CDS API** (``download_cds``): Downloads ERA5 data from the Copernicus
+   Climate Data Store using the ``cdsapi`` package.  Requires a CDS account
+   and API key.
+
+2. **Google Cloud Storage** (``download_gcs``): Accesses the ERA5 dataset
+   stored as Zarr on Google Cloud (via the WeatherBench2 / Pangeo archive).
+   No API key required.
+
+Both backends produce NetCDF files on disk that can be loaded with
+:func:`load_era5_vectorfield` and :func:`load_era5_wavefield` to obtain
+JAX-compatible field closures matching the interface expected by
+:func:`routetools.cost.cost_function`.
+"""
+
+from routetools.era5.loader import (
+    load_era5_vectorfield as load_era5_vectorfield,
+    load_era5_wavefield as load_era5_wavefield,
+    load_era5_windfield as load_era5_windfield,
+    load_natural_earth_land_mask as load_natural_earth_land_mask,
+)
+
+__all__ = [
+    "load_era5_vectorfield",
+    "load_era5_wavefield",
+    "load_era5_windfield",
+    "load_natural_earth_land_mask",
+]

--- a/routetools/era5/download_cds.py
+++ b/routetools/era5/download_cds.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 CORRIDORS: dict[str, list[float]] = {
     # Atlantic: Santander (43.6, -4.0) → New York (40.6, -69.0)
     # Pad: +10° N/S, +5° E/W
-    "atlantic": [55, -80, 25, 10],
+    "atlantic": [60, -80, 25, 10],
     # Pacific: Tokyo (34.8, 140.0) → Los Angeles (34.4, -121.0)
     # Great-circle goes up to ~50°N; pad generously
     # Split into two boxes? No — ERA5 handles wrap-around.

--- a/routetools/era5/download_cds.py
+++ b/routetools/era5/download_cds.py
@@ -1,0 +1,245 @@
+"""Download ERA5 data from the Copernicus Climate Data Store (CDS).
+
+Requires the ``cdsapi`` package and valid CDS API credentials.
+See https://cds.climate.copernicus.eu/how-to-api for setup instructions.
+
+The functions in this module download ERA5 reanalysis single-level and wave
+data for the route corridors needed by SWOPP3 and store them as NetCDF files.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Route corridor bounding boxes (North, West, South, East)
+# With generous padding around the actual route endpoints.
+# ---------------------------------------------------------------------------
+CORRIDORS: dict[str, list[float]] = {
+    # Atlantic: Santander (43.6, -4.0) → New York (40.6, -69.0)
+    # Pad: +10° N/S, +5° E/W
+    "atlantic": [55, -80, 25, 10],
+    # Pacific: Tokyo (34.8, 140.0) → Los Angeles (34.4, -121.0)
+    # Great-circle goes up to ~50°N; pad generously
+    # Split into two boxes? No — ERA5 handles wrap-around.
+    # We use lon 120E to 240E (== -120W) via 0-360 convention.
+    "pacific": [55, 120, 15, 240],
+}
+
+# ERA5 variables we need
+WIND_VARIABLES = ["10m_u_component_of_wind", "10m_v_component_of_wind"]
+WAVE_VARIABLES = [
+    "significant_height_of_combined_wind_waves_and_swell",
+    "mean_wave_direction",
+]
+
+# Default years / months for SWOPP3 (all of 2024)
+DEFAULT_YEAR = "2024"
+DEFAULT_MONTHS = [f"{m:02d}" for m in range(1, 13)]
+DEFAULT_DAYS = [f"{d:02d}" for d in range(1, 32)]
+DEFAULT_TIMES = [f"{h:02d}:00" for h in range(0, 24, 6)]  # 6-hourly
+
+
+def _ensure_cdsapi() -> "cdsapi.Client":  # type: ignore[name-defined]
+    """Import and return a CDS API client, raising a clear error if missing."""
+    try:
+        import cdsapi
+    except ImportError as exc:
+        raise ImportError(
+            "The 'cdsapi' package is required for CDS downloads.  "
+            "Install it with:  pip install cdsapi\n"
+            "Then configure your API key: https://cds.climate.copernicus.eu/how-to-api"
+        ) from exc
+    return cdsapi.Client()
+
+
+def download_era5_wind(
+    output_dir: str | Path = "data/era5",
+    corridor: str = "atlantic",
+    year: str = DEFAULT_YEAR,
+    months: list[str] | None = None,
+    days: list[str] | None = None,
+    times: list[str] | None = None,
+    grid: list[float] | None = None,
+) -> Path:
+    """Download ERA5 10-m wind components for a route corridor.
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Directory to store downloaded files.
+    corridor : str
+        One of ``"atlantic"`` or ``"pacific"``.
+    year : str
+        Year to download (default ``"2024"``).
+    months : list[str], optional
+        Months (default: all 12).
+    days : list[str], optional
+        Days (default: all 31).
+    times : list[str], optional
+        Hours in ``"HH:00"`` format (default: 6-hourly).
+    grid : list[float], optional
+        ``[lat_res, lon_res]`` in degrees (default ``[0.25, 0.25]``).
+
+    Returns
+    -------
+    Path
+        Path to the downloaded NetCDF file.
+    """
+    client = _ensure_cdsapi()
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    months = months or DEFAULT_MONTHS
+    days = days or DEFAULT_DAYS
+    times = times or DEFAULT_TIMES
+    grid = grid or [0.25, 0.25]
+
+    area = CORRIDORS[corridor]
+    filename = output_dir / f"era5_wind_{corridor}_{year}.nc"
+
+    if filename.exists():
+        logger.info("File already exists, skipping download: %s", filename)
+        return filename
+
+    logger.info(
+        "Downloading ERA5 wind data for %s corridor, year %s ...", corridor, year
+    )
+
+    client.retrieve(
+        "reanalysis-era5-single-levels",
+        {
+            "product_type": "reanalysis",
+            "variable": WIND_VARIABLES,
+            "year": year,
+            "month": months,
+            "day": days,
+            "time": times,
+            "area": area,
+            "grid": grid,
+            "data_format": "netcdf",
+        },
+        str(filename),
+    )
+
+    logger.info("Downloaded: %s", filename)
+    return filename
+
+
+def download_era5_waves(
+    output_dir: str | Path = "data/era5",
+    corridor: str = "atlantic",
+    year: str = DEFAULT_YEAR,
+    months: list[str] | None = None,
+    days: list[str] | None = None,
+    times: list[str] | None = None,
+    grid: list[float] | None = None,
+) -> Path:
+    """Download ERA5 wave data (Hs and mean direction) for a route corridor.
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Directory to store downloaded files.
+    corridor : str
+        One of ``"atlantic"`` or ``"pacific"``.
+    year : str
+        Year to download (default ``"2024"``).
+    months : list[str], optional
+        Months (default: all 12).
+    days : list[str], optional
+        Days (default: all 31).
+    times : list[str], optional
+        Hours in ``"HH:00"`` format (default: 6-hourly).
+    grid : list[float], optional
+        ``[lat_res, lon_res]`` in degrees (default ``[0.25, 0.25]``).
+
+    Returns
+    -------
+    Path
+        Path to the downloaded NetCDF file.
+    """
+    client = _ensure_cdsapi()
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    months = months or DEFAULT_MONTHS
+    days = days or DEFAULT_DAYS
+    times = times or DEFAULT_TIMES
+    grid = grid or [0.25, 0.25]
+
+    area = CORRIDORS[corridor]
+    filename = output_dir / f"era5_waves_{corridor}_{year}.nc"
+
+    if filename.exists():
+        logger.info("File already exists, skipping download: %s", filename)
+        return filename
+
+    logger.info(
+        "Downloading ERA5 wave data for %s corridor, year %s ...", corridor, year
+    )
+
+    client.retrieve(
+        "reanalysis-era5-single-levels",
+        {
+            "product_type": "reanalysis",
+            "variable": WAVE_VARIABLES,
+            "year": year,
+            "month": months,
+            "day": days,
+            "time": times,
+            "area": area,
+            "grid": grid,
+            "data_format": "netcdf",
+        },
+        str(filename),
+    )
+
+    logger.info("Downloaded: %s", filename)
+    return filename
+
+
+def download_all(
+    output_dir: str | Path = "data/era5",
+    year: str = DEFAULT_YEAR,
+    corridors: list[str] | None = None,
+    **kwargs: object,
+) -> list[Path]:
+    """Download all ERA5 data needed for SWOPP3.
+
+    Downloads wind and wave data for both Atlantic and Pacific corridors.
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Directory to store downloaded files.
+    year : str
+        Year to download.
+    corridors : list[str], optional
+        Corridors to download (default: both).
+    **kwargs
+        Forwarded to :func:`download_era5_wind` and
+        :func:`download_era5_waves`.
+
+    Returns
+    -------
+    list[Path]
+        Paths to all downloaded NetCDF files.
+    """
+    corridors = corridors or ["atlantic", "pacific"]
+    files: list[Path] = []
+    for corridor in corridors:
+        files.append(
+            download_era5_wind(
+                output_dir=output_dir, corridor=corridor, year=year, **kwargs
+            )
+        )
+        files.append(
+            download_era5_waves(
+                output_dir=output_dir, corridor=corridor, year=year, **kwargs
+            )
+        )
+    return files

--- a/routetools/era5/download_gcs.py
+++ b/routetools/era5/download_gcs.py
@@ -1,0 +1,279 @@
+"""Download ERA5 data from Google Cloud Storage (Zarr format).
+
+Accesses ERA5 reanalysis data from the WeatherBench2 / Pangeo archive
+hosted on Google Cloud.  No API key is required — the data is publicly
+accessible.
+
+References
+----------
+- WeatherBench2: https://weatherbench2.readthedocs.io/
+- ERA5 on GCS: gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Google Cloud Storage paths for ERA5 (ARCO-ERA5, 0.25° hourly)
+GCS_ERA5_SINGLE_LEVEL = (
+    "gs://gcp-public-data-arco-era5/ar/"
+    "full_37-1h-0p25deg-chunk-1.zarr-v3"
+)
+
+# Route corridor bounds: {name: (lat_min, lat_max, lon_min, lon_max)}
+# Longitudes in 0..360 convention for the Pacific to handle antimeridian.
+CORRIDORS: dict[str, tuple[float, float, float, float]] = {
+    "atlantic": (25.0, 55.0, -80.0, 10.0),
+    "pacific": (15.0, 55.0, 120.0, 240.0),
+}
+
+# ERA5 variable names in the ARCO-ERA5 Zarr archive
+WIND_U_VAR = "10m_u_component_of_wind"
+WIND_V_VAR = "10m_v_component_of_wind"
+WAVE_HS_VAR = "significant_height_of_combined_wind_waves_and_swell"
+WAVE_DIR_VAR = "mean_wave_direction"
+
+
+def _ensure_deps() -> None:
+    """Check that xarray, gcsfs, and zarr are available."""
+    missing = []
+    for pkg in ("xarray", "gcsfs", "zarr"):
+        try:
+            __import__(pkg)
+        except ImportError:
+            missing.append(pkg)
+    if missing:
+        raise ImportError(
+            f"The following packages are required for GCS downloads: "
+            f"{', '.join(missing)}.  Install them with:\n"
+            f"  pip install {' '.join(missing)}"
+        )
+
+
+def _open_era5_zarr(variables: list[str]) -> "xarray.Dataset":  # type: ignore[name-defined]
+    """Open the ERA5 Zarr store on GCS and select the given variables."""
+    import gcsfs  # noqa: F811
+    import xarray as xr
+
+    fs = gcsfs.GCSFileSystem(token="anon")
+    store = fs.get_mapper(GCS_ERA5_SINGLE_LEVEL)
+    ds = xr.open_zarr(store, consolidated=True)
+    return ds[variables]
+
+
+def _select_corridor(
+    ds: "xarray.Dataset",  # type: ignore[name-defined]
+    corridor: str,
+    year: str = "2024",
+    time_step: int = 6,
+) -> "xarray.Dataset":  # type: ignore[name-defined]
+    """Subset dataset to a corridor, year, and temporal step.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Full ERA5 dataset.
+    corridor : str
+        Name of the corridor (``"atlantic"`` or ``"pacific"``).
+    year : str
+        Year to select.
+    time_step : int
+        Hours between time steps (default 6 for 6-hourly).
+
+    Returns
+    -------
+    xarray.Dataset
+        Subset dataset.
+    """
+    lat_min, lat_max, lon_min, lon_max = CORRIDORS[corridor]
+
+    # Time selection
+    ds = ds.sel(time=slice(f"{year}-01-01", f"{year}-12-31"))
+    if time_step > 1:
+        ds = ds.isel(time=slice(None, None, time_step))
+
+    # Spatial selection
+    # ERA5 latitude is typically 90 to -90 (descending)
+    lat_dim = "latitude" if "latitude" in ds.dims else "lat"
+    lon_dim = "longitude" if "longitude" in ds.dims else "lon"
+
+    lats = ds[lat_dim].values
+    lons = ds[lon_dim].values
+
+    # Latitude selection (ERA5 lat is often descending: 90 → -90)
+    if lats[0] > lats[-1]:
+        lat_slice = slice(lat_max, lat_min)
+    else:
+        lat_slice = slice(lat_min, lat_max)
+
+    # Determine whether the dataset uses [0, 360) longitudes
+    ds_uses_0_360 = float(np.min(lons)) >= 0 and float(np.max(lons)) > 180
+
+    if lon_min < 0 and ds_uses_0_360:
+        # Corridor spans negative longitudes but dataset is in [0, 360).
+        # E.g. Atlantic (-80, 10) → need [280, 360) ∪ [0, 10] then
+        # relabel to [-80, 10].
+        import xarray as xr
+
+        lon_min_360 = lon_min % 360  # -80 → 280
+        part_west = ds.sel(
+            {lat_dim: lat_slice, lon_dim: slice(lon_min_360, 360.0)}
+        )
+        part_east = ds.sel(
+            {lat_dim: lat_slice, lon_dim: slice(0.0, lon_max)}
+        )
+        ds = xr.concat([part_west, part_east], dim=lon_dim)
+        # Relabel longitudes to [-180, 180) convention
+        new_lons = ds[lon_dim].values.copy()
+        new_lons[new_lons >= 180] -= 360
+        ds = ds.assign_coords({lon_dim: new_lons})
+    elif lon_max > 180:
+        # Pacific-style corridor already in [0, 360) range (e.g. 120–240)
+        # Convert dataset lons from [-180, 180] to [0, 360] if needed
+        if np.any(lons < 0):
+            ds = ds.assign_coords({lon_dim: np.mod(lons, 360)})
+            ds = ds.sortby(lon_dim)
+
+        ds = ds.sel(
+            {lat_dim: lat_slice, lon_dim: slice(lon_min, lon_max)}
+        )
+    else:
+        # Both corridor and dataset are in compatible ranges
+        ds = ds.sel(
+            {lat_dim: lat_slice, lon_dim: slice(lon_min, lon_max)}
+        )
+
+    return ds
+
+
+def download_era5_wind_gcs(
+    output_dir: str | Path = "data/era5",
+    corridor: str = "atlantic",
+    year: str = "2024",
+    time_step: int = 6,
+) -> Path:
+    """Download ERA5 10-m wind data from GCS and save as NetCDF.
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Output directory.
+    corridor : str
+        Route corridor name.
+    year : str
+        Year to download.
+    time_step : int
+        Hours between time steps (default 6).
+
+    Returns
+    -------
+    Path
+        Path to saved NetCDF file.
+    """
+    _ensure_deps()
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    filename = output_dir / f"era5_wind_{corridor}_{year}.nc"
+
+    if filename.exists():
+        logger.info("File already exists, skipping: %s", filename)
+        return filename
+
+    logger.info("Opening ERA5 wind data on GCS for %s/%s ...", corridor, year)
+    ds = _open_era5_zarr([WIND_U_VAR, WIND_V_VAR])
+    ds = _select_corridor(ds, corridor, year, time_step)
+
+    logger.info("Downloading and saving to %s ...", filename)
+    ds.to_netcdf(filename)
+    logger.info("Saved: %s (%.1f MB)", filename, filename.stat().st_size / 1e6)
+    return filename
+
+
+def download_era5_waves_gcs(
+    output_dir: str | Path = "data/era5",
+    corridor: str = "atlantic",
+    year: str = "2024",
+    time_step: int = 6,
+) -> Path:
+    """Download ERA5 wave data (Hs + direction) from GCS and save as NetCDF.
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Output directory.
+    corridor : str
+        Route corridor name.
+    year : str
+        Year to download.
+    time_step : int
+        Hours between time steps (default 6).
+
+    Returns
+    -------
+    Path
+        Path to saved NetCDF file.
+    """
+    _ensure_deps()
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    filename = output_dir / f"era5_waves_{corridor}_{year}.nc"
+
+    if filename.exists():
+        logger.info("File already exists, skipping: %s", filename)
+        return filename
+
+    logger.info("Opening ERA5 wave data on GCS for %s/%s ...", corridor, year)
+    ds = _open_era5_zarr([WAVE_HS_VAR, WAVE_DIR_VAR])
+    ds = _select_corridor(ds, corridor, year, time_step)
+
+    logger.info("Downloading and saving to %s ...", filename)
+    ds.to_netcdf(filename)
+    logger.info("Saved: %s (%.1f MB)", filename, filename.stat().st_size / 1e6)
+    return filename
+
+
+def download_all_gcs(
+    output_dir: str | Path = "data/era5",
+    year: str = "2024",
+    corridors: list[str] | None = None,
+    time_step: int = 6,
+) -> list[Path]:
+    """Download all ERA5 data needed for SWOPP3 from GCS.
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Output directory.
+    year : str
+        Year to download.
+    corridors : list[str], optional
+        Corridors to download (default: both).
+    time_step : int
+        Hours between time steps.
+
+    Returns
+    -------
+    list[Path]
+        Paths to all downloaded NetCDF files.
+    """
+    corridors = corridors or ["atlantic", "pacific"]
+    files: list[Path] = []
+    for corridor in corridors:
+        files.append(
+            download_era5_wind_gcs(
+                output_dir=output_dir, corridor=corridor, year=year,
+                time_step=time_step,
+            )
+        )
+        files.append(
+            download_era5_waves_gcs(
+                output_dir=output_dir, corridor=corridor, year=year,
+                time_step=time_step,
+            )
+        )
+    return files

--- a/routetools/era5/download_gcs.py
+++ b/routetools/era5/download_gcs.py
@@ -28,7 +28,7 @@ GCS_ERA5_SINGLE_LEVEL = (
 # Route corridor bounds: {name: (lat_min, lat_max, lon_min, lon_max)}
 # Longitudes in 0..360 convention for the Pacific to handle antimeridian.
 CORRIDORS: dict[str, tuple[float, float, float, float]] = {
-    "atlantic": (25.0, 55.0, -80.0, 10.0),
+    "atlantic": (25.0, 60.0, -80.0, 10.0),
     "pacific": (15.0, 55.0, 120.0, 240.0),
 }
 

--- a/routetools/era5/download_gcs.py
+++ b/routetools/era5/download_gcs.py
@@ -57,7 +57,7 @@ def _ensure_deps() -> None:
 
 def _open_era5_zarr(variables: list[str]) -> "xarray.Dataset":  # type: ignore[name-defined]
     """Open the ERA5 Zarr store on GCS and select the given variables."""
-    import gcsfs  # noqa: F811
+    import gcsfs
     import xarray as xr
 
     fs = gcsfs.GCSFileSystem(token="anon")

--- a/routetools/era5/loader.py
+++ b/routetools/era5/loader.py
@@ -191,8 +191,9 @@ def _build_field_closure(
         ts: jnp.ndarray | int | float,
     ) -> tuple[jnp.ndarray, jnp.ndarray]:
         # Normalise ts
-        if isinstance(ts, int | float):
+        if isinstance(ts, (int, float)):
             ts = jnp.array([ts], dtype=jnp.float32)
+        ts = jnp.atleast_1d(ts)
 
         # Handle mismatched lengths (same pattern as benchmark.py)
         diff = lat.shape[0] - ts.shape[0]
@@ -636,10 +637,25 @@ def load_natural_earth_land_mask(
     Land
         A ``Land`` object compatible with CMA-ES.
     """
-    import cartopy.io.shapereader as shpreader
-    from shapely.affinity import translate
-    from shapely.geometry import box
-    from shapely.validation import make_valid
+    try:
+        import cartopy.io.shapereader as shpreader
+        from shapely.affinity import translate
+        from shapely.geometry import box
+        from shapely.validation import make_valid
+    except ImportError as exc:
+        raise ImportError(
+            "Natural Earth land mask requires cartopy, shapely, and rasterio. "
+            "Install them with:\n  pip install cartopy shapely rasterio"
+        ) from exc
+
+    try:
+        import rasterio  # noqa: F401 — validate availability early
+        from rasterio import features, transform
+    except ImportError as exc:
+        raise ImportError(
+            "Natural Earth land mask requires rasterio. "
+            "Install it with:\n  pip install rasterio"
+        ) from exc
 
     from routetools.land import Land
 

--- a/routetools/era5/loader.py
+++ b/routetools/era5/loader.py
@@ -197,9 +197,12 @@ def _build_field_closure(
 
         # Handle mismatched lengths (same pattern as benchmark.py)
         diff = lat.shape[0] - ts.shape[0]
-        ts_full = (
-            jnp.concatenate([ts, jnp.full(diff, ts[-1])]) if diff > 0 else ts
-        )
+        if diff > 0:
+            ts_full = jnp.concatenate([ts, jnp.full(diff, ts[-1])])
+        elif diff < 0:
+            ts_full = ts[: lat.shape[0]]
+        else:
+            ts_full = ts
 
         # Offset: t=0 means departure time
         ts_full = ts_full + dep_offset

--- a/routetools/era5/loader.py
+++ b/routetools/era5/loader.py
@@ -1,0 +1,768 @@
+"""Load ERA5 NetCDF data into JAX-compatible field closures.
+
+The closures returned by the ``load_*`` functions conform to the interface
+expected by :func:`routetools.cost.cost_function`:
+
+- **vectorfield** ``(lon, lat, t) -> (u, v)`` — ocean current components.
+  For ERA5 wind data this returns 10-m wind components, which can be used
+  by a ship performance / polar model.
+- **wavefield** ``(lon, lat, t) -> (height, direction)`` — significant wave
+  height (m) and mean wave direction (degrees from North).
+- **windfield** ``(lon, lat, t) -> (u10, v10)`` — alias for the wind loader,
+  separated from "vectorfield" to make the distinction explicit.
+
+The ``t`` coordinate represents *hours elapsed since a reference epoch*
+(typically the departure time).  The loader precomputes the mapping from
+absolute NetCDF timestamps to a ``[0, N_t)`` integer index so that
+interpolation via ``jax.scipy.ndimage.map_coordinates`` works correctly.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from datetime import datetime
+from math import ceil
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import xarray as xr
+
+from routetools.vectorfield import time_variant
+
+logger = logging.getLogger(__name__)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def _load_dataset(path: str | Path) -> xr.Dataset:
+    """Open a NetCDF file with xarray.
+
+    Tries the ``scipy`` engine first (pure-Python, no C-library
+    compatibility issues), then falls back to ``netcdf4``.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"ERA5 data file not found: {path}")
+    last_exc: Exception | None = None
+    for engine in ("scipy", "netcdf4", None):
+        try:
+            return xr.open_dataset(path, engine=engine)
+        except Exception as exc:  # noqa: BLE001
+            last_exc = exc
+            logger.debug(
+                "Failed to open %s with engine %r", path, engine, exc_info=True
+            )
+            continue
+    raise RuntimeError(
+        f"Failed to open ERA5 data file {path!s} with engines "
+        "('scipy', 'netcdf4', None)"
+    ) from last_exc
+
+
+def _get_coord_name(ds: xr.Dataset, candidates: list[str]) -> str:
+    """Return the first coordinate name that exists in *ds*."""
+    for name in candidates:
+        if name in ds.coords or name in ds.dims:
+            return name
+    raise KeyError(
+        f"None of {candidates} found in dataset coordinates: "
+        f"{list(ds.coords)}"
+    )
+
+
+def _prepare_grid(
+    ds: xr.Dataset,
+    departure_time: datetime | str | np.datetime64 | None = None,
+) -> dict:
+    """Extract grid metadata and convert to JAX arrays.
+
+    Returns a dict with keys:
+        - ``lat``: 1-D numpy array of latitudes  (ascending)
+        - ``lon``: 1-D numpy array of longitudes (ascending)
+        - ``begin``: ``jnp.array([t0, lat0, lon0])`` — grid origin
+        - ``spacing``: ``jnp.array([dt, dlat, dlon])`` — grid step sizes
+        - ``departure_offset_h``: hours from first NetCDF timestamp to
+          *departure_time* (0 if *departure_time* is ``None``).
+    """
+    lat_name = _get_coord_name(ds, ["latitude", "lat"])
+    lon_name = _get_coord_name(ds, ["longitude", "lon"])
+    time_name = _get_coord_name(ds, ["time", "valid_time"])
+
+    lats = ds[lat_name].values.astype(np.float64)
+    lons = ds[lon_name].values.astype(np.float64)
+    times = ds[time_name].values  # numpy datetime64 array
+
+    # Ensure ascending latitude
+    if lats[0] > lats[-1]:
+        lats = lats[::-1]
+        ds = ds.isel({lat_name: slice(None, None, -1)})
+
+    # Ensure ascending longitude
+    if lons[0] > lons[-1]:
+        lons = lons[::-1]
+        ds = ds.isel({lon_name: slice(None, None, -1)})
+
+    # Convert times to hours since first timestamp
+    t0_np = times[0]
+    times_hours = (times - t0_np) / np.timedelta64(1, "h")
+    times_hours = times_hours.astype(np.float64)
+
+    # Compute departure offset
+    if departure_time is not None:
+        if isinstance(departure_time, str):
+            departure_time = np.datetime64(departure_time)
+        elif isinstance(departure_time, datetime):
+            departure_time = np.datetime64(departure_time)
+        departure_offset_h = float(
+            (departure_time - t0_np) / np.timedelta64(1, "h")
+        )
+    else:
+        departure_offset_h = 0.0
+
+    # Grid parameters
+    dt = float(times_hours[1] - times_hours[0]) if len(times_hours) > 1 else 1.0
+    dlat = float(lats[1] - lats[0]) if len(lats) > 1 else 1.0
+    dlon = float(lons[1] - lons[0]) if len(lons) > 1 else 1.0
+
+    begin = jnp.array(
+        [times_hours[0], lats[0], lons[0]], dtype=jnp.float32
+    )[None, :]
+    spacing = jnp.array([dt, dlat, dlon], dtype=jnp.float32)[None, :]
+
+    return {
+        "lat": lats,
+        "lon": lons,
+        "times_hours": times_hours,
+        "begin": begin,
+        "spacing": spacing,
+        "departure_offset_h": departure_offset_h,
+        "ds": ds,
+        "lat_name": lat_name,
+        "lon_name": lon_name,
+        "time_name": time_name,
+    }
+
+
+def _build_field_closure(
+    data_a: jnp.ndarray,
+    data_b: jnp.ndarray,
+    begin: jnp.ndarray,
+    spacing: jnp.ndarray,
+    departure_offset_h: float,
+    order: int = 1,
+    mode: str = "nearest",
+    add_time_variant_attr: bool = False,
+) -> Callable[
+    [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+    tuple[jnp.ndarray, jnp.ndarray],
+]:
+    """Build a JAX-interpolated field closure.
+
+    Parameters
+    ----------
+    data_a, data_b : jnp.ndarray
+        3-D arrays of shape ``(T, lat, lon)`` for the two field components.
+    begin, spacing : jnp.ndarray
+        Grid origin and step size, each of shape ``(1, 3)`` — ``[t, lat, lon]``.
+    departure_offset_h : float
+        Offset in hours to add to the ``t`` argument so that ``t=0`` maps to
+        the departure time within the dataset.
+    order : int
+        Interpolation order (1 = linear).
+    mode : str
+        Boundary mode for ``map_coordinates``.
+    add_time_variant_attr : bool
+        If ``True``, mark the returned function as ``time_variant``.
+
+    Returns
+    -------
+    Callable
+        ``(lon, lat, t) -> (a, b)`` closure.
+    """
+    dep_offset = jnp.float32(departure_offset_h)
+
+    def _field(
+        lon: jnp.ndarray,
+        lat: jnp.ndarray,
+        ts: jnp.ndarray | int | float,
+    ) -> tuple[jnp.ndarray, jnp.ndarray]:
+        # Normalise ts
+        if isinstance(ts, int | float):
+            ts = jnp.array([ts], dtype=jnp.float32)
+
+        # Handle mismatched lengths (same pattern as benchmark.py)
+        diff = lat.shape[0] - ts.shape[0]
+        ts_full = (
+            jnp.concatenate([ts, jnp.full(diff, ts[-1])]) if diff > 0 else ts
+        )
+
+        # Offset: t=0 means departure time
+        ts_full = ts_full + dep_offset
+
+        # Handle 2D inputs
+        if lat.ndim > 1:
+            shape = lat.shape
+            if ts_full.ndim < lat.ndim:
+                ts_full = jnp.repeat(ts_full[:, None], lat.shape[1], axis=1)
+            ts_full = ts_full.flatten()
+            lat = lat.flatten()
+            lon = lon.flatten()
+        else:
+            shape = None
+
+        # Build coordinates: [t, lat, lon]
+        x = jnp.stack([ts_full, lat, lon], axis=-1)
+
+        # Normalise to grid indices
+        coords = (x - begin) / spacing  # shape (N, 3)
+
+        # Interpolate
+        a = jax.scipy.ndimage.map_coordinates(
+            data_a, coords.T, order=order, mode=mode
+        )
+        b = jax.scipy.ndimage.map_coordinates(
+            data_b, coords.T, order=order, mode=mode
+        )
+
+        # Reshape if needed
+        if shape is not None:
+            a = a.reshape(shape)
+            b = b.reshape(shape)
+
+        return a, b
+
+    if add_time_variant_attr:
+        _field = time_variant(_field)
+
+    return _field
+
+
+# ── public API ────────────────────────────────────────────────────────────
+
+
+def load_era5_windfield(
+    path: str | Path,
+    departure_time: datetime | str | np.datetime64 | None = None,
+    order: int = 1,
+    u_var: str | None = None,
+    v_var: str | None = None,
+) -> Callable[
+    [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+    tuple[jnp.ndarray, jnp.ndarray],
+]:
+    """Load ERA5 10-m wind data and return a windfield closure.
+
+    The returned function has the signature
+    ``(lon, lat, t) -> (u10, v10)``
+    where ``u10`` and ``v10`` are the 10-m wind components in m/s.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the ERA5 wind NetCDF file.
+    departure_time : datetime or str or np.datetime64, optional
+        The voyage departure time.  When provided, ``t = 0`` in the returned
+        closure corresponds to this datetime; otherwise ``t = 0`` maps to the
+        first timestamp in the dataset.
+    order : int
+        Interpolation order (1 = linear, default).
+    u_var : str, optional
+        Name of the u-wind variable in the NetCDF file.
+    v_var : str, optional
+        Name of the v-wind variable in the NetCDF file.
+
+    Returns
+    -------
+    Callable
+        ``(lon, lat, t) -> (u10, v10)`` with ``.is_time_variant = True``.
+    """
+    ds = _load_dataset(path)
+
+    # Auto-detect variable names
+    if u_var is None:
+        for candidate in ["u10", "10m_u_component_of_wind", "U10"]:
+            if candidate in ds.data_vars:
+                u_var = candidate
+                break
+        if u_var is None:
+            ds.close()
+            raise KeyError(
+                f"Cannot find u-wind variable in {path}. "
+                f"Available: {list(ds.data_vars)}"
+            )
+    if v_var is None:
+        for candidate in ["v10", "10m_v_component_of_wind", "V10"]:
+            if candidate in ds.data_vars:
+                v_var = candidate
+                break
+        if v_var is None:
+            ds.close()
+            raise KeyError(
+                f"Cannot find v-wind variable in {path}. "
+                f"Available: {list(ds.data_vars)}"
+            )
+
+    grid = _prepare_grid(ds, departure_time)
+    ds = grid["ds"]  # use the reindexed dataset from _prepare_grid
+
+    # Extract data as JAX arrays: shape (T, lat, lon)
+    lat_name = grid["lat_name"]
+    udata = ds[u_var]
+    vdata = ds[v_var]
+
+    umat = jnp.array(udata.values, dtype=jnp.float32)
+    vmat = jnp.array(vdata.values, dtype=jnp.float32)
+
+    ds.close()  # release file handles; data is now in JAX arrays
+
+    logger.info(
+        "Loaded ERA5 wind: shape=%s, lat=[%.1f, %.1f], lon=[%.1f, %.1f], "
+        "t=[%.0f, %.0f] h",
+        umat.shape,
+        grid["lat"][0],
+        grid["lat"][-1],
+        grid["lon"][0],
+        grid["lon"][-1],
+        grid["times_hours"][0],
+        grid["times_hours"][-1],
+    )
+
+    return _build_field_closure(
+        umat,
+        vmat,
+        grid["begin"],
+        grid["spacing"],
+        grid["departure_offset_h"],
+        order=order,
+        mode="nearest",
+        add_time_variant_attr=True,
+    )
+
+
+def load_era5_vectorfield(
+    path: str | Path,
+    departure_time: datetime | str | np.datetime64 | None = None,
+    order: int = 1,
+    u_var: str | None = None,
+    v_var: str | None = None,
+) -> Callable[
+    [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+    tuple[jnp.ndarray, jnp.ndarray],
+]:
+    """Load ERA5 wind data and return a vectorfield-compatible closure.
+
+    This is identical to :func:`load_era5_windfield` but named to align with
+    the existing ``vectorfield`` interface used by ``cost_function``.
+
+    The 10-m wind components are returned as ``(u, v)`` in m/s.  For SWOPP3,
+    these are passed to the RISE polar model rather than being used directly
+    as ocean currents, but the function signature is the same.
+
+    See :func:`load_era5_windfield` for parameter docs.
+    """
+    return load_era5_windfield(
+        path, departure_time=departure_time, order=order,
+        u_var=u_var, v_var=v_var,
+    )
+
+
+def load_era5_wavefield(
+    path: str | Path,
+    departure_time: datetime | str | np.datetime64 | None = None,
+    order: int = 1,
+    hs_var: str | None = None,
+    dir_var: str | None = None,
+) -> Callable[
+    [jnp.ndarray, jnp.ndarray, jnp.ndarray],
+    tuple[jnp.ndarray, jnp.ndarray],
+]:
+    """Load ERA5 wave data and return a wavefield closure.
+
+    The returned function has the signature
+    ``(lon, lat, t) -> (hs, mwd)``
+    where ``hs`` is significant wave height in metres and ``mwd`` is mean wave
+    direction in degrees from North.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the ERA5 wave NetCDF file.
+    departure_time : datetime or str or np.datetime64, optional
+        The voyage departure time.  When provided, ``t = 0`` in the returned
+        closure corresponds to this datetime.
+    order : int
+        Interpolation order (1 = linear, default).
+    hs_var : str, optional
+        Name of the significant wave height variable.
+    dir_var : str, optional
+        Name of the mean wave direction variable.
+
+    Returns
+    -------
+    Callable
+        ``(lon, lat, t) -> (hs, mwd)``.
+    """
+    ds = _load_dataset(path)
+
+    # Auto-detect variable names
+    if hs_var is None:
+        for candidate in [
+            "swh",
+            "significant_height_of_combined_wind_waves_and_swell",
+            "Hs",
+            "hs",
+        ]:
+            if candidate in ds.data_vars:
+                hs_var = candidate
+                break
+        if hs_var is None:
+            ds.close()
+            raise KeyError(
+                f"Cannot find wave height variable in {path}. "
+                f"Available: {list(ds.data_vars)}"
+            )
+
+    if dir_var is None:
+        for candidate in ["mwd", "mean_wave_direction", "MWD"]:
+            if candidate in ds.data_vars:
+                dir_var = candidate
+                break
+        if dir_var is None:
+            ds.close()
+            raise KeyError(
+                f"Cannot find wave direction variable in {path}. "
+                f"Available: {list(ds.data_vars)}"
+            )
+
+    grid = _prepare_grid(ds, departure_time)
+    ds = grid["ds"]  # use the reindexed dataset from _prepare_grid
+
+    lat_name = grid["lat_name"]
+    hsdata = ds[hs_var]
+    dirdata = ds[dir_var]
+
+    hmat = jnp.array(hsdata.values, dtype=jnp.float32)
+    dmat = jnp.array(dirdata.values, dtype=jnp.float32)
+
+    ds.close()  # release file handles; data is now in JAX arrays
+
+    # Replace NaN with 0 (land points in wave data)
+    hmat = jnp.nan_to_num(hmat, nan=0.0)
+    dmat = jnp.nan_to_num(dmat, nan=0.0)
+
+    logger.info(
+        "Loaded ERA5 waves: shape=%s, lat=[%.1f, %.1f], lon=[%.1f, %.1f], "
+        "t=[%.0f, %.0f] h",
+        hmat.shape,
+        grid["lat"][0],
+        grid["lat"][-1],
+        grid["lon"][0],
+        grid["lon"][-1],
+        grid["times_hours"][0],
+        grid["times_hours"][-1],
+    )
+
+    return _build_field_closure(
+        hmat,
+        dmat,
+        grid["begin"],
+        grid["spacing"],
+        grid["departure_offset_h"],
+        order=order,
+        mode="nearest",
+        add_time_variant_attr=False,
+    )
+
+
+def load_era5_land_mask(
+    wave_path: str | Path,
+    hs_var: str | None = None,
+) -> "Land":
+    """Create a :class:`~routetools.land.Land` mask from ERA5 wave NaN values.
+
+    ERA5 wave variables (SWH, MWD) are NaN over land.  This function
+    reads the first timestep, marks every grid cell that is NaN as land,
+    and returns a ``Land`` object that can be passed to CMA-ES.
+
+    Parameters
+    ----------
+    wave_path : str or Path
+        Path to an ERA5 wave NetCDF file.
+    hs_var : str, optional
+        Name of the significant wave height variable.  Auto-detected if
+        ``None``.
+
+    Returns
+    -------
+    Land
+        A ``Land`` object whose grid covers the ERA5 file extent.
+    """
+    from routetools.land import Land
+
+    ds = _load_dataset(wave_path)
+
+    # Auto-detect wave-height variable
+    if hs_var is None:
+        for candidate in [
+            "swh",
+            "significant_height_of_combined_wind_waves_and_swell",
+            "Hs",
+            "hs",
+        ]:
+            if candidate in ds.data_vars:
+                hs_var = candidate
+                break
+        if hs_var is None:
+            ds.close()
+            raise KeyError(
+                f"Cannot find wave height variable in {wave_path}. "
+                f"Available: {list(ds.data_vars)}"
+            )
+
+    # Get grid coordinates
+    lat_name = _get_coord_name(ds, ["latitude", "lat"])
+    lon_name = _get_coord_name(ds, ["longitude", "lon"])
+
+    lats = ds[lat_name].values.astype(np.float64)
+    lons = ds[lon_name].values.astype(np.float64)
+
+    # Ensure ascending
+    if lats[0] > lats[-1]:
+        lats = lats[::-1]
+        ds = ds.isel({lat_name: slice(None, None, -1)})
+    if lons[0] > lons[-1]:
+        lons = lons[::-1]
+        ds = ds.isel({lon_name: slice(None, None, -1)})
+
+    # First timestep of wave height: NaN → land
+    hs_t0 = ds[hs_var].isel(
+        {_get_coord_name(ds, ["time", "valid_time"]): 0}
+    ).values
+
+    ds.close()
+
+    # hs_t0 shape is (lat, lon).  Land class expects (x, y) = (lon, lat).
+    is_land_latlon = np.isnan(hs_t0)  # (lat, lon)
+    is_land_lonlat = is_land_latlon.T  # (lon, lat)
+
+    # Land class: values > water_level → land.
+    # We use 1.0 for land, 0.0 for water, water_level = 0.5.
+    land_array = is_land_lonlat.astype(np.float32)
+
+    n_lon, n_lat = land_array.shape
+    lon_min, lon_max = float(lons[0]), float(lons[-1])
+    lat_min, lat_max = float(lats[0]), float(lats[-1])
+
+    # Land.__init__ computes lenx = ceil(xlim[1] - xlim[0]) * resolution[0]
+    # and expects land_array.shape == (lenx, leny).
+    # To match the ERA5 grid exactly we construct the Land object directly,
+    # bypassing the Perlin-noise generation path entirely.
+    land = Land.__new__(Land)
+    land._array = jnp.array(land_array)
+    land.x = jnp.linspace(lon_min, lon_max, n_lon)
+    land.y = jnp.linspace(lat_min, lat_max, n_lat)
+    land.xmin = lon_min
+    land.xmax = lon_max
+    land.xnorm = (n_lon - 1) / (lon_max - lon_min) if lon_max > lon_min else 1.0
+    land.ymin = lat_min
+    land.ymax = lat_max
+    land.ynorm = (n_lat - 1) / (lat_max - lat_min) if lat_max > lat_min else 1.0
+    land.resolution = (1, 1)
+    land.random_seed = None
+    land.water_level = 0.5
+    land.shape = land_array.shape
+    land.interpolate = 10       # insert 10 sub-points between waypoints to catch narrow land
+    land.outbounds_is_land = True
+    land.penalize_segments = True
+    land._map_mode = "nearest"
+    land._map_order = 0
+
+    land_indices = jnp.argwhere(land._array > land.water_level)
+    if land_indices.size > 0:
+        land._lats = land.y[land_indices[:, 1]]
+        land._lons = land.x[land_indices[:, 0]]
+    else:
+        land._lats = jnp.array([])
+        land._lons = jnp.array([])
+
+    n_land = int(np.sum(is_land_lonlat))
+    n_total = int(np.prod(is_land_lonlat.shape))
+    logger.info(
+        "ERA5 land mask: %d/%d cells are land (%.1f%%), "
+        "lon=[%.1f, %.1f], lat=[%.1f, %.1f], shape=%s",
+        n_land, n_total, 100 * n_land / n_total,
+        lon_min, lon_max, lat_min, lat_max, land_array.shape,
+    )
+
+    return land
+
+
+def load_natural_earth_land_mask(
+    lon_range: tuple[float, float],
+    lat_range: tuple[float, float],
+    resolution: float = 0.01,
+    ne_resolution: str = "10m",
+    interpolate: int = 50,
+) -> "Land":
+    """Create a high-resolution land mask from Natural Earth shapefiles.
+
+    Uses cartopy's Natural Earth 1:10m land polygons rasterized onto a
+    regular grid.  This is much more accurate than the ERA5 wave-NaN
+    approach for narrow land features (Cape Cod, Aleutian Islands,
+    Channel Islands, narrow straits, etc.).
+
+    Parameters
+    ----------
+    lon_range : tuple[float, float]
+        ``(lon_min, lon_max)`` — longitude extent of the corridor in
+        degrees East.  Values > 180 are supported (unwrapped antimeridian).
+    lat_range : tuple[float, float]
+        ``(lat_min, lat_max)`` — latitude extent in degrees North.
+    resolution : float
+        Grid cell size in degrees.  Default 0.01° ≈ 1.1 km at the equator.
+    ne_resolution : str
+        Natural Earth resolution: ``"10m"``, ``"50m"``, or ``"110m"``.
+    interpolate : int
+        Number of sub-points inserted between waypoints for segment
+        checking (passed to ``Land``).  Default 50 gives ~1 km spacing
+        with L=100 waypoints, matching the 0.01° mask resolution.
+
+    Returns
+    -------
+    Land
+        A ``Land`` object compatible with CMA-ES.
+    """
+    import cartopy.io.shapereader as shpreader
+    from shapely.affinity import translate
+    from shapely.geometry import box
+    from shapely.validation import make_valid
+
+    from routetools.land import Land
+
+    # Load Natural Earth land polygons
+    shp_path = shpreader.natural_earth(
+        resolution=ne_resolution, category="physical", name="land"
+    )
+    reader = shpreader.Reader(shp_path)
+    land_geoms = list(reader.geometries())
+
+    lon_min, lon_max = float(lon_range[0]), float(lon_range[1])
+    lat_min, lat_max = float(lat_range[0]), float(lat_range[1])
+
+    # Build a bounding box with a small buffer for clipping
+    buf = 1.0  # degree buffer
+    clip_box = box(lon_min - buf, lat_min - buf, lon_max + buf, lat_max + buf)
+
+    # If the corridor uses longitudes > 180 (unwrapped antimeridian),
+    # we need shifted copies of the NE geometries (which are in [-180, 180]).
+    need_shift = lon_max > 180 or lon_min > 180
+
+    # Clip geometries to the region of interest for efficiency
+    clipped = []
+    for geom in land_geoms:
+        if geom is None or geom.is_empty:
+            continue
+
+        # Original geometry (NE coordinates in [-180, 180])
+        try:
+            g = make_valid(geom) if not geom.is_valid else geom
+            intersection = g.intersection(clip_box)
+            if not intersection.is_empty:
+                clipped.append(intersection)
+        except Exception as exc:
+            logger.debug("NE geom intersection failed: %s", exc)
+
+        # For antimeridian-crossing corridors, also shift by +360°
+        # so that NE lon -180..-120 becomes 180..240, etc.
+        if need_shift:
+            try:
+                shifted = translate(geom, xoff=360)
+                shifted = make_valid(shifted) if not shifted.is_valid else shifted
+                intersection = shifted.intersection(clip_box)
+                if not intersection.is_empty:
+                    clipped.append(intersection)
+            except Exception as exc:
+                logger.debug("NE shifted geom intersection failed: %s", exc)
+
+    if not clipped:
+        clipped = []
+
+    # Build the raster grid dimensions
+    n_lon = int(ceil((lon_max - lon_min) / resolution)) + 1
+    n_lat = int(ceil((lat_max - lat_min) / resolution)) + 1
+
+    # Rasterize using rasterio scan-line fill (O(pixels), very fast)
+    from rasterio.features import rasterize
+    from rasterio.transform import from_bounds
+
+    # rasterio transform: maps pixel (col, row) → (lon, lat).
+    # rows = lat axis (n_lat), cols = lon axis (n_lon).
+    # The Land object expects array shape (n_lon, n_lat) with
+    # axis-0 = lon, axis-1 = lat, so we rasterize with
+    # width=n_lon, height=n_lat, then transpose.
+    transform = from_bounds(lon_min, lat_min, lon_max, lat_max, n_lon, n_lat)
+    shapes = [(geom, 1) for geom in clipped if geom is not None and not geom.is_empty]
+
+    if shapes:
+        # rasterize returns (height=n_lat, width=n_lon) uint8 array
+        # Row 0 = lat_max (north) in rasterio convention.
+        raster = rasterize(
+            shapes,
+            out_shape=(n_lat, n_lon),
+            transform=transform,
+            fill=0,
+            dtype=np.uint8,
+            all_touched=True,  # mark cells touched by polygon boundary
+        )
+        # Flip latitude so row 0 = lat_min (south), matching
+        # Land.y = linspace(lat_min, lat_max, n_lat).
+        raster = raster[::-1, :]
+        # Transpose to (n_lon, n_lat) to match Land's (x=lon, y=lat) convention
+        land_array = raster.T.astype(np.float32)
+    else:
+        land_array = np.zeros((n_lon, n_lat), dtype=np.float32)
+
+    # Construct the Land object (same bypass pattern as load_era5_land_mask)
+    land = Land.__new__(Land)
+    land._array = jnp.array(land_array)
+    land.x = jnp.linspace(lon_min, lon_max, n_lon)
+    land.y = jnp.linspace(lat_min, lat_max, n_lat)
+    land.xmin = lon_min
+    land.xmax = lon_max
+    land.xnorm = (n_lon - 1) / (lon_max - lon_min) if lon_max > lon_min else 1.0
+    land.ymin = lat_min
+    land.ymax = lat_max
+    land.ynorm = (n_lat - 1) / (lat_max - lat_min) if lat_max > lat_min else 1.0
+    land.resolution = (1, 1)
+    land.random_seed = None
+    land.water_level = 0.5
+    land.shape = land_array.shape
+    land.interpolate = interpolate
+    land.outbounds_is_land = True
+    land.penalize_segments = True
+    land._map_mode = "nearest"
+    land._map_order = 0
+
+    land_indices = jnp.argwhere(land._array > land.water_level)
+    if land_indices.size > 0:
+        land._lats = land.y[land_indices[:, 1]]
+        land._lons = land.x[land_indices[:, 0]]
+    else:
+        land._lats = jnp.array([])
+        land._lons = jnp.array([])
+
+    n_land = int(np.sum(land_array > 0.5))
+    n_total = n_lon * n_lat
+    logger.info(
+        "Natural Earth land mask (%s): %d/%d cells are land (%.1f%%), "
+        "lon=[%.1f, %.1f], lat=[%.1f, %.1f], res=%.3f°, shape=%s",
+        ne_resolution, n_land, n_total, 100 * n_land / n_total,
+        lon_min, lon_max, lat_min, lat_max, resolution, land_array.shape,
+    )
+
+    return land
+

--- a/routetools/era5/loader.py
+++ b/routetools/era5/loader.py
@@ -581,7 +581,7 @@ def load_era5_land_mask(
     land.shape = land_array.shape
     land.interpolate = 10       # insert 10 sub-points between waypoints to catch narrow land
     land.outbounds_is_land = True
-    land.penalize_segments = True
+    land.penalize_segments = False
     land._map_mode = "nearest"
     land._map_order = 0
 
@@ -762,7 +762,7 @@ def load_natural_earth_land_mask(
     land.shape = land_array.shape
     land.interpolate = interpolate
     land.outbounds_is_land = True
-    land.penalize_segments = True
+    land.penalize_segments = False
     land._map_mode = "nearest"
     land._map_order = 0
 

--- a/routetools/wrr_bench/__init__.py
+++ b/routetools/wrr_bench/__init__.py
@@ -1,3 +1,22 @@
+"""Legacy ocean benchmark module.
+
+.. deprecated::
+    ``wrr_bench`` is superseded by :mod:`routetools.era5` which provides
+    real-world ERA5 wind, wave, and current fields.  ``wrr_bench`` will be
+    removed in a future release.  Migrate to the ERA5-based pipeline::
+
+        from routetools.era5 import load_era5_windfield, load_era5_wavefield
+"""
+
+import warnings
+
+warnings.warn(
+    "routetools.wrr_bench is deprecated and will be removed in a future release. "
+    "Use routetools.era5 instead for real-world weather data.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 from routetools.wrr_bench.load import load_real_instance
 from routetools.wrr_bench.ocean import Ocean
 

--- a/scripts/download_era5.py
+++ b/scripts/download_era5.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+"""Download ERA5 weather data for SWOPP3 route corridors.
+
+Provides a single entry point for downloading ERA5 wind and wave data
+needed by the routetools weather-routing pipeline.  Two backends are
+supported:
+
+- **GCS** (default): Downloads from the public Google Cloud archive
+  (WeatherBench2 / Pangeo).  No API key required.
+- **CDS**: Downloads from the Copernicus Climate Data Store.
+  Requires ``cdsapi`` and a valid CDS API key.
+
+Usage
+-----
+Download all data for 2024 (both Atlantic and Pacific corridors)::
+
+    uv run scripts/download_era5.py
+
+Download only the Atlantic corridor for 2023 via GCS::
+
+    uv run scripts/download_era5.py --corridor atlantic --year 2023
+
+Download via the CDS API instead::
+
+    uv run scripts/download_era5.py --backend cds
+
+Output
+------
+Downloaded files are stored in ``data/era5/`` by default::
+
+    data/era5/
+    ├── era5_wind_atlantic_2024.nc
+    ├── era5_waves_atlantic_2024.nc
+    ├── era5_wind_pacific_2024.nc
+    └── era5_waves_pacific_2024.nc
+
+These can then be loaded via::
+
+    from routetools.era5 import load_era5_windfield, load_era5_wavefield
+
+    windfield = load_era5_windfield("data/era5/era5_wind_atlantic_2024.nc")
+    wavefield = load_era5_wavefield("data/era5/era5_waves_atlantic_2024.nc")
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+BACKENDS = ("gcs", "cds")
+CORRIDORS = ("atlantic", "pacific")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Download ERA5 wind and wave data for SWOPP3 corridors.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--backend",
+        choices=BACKENDS,
+        default="gcs",
+        help="Download backend: 'gcs' (default, no API key) or 'cds'.",
+    )
+    parser.add_argument(
+        "--corridor",
+        choices=CORRIDORS,
+        default=None,
+        help="Download a single corridor. Default: both.",
+    )
+    parser.add_argument(
+        "--year",
+        default="2024",
+        help="Year to download (default: 2024).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="data/era5",
+        help="Output directory (default: data/era5).",
+    )
+    parser.add_argument(
+        "--time-step",
+        type=int,
+        default=6,
+        help="Hours between time steps (default: 6). GCS backend only.",
+    )
+    args = parser.parse_args()
+
+    corridors = [args.corridor] if args.corridor else list(CORRIDORS)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info(
+        "Backend=%s  Year=%s  Corridors=%s  Output=%s",
+        args.backend, args.year, corridors, output_dir,
+    )
+
+    if args.backend == "gcs":
+        from routetools.era5.download_gcs import download_all_gcs
+
+        files = download_all_gcs(
+            output_dir=output_dir,
+            year=args.year,
+            corridors=corridors,
+            time_step=args.time_step,
+        )
+    elif args.backend == "cds":
+        from routetools.era5.download_cds import download_all
+
+        files = download_all(
+            output_dir=output_dir,
+            year=args.year,
+            corridors=corridors,
+        )
+    else:
+        print(f"Unknown backend: {args.backend}", file=sys.stderr)
+        sys.exit(1)
+
+    logger.info("Download complete. %d files:", len(files))
+    for f in files:
+        logger.info("  %s", f)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/era5_benchmark.py
+++ b/scripts/era5_benchmark.py
@@ -41,6 +41,7 @@ import matplotlib.pyplot as plt
 
 from routetools.cmaes import optimize
 from routetools.cost import haversine_distance_from_curve
+from routetools._ports import DICT_PORTS
 from routetools.era5 import (
     load_era5_wavefield,
     load_era5_windfield,
@@ -48,10 +49,6 @@ from routetools.era5 import (
 )
 from routetools.fms import optimize_fms
 from routetools.plot import plot_curve
-
-# Port coordinates (from routetools._ports)
-USNYC = {"lat": 40.53, "lon": -73.80}
-DEHAM = {"lat": 53.55, "lon": 9.99}
 
 
 def main() -> None:
@@ -118,20 +115,22 @@ def main() -> None:
     print(f"[ERA5] Loading waves from {wave_file}")
     wavefield = load_era5_wavefield(wave_file, departure_time=args.departure)
 
-    # Use the windfield as the vectorfield for the optimizer
-    vectorfield = windfield
+    # No ocean current data — use a zero vectorfield (SWOPP uses wind
+    # via the performance model, not as current in the cost function).
+    def vectorfield(lon, lat, t):
+        return jnp.zeros_like(lon), jnp.zeros_like(lon)
 
     # ── Build land mask ───────────────────────────────────────────────
-    # Atlantic corridor bounds (from CORRIDORS in download_cds.py)
+    # Atlantic corridor bounds (must cover Hamburg at ~54°N going around UK)
     lon_range = (-80.0, 10.0)
-    lat_range = (25.0, 55.0)
+    lat_range = (25.0, 60.0)
 
     print("[ERA5] Building Natural Earth land mask...")
     land = load_natural_earth_land_mask(lon_range=lon_range, lat_range=lat_range)
 
     # ── Source / destination ──────────────────────────────────────────
-    src = jnp.array([USNYC["lon"], USNYC["lat"]])
-    dst = jnp.array([DEHAM["lon"], DEHAM["lat"]])
+    src = jnp.array([DICT_PORTS["USNYC"]["lon"], DICT_PORTS["USNYC"]["lat"]])
+    dst = jnp.array([DICT_PORTS["DEHAM"]["lon"], DICT_PORTS["DEHAM"]["lat"]])
 
     # ── CMA-ES optimisation ──────────────────────────────────────────
     print("[CMA-ES] Optimising route USNYC → DEHAM ...")
@@ -146,7 +145,7 @@ def main() -> None:
         penalty=1e10,
         K=args.K,
         L=args.L,
-        num_pieces=3,
+        num_pieces=1,
         popsize=args.popsize,
         sigma0=1.0,
         tolfun=60.0,

--- a/scripts/era5_benchmark.py
+++ b/scripts/era5_benchmark.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python
+"""Real-world benchmark: USNYC → DEHAM using ERA5 weather data.
+
+This script demonstrates the full ERA5-based weather routing pipeline:
+
+1. Load ERA5 wind and wave fields from downloaded NetCDF files.
+2. Create a Natural Earth high-resolution land mask.
+3. Optimize a route from New York (USNYC) to Hamburg (DEHAM) departing
+   on 2023-01-08 00:00 UTC, at 12 knots through water.
+4. Refine the route with the FMS smoother.
+5. Plot and save the result.
+
+Prerequisites
+-------------
+Download ERA5 data for the Atlantic corridor first::
+
+    uv run scripts/download_era5.py --corridor atlantic --year 2023
+
+This creates ``data/era5/era5_wind_atlantic_2023.nc`` and
+``data/era5/era5_waves_atlantic_2023.nc``.
+
+Usage
+-----
+::
+
+    uv run scripts/era5_benchmark.py
+
+To change the departure date::
+
+    uv run scripts/era5_benchmark.py --departure 2023-02-15
+
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+
+from routetools.cmaes import optimize
+from routetools.cost import haversine_distance_from_curve
+from routetools.era5 import (
+    load_era5_wavefield,
+    load_era5_windfield,
+    load_natural_earth_land_mask,
+)
+from routetools.fms import optimize_fms
+from routetools.plot import plot_curve
+
+# Port coordinates (from routetools._ports)
+USNYC = {"lat": 40.53, "lon": -73.80}
+DEHAM = {"lat": 53.55, "lon": 9.99}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="ERA5-based benchmark: USNYC → DEHAM.",
+    )
+    parser.add_argument(
+        "--departure",
+        default="2023-01-08T00:00:00",
+        help="Departure datetime (default: 2023-01-08T00:00:00).",
+    )
+    parser.add_argument(
+        "--vel-ship",
+        type=float,
+        default=6.0,
+        help="Speed through water in m/s (≈12 kn). Default: 6.0.",
+    )
+    parser.add_argument(
+        "--data-dir",
+        default="data/era5",
+        help="Directory containing ERA5 NetCDF files.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="output",
+        help="Directory for output plots.",
+    )
+    parser.add_argument(
+        "--K", type=int, default=10, help="Free Bézier control points (default: 10)."
+    )
+    parser.add_argument(
+        "--L", type=int, default=320, help="Curve discretisation points (default: 320)."
+    )
+    parser.add_argument(
+        "--popsize", type=int, default=500, help="CMA-ES population (default: 500)."
+    )
+    parser.add_argument(
+        "--maxfevals",
+        type=int,
+        default=int(1e8),
+        help="Max CMA-ES evaluations (default: 1e8).",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed.")
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    wind_file = data_dir / "era5_wind_atlantic_2023.nc"
+    wave_file = data_dir / "era5_waves_atlantic_2023.nc"
+
+    for f in (wind_file, wave_file):
+        if not f.exists():
+            raise FileNotFoundError(
+                f"Missing {f}. Download first with:\n"
+                "  uv run scripts/download_era5.py --corridor atlantic --year 2023"
+            )
+
+    # ── Load ERA5 fields ──────────────────────────────────────────────
+    print(f"[ERA5] Loading wind from {wind_file}")
+    windfield = load_era5_windfield(wind_file, departure_time=args.departure)
+
+    print(f"[ERA5] Loading waves from {wave_file}")
+    wavefield = load_era5_wavefield(wave_file, departure_time=args.departure)
+
+    # Use the windfield as the vectorfield for the optimizer
+    vectorfield = windfield
+
+    # ── Build land mask ───────────────────────────────────────────────
+    # Atlantic corridor bounds (from CORRIDORS in download_cds.py)
+    lon_range = (-80.0, 10.0)
+    lat_range = (25.0, 55.0)
+
+    print("[ERA5] Building Natural Earth land mask...")
+    land = load_natural_earth_land_mask(lon_range=lon_range, lat_range=lat_range)
+
+    # ── Source / destination ──────────────────────────────────────────
+    src = jnp.array([USNYC["lon"], USNYC["lat"]])
+    dst = jnp.array([DEHAM["lon"], DEHAM["lat"]])
+
+    # ── CMA-ES optimisation ──────────────────────────────────────────
+    print("[CMA-ES] Optimising route USNYC → DEHAM ...")
+    curve_cmaes, dict_cmaes = optimize(
+        vectorfield=vectorfield,
+        src=src,
+        dst=dst,
+        land=land,
+        wavefield=wavefield,
+        travel_stw=args.vel_ship,
+        travel_time=None,
+        penalty=1e10,
+        K=args.K,
+        L=args.L,
+        num_pieces=3,
+        popsize=args.popsize,
+        sigma0=1.0,
+        tolfun=60.0,
+        damping=1.0,
+        maxfevals=args.maxfevals,
+        weight_l1=1.0,
+        weight_l2=0.0,
+        spherical_correction=True,
+        keep_top=0.002,
+        seed=args.seed,
+        verbose=True,
+    )
+    print(f"[CMA-ES] Done — cost = {dict_cmaes['cost'] / 3600:.1f} hours")
+
+    # ── FMS refinement ───────────────────────────────────────────────
+    print("[FMS] Refining route ...")
+    curve_fms, dict_fms = optimize_fms(
+        vectorfield=vectorfield,
+        curve=curve_cmaes,
+        land=land,
+        travel_stw=args.vel_ship,
+        travel_time=None,
+        patience=100,
+        damping=0.9,
+        maxfevals=int(1e6),
+        weight_l1=1.0,
+        weight_l2=0.0,
+        spherical_correction=True,
+        seed=args.seed,
+        verbose=True,
+    )
+    print(f"[FMS] Done — cost = {sum(dict_fms['cost']) / 3600:.1f} hours")
+
+    # ── Metrics ──────────────────────────────────────────────────────
+    dist_cmaes = float(jnp.sum(haversine_distance_from_curve(curve_cmaes))) / 1000
+    dist_fms = float(jnp.sum(haversine_distance_from_curve(curve_fms[0]))) / 1000
+
+    print(f"\n{'Route':<12} {'Cost (h)':>10} {'Distance (km)':>14}")
+    print("-" * 38)
+    print(f"{'CMA-ES':<12} {dict_cmaes['cost'] / 3600:>10.1f} {dist_cmaes:>14.0f}")
+    print(
+        f"{'FMS':<12} {sum(dict_fms['cost']) / 3600:>10.1f} {dist_fms:>14.0f}"
+    )
+
+    # ── Plot ─────────────────────────────────────────────────────────
+    fig, ax = plot_curve(
+        vectorfield=vectorfield,
+        ls_curve=[curve_cmaes, curve_fms[0]],
+        ls_name=[
+            f"CMA-ES ({dict_cmaes['cost'] / 3600:.0f} h, {dist_cmaes:.0f} km)",
+            f"FMS ({sum(dict_fms['cost']) / 3600:.0f} h, {dist_fms:.0f} km)",
+        ],
+        land=land,
+        gridstep=1 / 12,
+        figsize=(10, 6),
+        xlim=(lon_range[0], lon_range[1]),
+        ylim=(lat_range[0], lat_range[1]),
+        color_currents=True,
+    )
+    ax.set_title(f"USNYC → DEHAM | {args.departure} | {2 * args.vel_ship:.0f} kn")
+    fig.tight_layout()
+
+    outfile = output_dir / "era5_benchmark_usnyc_deham.jpg"
+    fig.savefig(outfile, dpi=300)
+    plt.close()
+    print(f"\n[SAVED] {outfile}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_era5.py
+++ b/tests/test_era5.py
@@ -1,0 +1,329 @@
+"""Tests for the ERA5 data loading and field construction.
+
+These tests create small synthetic NetCDF files that mimic the ERA5 format
+and verify that the loaders produce JAX-compatible field closures with
+correct interpolation behaviour.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import xarray as xr
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: small synthetic ERA5-like NetCDF files
+# ---------------------------------------------------------------------------
+
+
+def _make_wind_nc(path: Path) -> None:
+    """Create a small synthetic ERA5 wind NetCDF file."""
+    # 4 time steps (6-hourly over one day), 5 lats, 6 lons
+    times = np.array(
+        ["2024-01-15T00:00", "2024-01-15T06:00",
+         "2024-01-15T12:00", "2024-01-15T18:00"],
+        dtype="datetime64[ns]",
+    )
+    lats = np.array([30.0, 35.0, 40.0, 45.0, 50.0])
+    lons = np.array([-70.0, -60.0, -50.0, -40.0, -30.0, -20.0])
+
+    # Simple pattern: u10 = lon/10 + t*0.1, v10 = lat/10 + t*0.1 (varies with time)
+    u10 = np.zeros((4, 5, 6), dtype=np.float32)
+    v10 = np.zeros((4, 5, 6), dtype=np.float32)
+    for t in range(4):
+        for i, lat in enumerate(lats):
+            for j, lon in enumerate(lons):
+                u10[t, i, j] = lon / 10.0 + t * 0.1
+                v10[t, i, j] = lat / 10.0 + t * 0.1
+
+    ds = xr.Dataset(
+        {
+            "u10": (["time", "latitude", "longitude"], u10),
+            "v10": (["time", "latitude", "longitude"], v10),
+        },
+        coords={
+            "time": times,
+            "latitude": lats,
+            "longitude": lons,
+        },
+    )
+    ds.to_netcdf(path, engine="scipy")
+
+
+def _make_wave_nc(path: Path) -> None:
+    """Create a small synthetic ERA5 wave NetCDF file."""
+    times = np.array(
+        ["2024-01-15T00:00", "2024-01-15T06:00",
+         "2024-01-15T12:00", "2024-01-15T18:00"],
+        dtype="datetime64[ns]",
+    )
+    lats = np.array([30.0, 35.0, 40.0, 45.0, 50.0])
+    lons = np.array([-70.0, -60.0, -50.0, -40.0, -30.0, -20.0])
+
+    swh = np.ones((4, 5, 6), dtype=np.float32) * 2.0  # 2m everywhere
+    mwd = np.ones((4, 5, 6), dtype=np.float32) * 180.0  # from South
+
+    ds = xr.Dataset(
+        {
+            "swh": (["time", "latitude", "longitude"], swh),
+            "mwd": (["time", "latitude", "longitude"], mwd),
+        },
+        coords={
+            "time": times,
+            "latitude": lats,
+            "longitude": lons,
+        },
+    )
+    ds.to_netcdf(path, engine="scipy")
+
+
+def _make_descending_lat_nc(path: Path) -> None:
+    """Create a wind NetCDF with descending latitudes (ERA5 default order)."""
+    times = np.array(
+        ["2024-01-15T00:00", "2024-01-15T06:00"],
+        dtype="datetime64[ns]",
+    )
+    lats = np.array([50.0, 45.0, 40.0, 35.0, 30.0])  # descending!
+    lons = np.array([-70.0, -60.0, -50.0, -40.0])
+
+    u10 = np.zeros((2, 5, 4), dtype=np.float32)
+    v10 = np.zeros((2, 5, 4), dtype=np.float32)
+    for t in range(2):
+        for i, lat in enumerate(lats):
+            for j, lon in enumerate(lons):
+                u10[t, i, j] = lon / 10.0
+                v10[t, i, j] = lat / 10.0
+
+    ds = xr.Dataset(
+        {
+            "u10": (["time", "latitude", "longitude"], u10),
+            "v10": (["time", "latitude", "longitude"], v10),
+        },
+        coords={
+            "time": times,
+            "latitude": lats,
+            "longitude": lons,
+        },
+    )
+    ds.to_netcdf(path, engine="scipy")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadERA5Windfield:
+    """Tests for load_era5_windfield / load_era5_vectorfield."""
+
+    def test_basic_load_and_shape(self) -> None:
+        """Windfield closure returns arrays of the correct shape."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind.nc"
+            _make_wind_nc(nc_path)
+
+            wf = load_era5_windfield(nc_path)
+
+            # Query at a single point
+            lon = jnp.array([[-50.0]])
+            lat = jnp.array([[40.0]])
+            t = jnp.array([0.0])
+
+            u, v = wf(lon, lat, t)
+            assert u.shape == lon.shape
+            assert v.shape == lon.shape
+
+    def test_time_variant_attribute(self) -> None:
+        """Windfield should be marked as time-variant."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind.nc"
+            _make_wind_nc(nc_path)
+            wf = load_era5_windfield(nc_path)
+            assert hasattr(wf, "is_time_variant")
+            assert wf.is_time_variant is True
+
+    def test_interpolation_values(self) -> None:
+        """Values at grid points should match the synthetic data."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind.nc"
+            _make_wind_nc(nc_path)
+            wf = load_era5_windfield(nc_path)
+
+            # At t=0, grid point (lon=-50, lat=40): u10 = -50/10 = -5.0
+            lon = jnp.array([-50.0])
+            lat = jnp.array([40.0])
+            t = jnp.array([0.0])
+
+            u, v = wf(lon, lat, t)
+            np.testing.assert_allclose(float(u[0]), -5.0, atol=0.1)
+            np.testing.assert_allclose(float(v[0]), 4.0, atol=0.1)
+
+    def test_batch_2d_input(self) -> None:
+        """Windfield handles 2D batched inputs (B, L-1)."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind.nc"
+            _make_wind_nc(nc_path)
+            wf = load_era5_windfield(nc_path)
+
+            # Batch of 3 paths, each with 4 segments
+            lon = jnp.ones((3, 4)) * -50.0
+            lat = jnp.ones((3, 4)) * 40.0
+            t = jnp.array([0.0, 0.0, 0.0])
+
+            u, v = wf(lon, lat, t)
+            assert u.shape == (3, 4)
+            assert v.shape == (3, 4)
+
+    def test_departure_time_offset(self) -> None:
+        """When departure_time is set, t=0 maps to that time."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind.nc"
+            _make_wind_nc(nc_path)
+
+            # Departure at 12:00 (third time step, index 2)
+            wf = load_era5_windfield(
+                nc_path, departure_time="2024-01-15T12:00"
+            )
+
+            lon = jnp.array([-50.0])
+            lat = jnp.array([40.0])
+            t = jnp.array([0.0])  # Should map to 12:00 UTC
+
+            u, v = wf(lon, lat, t)
+            # At t=12h (index 2): u10 = -50/10 + 2*0.1 = -4.8
+            np.testing.assert_allclose(float(u[0]), -4.8, atol=0.15)
+
+    def test_descending_latitude(self) -> None:
+        """Loader handles ERA5 files with descending latitudes."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind_desc.nc"
+            _make_descending_lat_nc(nc_path)
+            wf = load_era5_windfield(nc_path)
+
+            lon = jnp.array([-50.0])
+            lat = jnp.array([40.0])
+            t = jnp.array([0.0])
+
+            u, v = wf(lon, lat, t)
+            np.testing.assert_allclose(float(u[0]), -5.0, atol=0.1)
+            np.testing.assert_allclose(float(v[0]), 4.0, atol=0.1)
+
+    def test_file_not_found(self) -> None:
+        """Raises FileNotFoundError for missing files."""
+        from routetools.era5.loader import load_era5_windfield
+
+        with pytest.raises(FileNotFoundError):
+            load_era5_windfield("/nonexistent/path.nc")
+
+
+class TestLoadERA5Wavefield:
+    """Tests for load_era5_wavefield."""
+
+    def test_basic_load(self) -> None:
+        """Wavefield closure returns correct values."""
+        from routetools.era5.loader import load_era5_wavefield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "waves.nc"
+            _make_wave_nc(nc_path)
+            wf = load_era5_wavefield(nc_path)
+
+            lon = jnp.array([-50.0])
+            lat = jnp.array([40.0])
+            t = jnp.array([0.0])
+
+            hs, mwd = wf(lon, lat, t)
+            np.testing.assert_allclose(float(hs[0]), 2.0, atol=0.1)
+            np.testing.assert_allclose(float(mwd[0]), 180.0, atol=0.1)
+
+    def test_wavefield_not_time_variant(self) -> None:
+        """Wavefield should NOT have is_time_variant=True."""
+        from routetools.era5.loader import load_era5_wavefield
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "waves.nc"
+            _make_wave_nc(nc_path)
+            wf = load_era5_wavefield(nc_path)
+            # wavefield closures don't get the time_variant decorator
+            assert not getattr(wf, "is_time_variant", False)
+
+
+class TestLoadERA5Vectorfield:
+    """Tests for load_era5_vectorfield (alias of windfield)."""
+
+    def test_alias_works(self) -> None:
+        """load_era5_vectorfield returns same result as load_era5_windfield."""
+        from routetools.era5.loader import (
+            load_era5_vectorfield,
+            load_era5_windfield,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nc_path = Path(tmpdir) / "wind.nc"
+            _make_wind_nc(nc_path)
+
+            vf = load_era5_vectorfield(nc_path)
+            wf = load_era5_windfield(nc_path)
+
+            lon = jnp.array([-50.0])
+            lat = jnp.array([40.0])
+            t = jnp.array([0.0])
+
+            u1, v1 = vf(lon, lat, t)
+            u2, v2 = wf(lon, lat, t)
+            np.testing.assert_allclose(u1, u2)
+            np.testing.assert_allclose(v1, v2)
+
+
+class TestDownloadCDS:
+    """Tests for the CDS download module (structure only, no actual API calls)."""
+
+    def test_corridors_defined(self) -> None:
+        """Verify corridor bounding boxes are defined."""
+        from routetools.era5.download_cds import CORRIDORS
+
+        assert "atlantic" in CORRIDORS
+        assert "pacific" in CORRIDORS
+        for name, bbox in CORRIDORS.items():
+            assert len(bbox) == 4, f"Corridor {name} should have 4 bounds"
+
+    def test_variables_defined(self) -> None:
+        """Verify ERA5 variable names are defined."""
+        from routetools.era5.download_cds import WAVE_VARIABLES, WIND_VARIABLES
+
+        assert len(WIND_VARIABLES) == 2
+        assert len(WAVE_VARIABLES) == 2
+
+
+class TestDownloadGCS:
+    """Tests for the GCS download module (structure only, no actual downloads)."""
+
+    def test_corridors_defined(self) -> None:
+        """Verify corridor bounding boxes are defined."""
+        from routetools.era5.download_gcs import CORRIDORS
+
+        assert "atlantic" in CORRIDORS
+        assert "pacific" in CORRIDORS
+
+    def test_gcs_path_exists(self) -> None:
+        """Verify GCS bucket path is configured."""
+        from routetools.era5.download_gcs import GCS_ERA5_SINGLE_LEVEL
+
+        assert "gcp-public-data" in GCS_ERA5_SINGLE_LEVEL

--- a/tests/test_era5.py
+++ b/tests/test_era5.py
@@ -327,3 +327,70 @@ class TestDownloadGCS:
         from routetools.era5.download_gcs import GCS_ERA5_SINGLE_LEVEL
 
         assert "gcp-public-data" in GCS_ERA5_SINGLE_LEVEL
+
+
+class TestLoadERA5LandMask:
+    """Tests for load_era5_land_mask — derives Land from wave NaN patterns."""
+
+    def test_basic_land_mask(self, tmp_path: Path) -> None:
+        """Wave NaN cells become land, valid cells become water."""
+        from routetools.era5.loader import load_era5_land_mask
+
+        # Create a synthetic wave NC with known NaN pattern
+        times = np.array(["2024-01-15T00:00"], dtype="datetime64[ns]")
+        lats = np.array([30.0, 35.0, 40.0, 45.0, 50.0])
+        lons = np.array([-70.0, -60.0, -50.0, -40.0, -30.0, -20.0])
+        swh = np.ones((1, 5, 6), dtype=np.float32) * 2.0
+        mwd = np.ones((1, 5, 6), dtype=np.float32) * 180.0
+
+        # Mark some cells as land (NaN)
+        swh[0, 0, 0] = np.nan   # (lat=30, lon=-70) → land
+        swh[0, 2, 3] = np.nan   # (lat=40, lon=-40) → land
+        mwd[0, 0, 0] = np.nan
+        mwd[0, 2, 3] = np.nan
+
+        ds = xr.Dataset(
+            {
+                "swh": (["time", "latitude", "longitude"], swh),
+                "mwd": (["time", "latitude", "longitude"], mwd),
+            },
+            coords={"time": times, "latitude": lats, "longitude": lons},
+        )
+        nc_path = tmp_path / "wave_land.nc"
+        ds.to_netcdf(nc_path, engine="scipy")
+
+        land = load_era5_land_mask(nc_path)
+
+        # Land object grid should cover the file extent
+        assert land.xmin == -70.0
+        assert land.xmax == -20.0
+        assert land.ymin == 30.0
+        assert land.ymax == 50.0
+
+        # Internal array shape should be (lon, lat) = (6, 5)
+        assert land._array.shape == (6, 5)
+
+        # Check NaN → land (value > 0.5) and valid → water (value < 0.5)
+        arr = np.array(land._array)
+        assert arr[0, 0] > 0.5, "NaN cell should be land"
+        assert arr[3, 2] > 0.5, "NaN cell should be land"
+        assert arr[1, 1] < 0.5, "Valid cell should be water"
+        assert arr[5, 4] < 0.5, "Valid cell should be water"
+
+    def test_missing_variable_raises(self, tmp_path: Path) -> None:
+        """KeyError when no wave-height variable is found."""
+        from routetools.era5.loader import load_era5_land_mask
+
+        times = np.array(["2024-01-15T00:00"], dtype="datetime64[ns]")
+        lats = np.array([30.0, 35.0])
+        lons = np.array([-70.0, -60.0])
+        ds = xr.Dataset(
+            {"temperature": (["time", "latitude", "longitude"],
+                             np.ones((1, 2, 2), dtype=np.float32))},
+            coords={"time": times, "latitude": lats, "longitude": lons},
+        )
+        nc_path = tmp_path / "no_wave.nc"
+        ds.to_netcdf(nc_path, engine="scipy")
+
+        with pytest.raises(KeyError, match="Cannot find wave height"):
+            load_era5_land_mask(nc_path)


### PR DESCRIPTION
## Summary
Add ERA5 data loading and download utilities for real-world weather routing.

### New files
- `routetools/era5/loader.py`: Load ERA5 wind/wave fields, create interpolated vectorfield/wavefield callables
- `routetools/era5/download_cds.py`: Download ERA5 data from CDS API
- `routetools/era5/download_gcs.py`: Download ERA5 data from Google Cloud Storage
- `routetools/era5/__init__.py`: Public API exports
- `tests/test_era5.py`: Comprehensive test suite

### Modified files
- `pyproject.toml`: Add scipy, netCDF4 deps; era5-cds/era5-gcs optionals; update packages list

### Dependencies
None (independent)

---
*Part 1 of 9 — extracted from vangelis branch for clean review*

---
Closes #25