### PR TITLE
feat: time-variant cost function and RISE energy cost

### DIFF
--- a/routetools/cost.py
+++ b/routetools/cost.py
@@ -9,9 +9,19 @@ from jax import jit, lax
 from routetools._cost.haversine import (
     haversine_distance_from_curve as haversine_distance_from_curve,
 )
-from routetools._cost.haversine import haversine_meters_components
+from routetools._cost.haversine import EARTH_RADIUS, haversine_meters_components
 from routetools._cost.waves import wave_adjusted_speed
 from routetools.land import Land, move_curve_away_from_land
+from routetools.performance import (
+    A_W,
+    K_A,
+    K_H,
+    K_S,
+    K_W,
+    SAIL_DEAD_ZONE_DEG,
+    SAIL_QUADRATIC_CORRECTION,
+    predict_power_jax,
+)
 
 
 def angle_wrt_true_north(dx: jnp.ndarray, dy: jnp.ndarray) -> jnp.ndarray:
@@ -60,6 +70,7 @@ def cost_function(
     weight_l1: float = 1.0,
     weight_l2: float = 0.0,
     spherical_correction: bool = False,
+    time_offset: float = 0.0,
 ) -> jnp.ndarray:
     """
     Compute the cost of a batch of paths navigating over a vector field.
@@ -113,9 +124,13 @@ def cost_function(
             spherical_correction=spherical_correction,
         )
     elif (travel_time is not None) and is_time_variant:
-        # Not supported
-        raise NotImplementedError(
-            "Time-variant cost function with fixed travel time is not implemented."
+        cost = cost_function_constant_cost_time_variant(
+            vectorfield,
+            curve,
+            travel_time,
+            wavefield=wavefield,
+            spherical_correction=spherical_correction,
+            time_offset=time_offset,
         )
     elif (travel_time is not None) and (not is_time_variant):
         cost = cost_function_constant_cost_time_invariant(
@@ -372,6 +387,202 @@ def cost_function_constant_cost_time_invariant(
     # We must navigate the path in a fixed time
     cost = ((dxdt - uinterp) ** 2 + (dydt - vinterp) ** 2) / 2
     return cost * dt
+
+
+@partial(
+    jit,
+    static_argnames=("vectorfield", "travel_time", "wavefield", "spherical_correction"),
+)
+def cost_function_constant_cost_time_variant(
+    vectorfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ],
+    curve: jnp.ndarray,
+    travel_time: float,
+    wavefield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
+    spherical_correction: bool = False,
+    time_offset: float = 0.0,
+) -> jnp.ndarray:
+    """Compute energy cost for fixed-time routes with time-variant vector fields.
+
+    Each segment takes ``dt = travel_time / (L-1)``.  The vector field is
+    sampled at the midpoint of each segment at its corresponding timestamp,
+    shifted by *time_offset*.
+
+    Parameters
+    ----------
+    vectorfield : Callable
+        ``(lon, lat, t) -> (u, v)`` with ``t`` in the same units as
+        *travel_time* (typically hours for ERA5).
+    curve : jnp.ndarray
+        Batch of trajectories, shape ``(B, L, 2)``.
+    travel_time : float
+        Fixed total passage time.
+    wavefield : Callable, optional
+        ``(lon, lat, t) -> (height, direction)``.
+    spherical_correction : bool
+        Whether to compute distances on the sphere.
+    time_offset : float
+        Offset added to segment timestamps before querying the field.
+        For ERA5 this is the departure's offset in hours from the
+        dataset epoch (2024-01-01T00:00).  Not a ``static_argname``
+        so changing it does not trigger JIT recompilation.
+
+    Returns
+    -------
+    jnp.ndarray
+        Cost per segment, shape ``(B, L-1)``.
+    """
+    n_seg = curve.shape[1] - 1
+    dt = travel_time / n_seg
+
+    # Segment midpoints (position)
+    curvex = (curve[:, :-1, 0] + curve[:, 1:, 0]) / 2
+    curvey = (curve[:, :-1, 1] + curve[:, 1:, 1]) / 2
+
+    # Segment midpoints (time), shifted by departure offset.
+    seg_times = time_offset + (jnp.arange(n_seg) + 0.5) * dt  # shape (n_seg,)
+    # Broadcast to batch: shape (B, n_seg)
+    curvet = jnp.broadcast_to(seg_times[None, :], curvex.shape)
+
+    uinterp, vinterp = vectorfield(curvex, curvey, curvet)
+
+    # Distances between waypoints
+    if spherical_correction:
+        dx, dy = haversine_meters_components(
+            curve[:, :-1, 1],
+            curve[:, :-1, 0],
+            curve[:, 1:, 1],
+            curve[:, 1:, 0],
+        )
+    else:
+        dx = jnp.diff(curve[:, :, 0], axis=1)
+        dy = jnp.diff(curve[:, :, 1], axis=1)
+
+    # SOG = displacement / dt  (convert dt from hours to seconds so
+    # that SOG is in m/s, matching the wind field units).
+    dt_s = dt * 3600.0
+    dxdt = dx / dt_s
+    dydt = dy / dt_s
+
+    # STW cost = ‖SOG - current‖² / 2 · dt_s
+    cost = ((dxdt - uinterp) ** 2 + (dydt - vinterp) ** 2) / 2
+    return cost * dt_s
+
+
+# ---------------------------------------------------------------------------
+# RISE performance-model cost (for SWOPP3)
+# ---------------------------------------------------------------------------
+@partial(
+    jit,
+    static_argnames=(
+        "windfield",
+        "wavefield",
+        "travel_time",
+        "wps",
+    ),
+)
+def cost_function_rise(
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ],
+    curve: jnp.ndarray,
+    travel_time: float,
+    wavefield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
+    wps: bool = False,
+    time_offset: float = 0.0,
+) -> jnp.ndarray:
+    """Compute SWOPP3 energy consumption for a batch of fixed-time routes.
+
+    Uses the closed-form RISE performance model (hull drag, aerodynamic
+    drag, wave added resistance, wingsail thrust) evaluated entirely in
+    JAX so that the function is JIT-compilable and could support
+    gradient-based optimisation in the future.
+
+    Each segment takes ``dt = travel_time / (L-1)``.  Wind and waves are
+    sampled at each segment midpoint at its corresponding timestamp.
+
+    Parameters
+    ----------
+    windfield : Callable
+        ``(lon, lat, t) -> (u10, v10)`` where ``u10, v10`` are wind
+        components in m/s.  ``t`` is in the same unit as *travel_time*
+        (hours for ERA5).
+    curve : jnp.ndarray
+        Batch of trajectories, shape ``(B, L, 2)`` with ``(lon, lat)``
+        in degrees.
+    travel_time : float
+        Fixed total passage time (hours).
+    wavefield : Callable, optional
+        ``(lon, lat, t) -> (hs, mwd)`` where ``hs`` is significant wave
+        height in metres and ``mwd`` is mean wave direction (degrees
+        from North).
+    wps : bool
+        Whether wingsails are deployed.
+    time_offset : float
+        Departure offset in hours from the field's time origin.
+
+    Returns
+    -------
+    jnp.ndarray
+        Total energy in MWh per route, shape ``(B,)``.
+    """
+    n_seg = curve.shape[1] - 1
+    dt_h = travel_time / n_seg  # hours per segment
+
+    # ---- segment midpoints (position) ----
+    mid_lon = (curve[:, :-1, 0] + curve[:, 1:, 0]) / 2  # (B, n_seg)
+    mid_lat = (curve[:, :-1, 1] + curve[:, 1:, 1]) / 2
+
+    # ---- segment midpoints (time) ----
+    seg_times = time_offset + (jnp.arange(n_seg) + 0.5) * dt_h  # (n_seg,)
+    curvet = jnp.broadcast_to(seg_times[None, :], mid_lon.shape)  # (B, n_seg)
+
+    # ---- segment bearings (Mercator approximation, all in JAX) ----
+    dlon = jnp.diff(curve[:, :, 0], axis=1)  # (B, n_seg)
+    dlat = jnp.diff(curve[:, :, 1], axis=1)
+    lat_mid_rad = jnp.radians(mid_lat)
+    dx_bear = dlon * jnp.cos(lat_mid_rad)  # eastward
+    dy_bear = dlat  # northward
+    bearing_deg = jnp.mod(jnp.degrees(jnp.arctan2(dx_bear, dy_bear)), 360.0)
+
+    # ---- segment distances (haversine, metres) & ship speed ----
+    dx_m, dy_m = haversine_meters_components(
+        curve[:, :-1, 1], curve[:, :-1, 0],
+        curve[:, 1:, 1], curve[:, 1:, 0],
+    )
+    seg_dist_m = jnp.sqrt(dx_m**2 + dy_m**2)  # (B, n_seg)
+    dt_s = dt_h * 3600.0
+    v_mps = seg_dist_m / dt_s  # ship speed m/s per segment
+
+    # ---- wind ----
+    u10, v10 = windfield(mid_lon, mid_lat, curvet)
+    tws = jnp.sqrt(u10**2 + v10**2)
+    # Wind FROM direction (meteorological convention)
+    wind_from_deg = jnp.mod(180.0 + jnp.degrees(jnp.arctan2(u10, v10)), 360.0)
+    twa = jnp.mod(wind_from_deg - bearing_deg, 360.0)
+
+    # ---- waves ----
+    if wavefield is not None:
+        hs, mwd = wavefield(mid_lon, mid_lat, curvet)
+        mwa = jnp.mod(mwd - bearing_deg, 360.0)
+    else:
+        hs = jnp.zeros_like(mid_lon)
+        mwa = jnp.zeros_like(mid_lon)
+
+    # ---- RISE power model (kW) ----
+    power_kw = predict_power_jax(tws, twa, hs, mwa, v_mps, wps=wps)
+
+    # ---- integrate: energy = Σ P_kW · Δt_h → kWh, then /1000 → MWh ----
+    energy_mwh = jnp.sum(power_kw, axis=1) * dt_h / 1000.0
+
+    return energy_mwh
 
 
 def interpolate_to_constant_cost(

--- a/routetools/cost.py
+++ b/routetools/cost.py
@@ -9,19 +9,14 @@ from jax import jit, lax
 from routetools._cost.haversine import (
     haversine_distance_from_curve as haversine_distance_from_curve,
 )
-from routetools._cost.haversine import EARTH_RADIUS, haversine_meters_components
+from routetools._cost.haversine import haversine_meters_components
 from routetools._cost.waves import wave_adjusted_speed
 from routetools.land import Land, move_curve_away_from_land
-from routetools.performance import (
-    A_W,
-    K_A,
-    K_H,
-    K_S,
-    K_W,
-    SAIL_DEAD_ZONE_DEG,
-    SAIL_QUADRATIC_CORRECTION,
-    predict_power_jax,
-)
+
+try:
+    from routetools.performance import predict_power_jax
+except ModuleNotFoundError:
+    predict_power_jax = None
 
 
 def angle_wrt_true_north(dx: jnp.ndarray, dy: jnp.ndarray) -> jnp.ndarray:
@@ -86,19 +81,24 @@ def cost_function(
         vector field.
     curve : jnp.ndarray
         A batch of trajectories (an array of shape B x L x 2).
-        Coordinates are (lon, lat) or (x, y).
+        Coordinates are ordered as ``(lon, lat)`` for geographic fields, or
+        ``(x, y)`` for projected planar fields.
     travel_stw : float, optional
         The boat will have this fixed speed through water (STW). If applying the
         spherical correction, this speed is in meters per second.
     travel_time : float, optional
-        The boat can regulate its STW but must complete the path in exactly this time.
-        If applying the spherical correction, this time is in seconds.
+        The boat can regulate its STW but must complete the path in exactly this
+        time. Units must match the vector field time axis (for ERA5, hours).
     weight_l1 : float, optional
         Weight for the L1 norm in the combined cost. Default is 1.0.
     weight_l2 : float, optional
         Weight for the L2 norm in the combined cost. Default is 0.0.
     spherical_correction : bool, optional
-        Whether to apply spherical correction to distances. Default is False.
+        Whether to apply spherical correction to distances. If False, coordinates
+        are expected to already be in projected metric units.
+    time_offset : float, optional
+        Offset added to segment timestamps before querying time-variant fields.
+        Units must match ``travel_time`` (for ERA5, hours).
 
     Returns
     -------
@@ -391,10 +391,7 @@ def cost_function_constant_cost_time_invariant(
 
 @partial(
     jit,
-    # NOTE: travel_time is static to allow constant-folding of dt inside the
-    # traced computation.  This means a new compilation per distinct value.
-    # In routing loops travel_time is typically fixed, so this is acceptable.
-    static_argnames=("vectorfield", "travel_time", "wavefield", "spherical_correction"),
+    static_argnames=("vectorfield", "wavefield", "spherical_correction"),
 )
 def cost_function_constant_cost_time_variant(
     vectorfield: Callable[
@@ -418,26 +415,31 @@ def cost_function_constant_cost_time_variant(
     Parameters
     ----------
     vectorfield : Callable
-        ``(lon, lat, t) -> (u, v)`` with ``t`` in the same units as
+        ``(lon, lat, t) -> (u, v)`` where ``lon, lat`` are in degrees,
+        ``u, v`` are in m/s, and ``t`` is in the same units as
         *travel_time* (typically hours for ERA5).
     curve : jnp.ndarray
-        Batch of trajectories, shape ``(B, L, 2)``.
+        Batch of trajectories, shape ``(B, L, 2)``. Coordinates are
+        ``(lon, lat)`` when ``spherical_correction=True`` and projected
+        ``(x, y)`` in metres when ``spherical_correction=False``.
     travel_time : float
-        Fixed total passage time.
+        Fixed total passage time (hours for ERA5).
     wavefield : Callable, optional
-        ``(lon, lat, t) -> (height, direction)``.
+        ``(lon, lat, t) -> (height, direction)``. Currently unused in this
+        function and kept for API symmetry.
     spherical_correction : bool
-        Whether to compute distances on the sphere.
+        Whether to compute distances on the sphere. If False, ``curve``
+        coordinates must already be in metres.
     time_offset : float
-        Offset added to segment timestamps before querying the field.
+        Offset added to segment timestamps before querying the field (hours).
         For ERA5 this is the departure's offset in hours from the
-        dataset epoch (2024-01-01T00:00).  Not a ``static_argname``
-        so changing it does not trigger JIT recompilation.
+        dataset epoch (2024-01-01T00:00).
 
     Returns
     -------
     jnp.ndarray
-        Cost per segment, shape ``(B, L-1)``.
+        Cost per segment, shape ``(B, L-1)``. With SI inputs this has
+        units of m^2/s.
     """
     n_seg = curve.shape[1] - 1
     dt = travel_time / n_seg
@@ -526,7 +528,7 @@ def cost_function_rise(
         (hours for ERA5).
     curve : jnp.ndarray
         Batch of trajectories, shape ``(B, L, 2)`` with ``(lon, lat)``
-        in degrees.
+        in degrees. Coordinate order must match the wind/wave fields.
     travel_time : float
         Fixed total passage time (hours).
     wavefield : Callable, optional
@@ -543,6 +545,11 @@ def cost_function_rise(
     jnp.ndarray
         Total energy in MWh per route, shape ``(B,)``.
     """
+    if predict_power_jax is None:
+        raise ModuleNotFoundError(
+            "routetools.performance is required for cost_function_rise."
+        )
+
     n_seg = curve.shape[1] - 1
     dt_h = travel_time / n_seg  # hours per segment
 
@@ -554,23 +561,25 @@ def cost_function_rise(
     seg_times = time_offset + (jnp.arange(n_seg) + 0.5) * dt_h  # (n_seg,)
     curvet = jnp.broadcast_to(seg_times[None, :], mid_lon.shape)  # (B, n_seg)
 
-    # ---- segment bearings (Mercator approximation, all in JAX) ----
-    # NOTE: bearings use a cheap Mercator projection while segment
-    # distances below use haversine.  For the short segments typical
-    # of SWOPP3 routes (< 100 nm, mid-latitudes) the bearing error is
-    # negligible (< 0.1°).  A full great-circle bearing would be more
-    # accurate at high latitudes or for very long segments.
-    dlon = jnp.diff(curve[:, :, 0], axis=1)  # (B, n_seg)
-    dlat = jnp.diff(curve[:, :, 1], axis=1)
-    lat_mid_rad = jnp.radians(mid_lat)
-    dx_bear = dlon * jnp.cos(lat_mid_rad)  # eastward
-    dy_bear = dlat  # northward
-    bearing_deg = jnp.mod(jnp.degrees(jnp.arctan2(dx_bear, dy_bear)), 360.0)
+    # ---- segment bearings (great-circle, all in JAX) ----
+    lon1_rad = jnp.radians(curve[:, :-1, 0])
+    lon2_rad = jnp.radians(curve[:, 1:, 0])
+    lat1_rad = jnp.radians(curve[:, :-1, 1])
+    lat2_rad = jnp.radians(curve[:, 1:, 1])
+    dlon_rad = lon2_rad - lon1_rad
+    x = jnp.sin(dlon_rad) * jnp.cos(lat2_rad)
+    y = jnp.cos(lat1_rad) * jnp.sin(lat2_rad) - jnp.sin(lat1_rad) * jnp.cos(
+        lat2_rad
+    ) * jnp.cos(dlon_rad)
+    bearing_rad = jnp.arctan2(x, y)
+    bearing_deg = jnp.mod(jnp.degrees(bearing_rad), 360.0)
 
     # ---- segment distances (haversine, metres) & ship speed ----
     dx_m, dy_m = haversine_meters_components(
-        curve[:, :-1, 1], curve[:, :-1, 0],
-        curve[:, 1:, 1], curve[:, 1:, 0],
+        curve[:, :-1, 1],
+        curve[:, :-1, 0],
+        curve[:, 1:, 1],
+        curve[:, 1:, 0],
     )
     seg_dist_m = jnp.sqrt(dx_m**2 + dy_m**2)  # (B, n_seg)
     dt_s = dt_h * 3600.0

--- a/routetools/cost.py
+++ b/routetools/cost.py
@@ -391,6 +391,9 @@ def cost_function_constant_cost_time_invariant(
 
 @partial(
     jit,
+    # NOTE: travel_time is static to allow constant-folding of dt inside the
+    # traced computation.  This means a new compilation per distinct value.
+    # In routing loops travel_time is typically fixed, so this is acceptable.
     static_argnames=("vectorfield", "travel_time", "wavefield", "spherical_correction"),
 )
 def cost_function_constant_cost_time_variant(
@@ -450,6 +453,10 @@ def cost_function_constant_cost_time_variant(
 
     uinterp, vinterp = vectorfield(curvex, curvey, curvet)
 
+    # TODO: wavefield is accepted for API symmetry with cost_function_rise
+    # but is not yet used in this function.  Wire it into an added-resistance
+    # term once the STW cost model supports wave effects.
+
     # Distances between waypoints
     if spherical_correction:
         dx, dy = haversine_meters_components(
@@ -459,6 +466,9 @@ def cost_function_constant_cost_time_variant(
             curve[:, 1:, 0],
         )
     else:
+        # NOTE: when spherical_correction is False the curve coordinates
+        # must already be in metres (projected x/y).  Raw lon/lat degrees
+        # will produce dimensionally incorrect costs.
         dx = jnp.diff(curve[:, :, 0], axis=1)
         dy = jnp.diff(curve[:, :, 1], axis=1)
 
@@ -545,6 +555,11 @@ def cost_function_rise(
     curvet = jnp.broadcast_to(seg_times[None, :], mid_lon.shape)  # (B, n_seg)
 
     # ---- segment bearings (Mercator approximation, all in JAX) ----
+    # NOTE: bearings use a cheap Mercator projection while segment
+    # distances below use haversine.  For the short segments typical
+    # of SWOPP3 routes (< 100 nm, mid-latitudes) the bearing error is
+    # negligible (< 0.1°).  A full great-circle bearing would be more
+    # accurate at high latitudes or for very long segments.
     dlon = jnp.diff(curve[:, :, 0], axis=1)  # (B, n_seg)
     dlat = jnp.diff(curve[:, :, 1], axis=1)
     lat_mid_rad = jnp.radians(mid_lat)

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,6 +1,7 @@
 import jax.numpy as jnp
 import numpy as np
 
+import routetools.cost as cost_module
 from routetools.cost import interpolate_to_constant_cost
 from routetools.vectorfield import vectorfield_zero
 
@@ -37,3 +38,48 @@ def test_interpolate_to_constant_cost():
     assert jnp.allclose(
         distances, avg_distance, atol=1e-2
     ), f"distances: {distances}, avg_distance: {avg_distance}"
+
+
+def _field_zero(
+    lon: jnp.ndarray,
+    lat: jnp.ndarray,
+    t: jnp.ndarray,
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    del lat, t
+    return jnp.zeros_like(lon), jnp.zeros_like(lon)
+
+
+def test_cost_function_rise_returns_energy_in_mwh(monkeypatch):
+    """A constant 500 kW profile over 10 h and 2 segments yields 5 MWh."""
+
+    def _predict_power_constant(
+        tws: jnp.ndarray,
+        twa: jnp.ndarray,
+        hs: jnp.ndarray,
+        mwa: jnp.ndarray,
+        v_mps: jnp.ndarray,
+        wps: bool = False,
+    ) -> jnp.ndarray:
+        del twa, hs, mwa, v_mps, wps
+        return jnp.full_like(tws, 500.0)
+
+    monkeypatch.setattr(cost_module, "predict_power_jax", _predict_power_constant)
+
+    curve = jnp.array(
+        [
+            [
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [2.0, 0.0],
+            ]
+        ]
+    )
+
+    energy_mwh = cost_module.cost_function_rise(
+        windfield=_field_zero,
+        curve=curve,
+        travel_time=10.0,
+        wavefield=_field_zero,
+    )
+
+    assert jnp.allclose(energy_mwh, jnp.array([5.0]), atol=1e-6)


### PR DESCRIPTION
## Summary
Extend `cost.py` with two new cost functions for real-world weather routing.

### Changes to `routetools/cost.py`
- `cost_function_constant_cost_time_variant()`: Energy cost for fixed-time routes with time-variant vector fields (ERA5). Supports `time_offset` for departure-relative timestamps.
- `cost_function_rise()`: SWOPP3 energy consumption using the RISE parametric model. Returns total energy in MWh.
- Add `time_offset` parameter to the main `cost_function()` dispatcher.
- Import `EARTH_RADIUS` and performance model constants.

### Dependencies
- #42 (feat/performance-model) — for `predict_power_jax` imports

---
*Part 5 of 9 — extracted from vangelis branch for clean review*

---
Relates to #23