### PR TITLE
feat: CMA-ES optimizer enhancements

### DIFF
--- a/routetools/cmaes.py
+++ b/routetools/cmaes.py
@@ -374,10 +374,10 @@ def _cma_evolution_strategy(
                 curve_check = curve
             land_count = land.penalization(curve_check, penalty=1)
             has_land = land_count > 0
-            # Death penalty: land-crossing candidates get cost=1e10,
+            # Death penalty: land-crossing candidates get cost=penalty,
             # plus land_count as gradient signal so CMA-ES moves
             # toward fewer land points.
-            cost = jnp.where(has_land, 1e10 + land_count, cost)
+            cost = jnp.where(has_land, penalty + land_count, cost)
 
         # Weather constraint penalization
         if weather_penalty_weight > 0 and (windfield is not None or wavefield is not None):
@@ -484,7 +484,8 @@ def optimize(
         A function that returns the height and direction of the wave field,
         by default None
     penalty : float, optional
-        Penalty for land points, by default 10
+        Large penalty applied to routes that intersect land (death-penalty
+        scheme), by default 1e10
     weather_penalty_weight : float, optional
         Penalty weight for weather constraint violations (TWS, Hs).
         Set to 0 (default) to disable weather penalties.
@@ -643,6 +644,7 @@ def optimize(
                 weight_l1=weight_l1,
                 weight_l2=weight_l2,
                 spherical_correction=spherical_correction,
+                time_offset=time_offset,
             ).item()
         if land is not None and penalty > 0:
             c0_batch = curve0[jnp.newaxis, :, :]
@@ -652,7 +654,7 @@ def optimize(
                 c0_check = c0_batch
             land_count = land.penalization(c0_check, penalty=1).item()
             if land_count > 0:
-                cost_initial = 1e10 + land_count
+                cost_initial = penalty + land_count
         if weather_penalty_weight > 0 and (
             windfield is not None or wavefield is not None
         ):
@@ -857,7 +859,7 @@ def optimize_with_increasing_penalization(
             curve_check = curve[land_margin:-land_margin, :]
         else:
             curve_check = curve
-        if land(curve_check).any():
+        if land is not None and land(curve_check).any():
             penalty += penalty_increment
             x0 = es.best.x
         else:

--- a/routetools/cmaes.py
+++ b/routetools/cmaes.py
@@ -16,6 +16,7 @@ from jax import jit
 from routetools.cost import cost_function
 from routetools.land import Land
 from routetools.vectorfield import vectorfield_fourvortices
+from routetools.weather import weather_penalty as _weather_penalty
 
 
 @jit  # type: ignore[misc]
@@ -282,7 +283,14 @@ def _cma_evolution_strategy(
         [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
     ]
     | None = None,
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
     penalty: float = 1e10,
+    weather_penalty_weight: float = 0.0,
+    tws_limit: float = 20.0,
+    hs_limit: float = 7.0,
     travel_stw: float | None = None,
     travel_time: float | None = None,
     L: int = 64,
@@ -298,6 +306,9 @@ def _cma_evolution_strategy(
     weight_l2: float = 0.0,
     keep_top: float = 0.0,
     spherical_correction: bool = False,
+    time_offset: float = 0.0,
+    cost_fn: Callable[[jnp.ndarray], jnp.ndarray] | None = None,
+    land_margin: int = 0,
     verbose: bool = True,
     **kwargs: dict[str, Any],
 ) -> cma.CMAEvolutionStrategy:
@@ -339,20 +350,45 @@ def _cma_evolution_strategy(
             force_L_multiple_of_num_pieces=force_L_multiple_of_num_pieces,
         )
 
-        cost: jnp.ndarray = cost_function(
-            vectorfield=vectorfield,
-            curve=curve,
-            wavefield=wavefield,
-            travel_stw=travel_stw,
-            travel_time=travel_time,
-            weight_l1=weight_l1,
-            weight_l2=weight_l2,
-            spherical_correction=spherical_correction,
-        )
+        if cost_fn is not None:
+            cost = cost_fn(curve)
+        else:
+            cost = cost_function(
+                vectorfield=vectorfield,
+                curve=curve,
+                wavefield=wavefield,
+                travel_stw=travel_stw,
+                travel_time=travel_time,
+                weight_l1=weight_l1,
+                weight_l2=weight_l2,
+                spherical_correction=spherical_correction,
+                time_offset=time_offset,
+            )
 
         # Land penalization
         if land is not None and penalty > 0:
-            cost += land.penalization(curve, penalty=penalty)
+            # Skip the first/last `land_margin` waypoints (ports on coast)
+            if land_margin > 0 and curve.shape[1] > 2 * land_margin:
+                curve_check = curve[:, land_margin:-land_margin, :]
+            else:
+                curve_check = curve
+            land_count = land.penalization(curve_check, penalty=1)
+            has_land = land_count > 0
+            # Death penalty: land-crossing candidates get cost=1e10,
+            # plus land_count as gradient signal so CMA-ES moves
+            # toward fewer land points.
+            cost = jnp.where(has_land, 1e10 + land_count, cost)
+
+        # Weather constraint penalization
+        if weather_penalty_weight > 0 and (windfield is not None or wavefield is not None):
+            cost += _weather_penalty(
+                curve,
+                windfield=windfield,
+                wavefield=wavefield,
+                tws_limit=tws_limit,
+                hs_limit=hs_limit,
+                penalty=weather_penalty_weight,
+            )
 
         # Replace the worst solutions with the best found so far
         if keep_top > 0 and es.countiter > 1:
@@ -392,7 +428,14 @@ def optimize(
         [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
     ]
     | None = None,
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
     penalty: float = 1e10,
+    weather_penalty_weight: float = 0.0,
+    tws_limit: float = 20.0,
+    hs_limit: float = 7.0,
     travel_stw: float | None = None,
     travel_time: float | None = None,
     K: int = 6,
@@ -409,6 +452,9 @@ def optimize(
     keep_top: float = 0.0,
     spherical_correction: bool = False,
     seed: float = jnp.nan,
+    time_offset: float = 0.0,
+    cost_fn: Callable[[jnp.ndarray], jnp.ndarray] | None = None,
+    land_margin: int = 0,
     verbose: bool = True,
 ) -> tuple[jnp.ndarray, dict[str, Any]]:
     """
@@ -439,6 +485,13 @@ def optimize(
         by default None
     penalty : float, optional
         Penalty for land points, by default 10
+    weather_penalty_weight : float, optional
+        Penalty weight for weather constraint violations (TWS, Hs).
+        Set to 0 (default) to disable weather penalties.
+    tws_limit : float, optional
+        Maximum allowed true wind speed in m/s, by default 20.0
+    hs_limit : float, optional
+        Maximum allowed significant wave height in m, by default 7.0
     travel_stw : float, optional
         The boat will have this fixed speed through water (STW).
         If set, then `travel_time` must be None. By default None
@@ -504,24 +557,25 @@ def optimize(
         # Initial solution from provided curve
         x0 = curve_to_control(curve0, K=K, num_pieces=num_pieces)
         # Validate that, after conversion, it still does not cross land
-        curve_check = control_to_curve(
-            x0,
-            src,
-            dst,
-            L=L,
-            num_pieces=num_pieces,
-            force_L_multiple_of_num_pieces=force_L_multiple_of_num_pieces,
-        )
-        is_land = land(curve_check)
-        if land is not None and is_land.any():
-            ls_idx = jnp.where(is_land)[0].tolist()
-            warnings.warn(
-                "[WARNING] The provided initial curve0 crosses land "
-                "after conversion to control points. "
-                f"Indices on land (out of {is_land.size}): {ls_idx}",
-                category=UserWarning,
-                stacklevel=2,
+        if land is not None:
+            curve_check = control_to_curve(
+                x0,
+                src,
+                dst,
+                L=L,
+                num_pieces=num_pieces,
+                force_L_multiple_of_num_pieces=force_L_multiple_of_num_pieces,
             )
+            is_land = land(curve_check)
+            if is_land.any():
+                ls_idx = jnp.where(is_land)[0].tolist()
+                warnings.warn(
+                    "[WARNING] The provided initial curve0 crosses land "
+                    "after conversion to control points. "
+                    f"Indices on land (out of {is_land.size}): {ls_idx}",
+                    category=UserWarning,
+                    stacklevel=2,
+                )
 
     # Initial standard deviation to sample new solutions
     # One sigma is half the distance between src and dst
@@ -535,7 +589,11 @@ def optimize(
         x0=x0,
         land=land,
         wavefield=wavefield,
+        windfield=windfield,
         penalty=penalty,
+        weather_penalty_weight=weather_penalty_weight,
+        tws_limit=tws_limit,
+        hs_limit=hs_limit,
         travel_stw=travel_stw,
         travel_time=travel_time,
         L=L,
@@ -551,6 +609,9 @@ def optimize(
         seed=seed,
         keep_top=keep_top,
         spherical_correction=spherical_correction,
+        time_offset=time_offset,
+        cost_fn=cost_fn,
+        land_margin=land_margin,
         verbose=verbose,
     )
     time_end = time.time()
@@ -570,19 +631,38 @@ def optimize(
 
     # Compare the best curve with the initial one if provided
     if curve0 is not None:
-        cost_initial: float = cost_function(
-            vectorfield=vectorfield,
-            curve=curve0[jnp.newaxis, :, :],
-            wavefield=wavefield,
-            travel_stw=travel_stw,
-            travel_time=travel_time,
-            weight_l1=weight_l1,
-            weight_l2=weight_l2,
-            spherical_correction=spherical_correction,
-        ).item()
+        if cost_fn is not None:
+            cost_initial: float = cost_fn(curve0[jnp.newaxis, :, :]).item()
+        else:
+            cost_initial: float = cost_function(
+                vectorfield=vectorfield,
+                curve=curve0[jnp.newaxis, :, :],
+                wavefield=wavefield,
+                travel_stw=travel_stw,
+                travel_time=travel_time,
+                weight_l1=weight_l1,
+                weight_l2=weight_l2,
+                spherical_correction=spherical_correction,
+            ).item()
         if land is not None and penalty > 0:
-            cost_initial += land.penalization(
-                curve0[jnp.newaxis, :, :], penalty=penalty
+            c0_batch = curve0[jnp.newaxis, :, :]
+            if land_margin > 0 and c0_batch.shape[1] > 2 * land_margin:
+                c0_check = c0_batch[:, land_margin:-land_margin, :]
+            else:
+                c0_check = c0_batch
+            land_count = land.penalization(c0_check, penalty=1).item()
+            if land_count > 0:
+                cost_initial = 1e10 + land_count
+        if weather_penalty_weight > 0 and (
+            windfield is not None or wavefield is not None
+        ):
+            cost_initial += _weather_penalty(
+                curve0[jnp.newaxis, :, :],
+                windfield=windfield,
+                wavefield=wavefield,
+                tws_limit=tws_limit,
+                hs_limit=hs_limit,
+                penalty=weather_penalty_weight,
             ).item()
         if cost_initial < cost_best:
             warnings.warn(
@@ -615,9 +695,16 @@ def optimize_with_increasing_penalization(
         [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
     ]
     | None = None,
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
     penalty_init: float = 0,
     penalty_increment: float = 10,
     maxiter: int = 10,
+    weather_penalty_weight: float = 0.0,
+    tws_limit: float = 20.0,
+    hs_limit: float = 7.0,
     travel_stw: float | None = None,
     travel_time: float | None = None,
     K: int = 6,
@@ -633,6 +720,9 @@ def optimize_with_increasing_penalization(
     weight_l2: float = 0.0,
     spherical_correction: bool = False,
     seed: float = jnp.nan,
+    time_offset: float = 0.0,
+    cost_fn: Callable[[jnp.ndarray], jnp.ndarray] | None = None,
+    land_margin: int = 0,
     verbose: bool = True,
 ) -> tuple[list[jnp.ndarray], list[float]]:
     """
@@ -664,6 +754,13 @@ def optimize_with_increasing_penalization(
         Increment in the penalty for land points. By default 10
     maxiter : int, optional
         Maximum number of iterations. By default 10
+    weather_penalty_weight : float, optional
+        Penalty weight for weather constraint violations (TWS, Hs).
+        Set to 0 (default) to disable weather penalties.
+    tws_limit : float, optional
+        Maximum allowed true wind speed in m/s, by default 20.0
+    hs_limit : float, optional
+        Maximum allowed significant wave height in m, by default 7.0
     travel_stw : float, optional
         The boat will have this fixed speed through water (STW).
         If set, then `travel_time` must be None. By default None
@@ -720,7 +817,11 @@ def optimize_with_increasing_penalization(
             x0=x0,
             land=land,
             wavefield=wavefield,
+            windfield=windfield,
             penalty=penalty,
+            weather_penalty_weight=weather_penalty_weight,
+            tws_limit=tws_limit,
+            hs_limit=hs_limit,
             travel_stw=travel_stw,
             travel_time=travel_time,
             L=L,
@@ -734,6 +835,9 @@ def optimize_with_increasing_penalization(
             weight_l2=weight_l2,
             spherical_correction=spherical_correction,
             seed=seed,
+            time_offset=time_offset,
+            cost_fn=cost_fn,
+            land_margin=land_margin,
             verbose=verbose,
         )
         if verbose:
@@ -749,7 +853,11 @@ def optimize_with_increasing_penalization(
             force_L_multiple_of_num_pieces=force_L_multiple_of_num_pieces,
         )
         # sigma0 = es.sigma0
-        if land(curve).any():
+        if land_margin > 0 and curve.shape[0] > 2 * land_margin:
+            curve_check = curve[land_margin:-land_margin, :]
+        else:
+            curve_check = curve
+        if land(curve_check).any():
             penalty += penalty_increment
             x0 = es.best.x
         else:

--- a/routetools/cmaes.py
+++ b/routetools/cmaes.py
@@ -380,7 +380,9 @@ def _cma_evolution_strategy(
             cost = jnp.where(has_land, penalty + land_count, cost)
 
         # Weather constraint penalization
-        if weather_penalty_weight > 0 and (windfield is not None or wavefield is not None):
+        if weather_penalty_weight > 0 and (
+            windfield is not None or wavefield is not None
+        ):
             cost += _weather_penalty(
                 curve,
                 windfield=windfield,


### PR DESCRIPTION
## Summary
Major updates to the CMA-ES optimizer for real-world weather routing.

### Changes to `routetools/cmaes.py`
- **`cost_fn` callback**: Allow custom cost functions (e.g., RISE energy model) instead of the built-in `cost_function`
- **`time_offset`**: Thread departure time offset through to cost functions for time-variant ERA5 fields
- **Death penalty**: Replace additive land penalty with death penalty (`cost=1e10 + land_count`) for land-crossing routes
- **`land_margin`**: Skip first/last N waypoints from land checks (ports are on the coast)
- **Weather penalties**: Integrate `weather_penalty()` with configurable TWS and Hs limits via `windfield`/`wavefield` callbacks
- **`curve0` fixes**: Guard land check with `if land is not None`, apply death penalty + weather penalty to initial curve comparison

All three public functions updated: `optimize()`, `_cma_evolution_strategy()`, `optimize_with_increasing_penalization()`.

### Dependencies
- #44 (feat/weather-constraints) — for `weather_penalty` import
- #45 (feat/cost-improvements) — for `time_offset` and `cost_fn` support

---
*Part 6 of 9 — extracted from vangelis branch for clean review*

---
Relates to #4, #20, #21