### PR TITLE
feat: SWOPP3 competition core modules

### DIFF
--- a/routetools/swopp3.py
+++ b/routetools/swopp3.py
@@ -34,7 +34,7 @@ AO_WPS: 366 departures, 354h passage
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import jax.numpy as jnp
 
@@ -187,7 +187,7 @@ def departures_2024() -> list[datetime]:
         366 timezone-aware ``datetime`` objects (UTC), one per day from
         2024-01-01 12:00 UTC through 2024-12-31 12:00 UTC.
     """
-    start = datetime(_YEAR, 1, 1, _DEPARTURE_HOUR, tzinfo=timezone.utc)
+    start = datetime(_YEAR, 1, 1, _DEPARTURE_HOUR, tzinfo=UTC)
     return [start + timedelta(days=d) for d in range(366)]
 
 

--- a/routetools/swopp3.py
+++ b/routetools/swopp3.py
@@ -1,0 +1,324 @@
+"""SWOPP3 competition configuration — routes, departures, and cases.
+
+Defines the two SWOPP3 routes (Trans-Atlantic and Trans-Pacific), their
+fixed passage times, and the 366 daily departures throughout 2024.
+
+The 8 SWOPP3 cases (Table 2 in the SWOPP3 info package):
+
+====  =========  ====================  =========================  ===
+Case  Name       Route                 Strategy                   WPS
+====  =========  ====================  =========================  ===
+1     AO_WPS     Atlantic westbound    Optimised route + speed    yes
+2     AO_noWPS   Atlantic westbound    Optimised route + speed    no
+3     AGC_WPS    Atlantic westbound    Great circle, fixed speed  yes
+4     AGC_noWPS  Atlantic westbound    Great circle, fixed speed  no
+5     PO_WPS     Pacific eastbound     Optimised route + speed    yes
+6     PO_noWPS   Pacific eastbound     Optimised route + speed    no
+7     PGC_WPS    Pacific eastbound     Great circle, fixed speed  yes
+8     PGC_noWPS  Pacific eastbound     Great circle, fixed speed  no
+====  =========  ====================  =========================  ===
+
+- **Optimised (O):** CMA-ES finds minimum-energy route and speed profile.
+- **Great Circle (GC):** Fixed geodesic route, constant speed.
+- **WPS:** RISE polar model with wingsails enabled.
+- **noWPS:** RISE polar model with wingsails disabled (engine only).
+
+Example
+-------
+>>> from routetools.swopp3 import SWOPP3_CASES, departures_2024
+>>> case = SWOPP3_CASES["AO_WPS"]
+>>> deps = departures_2024()
+>>> print(f"{case['name']}: {len(deps)} departures, {case['passage_hours']}h passage")
+AO_WPS: 366 departures, 354h passage
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import jax.numpy as jnp
+
+# ---------------------------------------------------------------------------
+# Port coordinates  (lon, lat)  — matching routetools._ports.DICT_PORTS
+# ---------------------------------------------------------------------------
+PORTS: dict[str, dict] = {
+    "ESSDR": {
+        "name": "Santander",
+        "lat": 43.6,
+        "lon": -4.0,
+    },
+    "USNYC": {
+        "name": "New York",
+        "lat": 40.53,
+        "lon": -73.80,
+    },
+    "JPTYO": {
+        "name": "Tokyo / Yokohama",
+        "lat": 34.8,
+        "lon": 140.0,
+    },
+    "USLAX": {
+        "name": "Los Angeles",
+        "lat": 34.4,
+        "lon": -121.0,
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Route definitions
+# ---------------------------------------------------------------------------
+ROUTE_ATLANTIC = {
+    "id": "atlantic",
+    "label": "Trans-Atlantic",
+    "src_port": "ESSDR",
+    "dst_port": "USNYC",
+    "passage_hours": 354,
+    "gc_distance_nm": 2833,
+}
+
+ROUTE_PACIFIC = {
+    "id": "pacific",
+    "label": "Trans-Pacific",
+    "src_port": "JPTYO",
+    "dst_port": "USLAX",
+    "passage_hours": 583,
+    "gc_distance_nm": 4663,
+}
+
+# ---------------------------------------------------------------------------
+# The 8 SWOPP3 cases
+# ---------------------------------------------------------------------------
+SWOPP3_CASES: dict[str, dict] = {
+    "AO_WPS": {
+        "name": "AO_WPS",
+        "label": "Atlantic Optimised, with WPS",
+        "route": "atlantic",
+        "src_port": "ESSDR",
+        "dst_port": "USNYC",
+        "passage_hours": 354,
+        "strategy": "optimised",
+        "wps": True,
+    },
+    "AO_noWPS": {
+        "name": "AO_noWPS",
+        "label": "Atlantic Optimised, without WPS",
+        "route": "atlantic",
+        "src_port": "ESSDR",
+        "dst_port": "USNYC",
+        "passage_hours": 354,
+        "strategy": "optimised",
+        "wps": False,
+    },
+    "AGC_WPS": {
+        "name": "AGC_WPS",
+        "label": "Atlantic Great Circle, with WPS",
+        "route": "atlantic",
+        "src_port": "ESSDR",
+        "dst_port": "USNYC",
+        "passage_hours": 354,
+        "strategy": "gc",
+        "wps": True,
+    },
+    "AGC_noWPS": {
+        "name": "AGC_noWPS",
+        "label": "Atlantic Great Circle, without WPS",
+        "route": "atlantic",
+        "src_port": "ESSDR",
+        "dst_port": "USNYC",
+        "passage_hours": 354,
+        "strategy": "gc",
+        "wps": False,
+    },
+    "PO_WPS": {
+        "name": "PO_WPS",
+        "label": "Pacific Optimised, with WPS",
+        "route": "pacific",
+        "src_port": "JPTYO",
+        "dst_port": "USLAX",
+        "passage_hours": 583,
+        "strategy": "optimised",
+        "wps": True,
+    },
+    "PO_noWPS": {
+        "name": "PO_noWPS",
+        "label": "Pacific Optimised, without WPS",
+        "route": "pacific",
+        "src_port": "JPTYO",
+        "dst_port": "USLAX",
+        "passage_hours": 583,
+        "strategy": "optimised",
+        "wps": False,
+    },
+    "PGC_WPS": {
+        "name": "PGC_WPS",
+        "label": "Pacific Great Circle, with WPS",
+        "route": "pacific",
+        "src_port": "JPTYO",
+        "dst_port": "USLAX",
+        "passage_hours": 583,
+        "strategy": "gc",
+        "wps": True,
+    },
+    "PGC_noWPS": {
+        "name": "PGC_noWPS",
+        "label": "Pacific Great Circle, without WPS",
+        "route": "pacific",
+        "src_port": "JPTYO",
+        "dst_port": "USLAX",
+        "passage_hours": 583,
+        "strategy": "gc",
+        "wps": False,
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Departure schedule
+# ---------------------------------------------------------------------------
+_YEAR = 2024  # Leap year → 366 days
+_DEPARTURE_HOUR = 12  # Noon UTC
+
+
+def departures_2024() -> list[datetime]:
+    """Return the 366 daily noon-UTC departures for 2024.
+
+    Returns
+    -------
+    list[datetime]
+        366 timezone-aware ``datetime`` objects (UTC), one per day from
+        2024-01-01 12:00 UTC through 2024-12-31 12:00 UTC.
+    """
+    start = datetime(_YEAR, 1, 1, _DEPARTURE_HOUR, tzinfo=timezone.utc)
+    return [start + timedelta(days=d) for d in range(366)]
+
+
+def departure_strings(fmt: str = "%Y-%m-%dT%H:%M:%S") -> list[str]:
+    """Return departure datetimes as formatted strings.
+
+    Parameters
+    ----------
+    fmt : str
+        ``strftime`` format, default ISO-8601 without timezone suffix.
+
+    Returns
+    -------
+    list[str]
+        366 formatted date strings.
+    """
+    return [d.strftime(fmt) for d in departures_2024()]
+
+
+# ---------------------------------------------------------------------------
+# Helper: build (src, dst) JAX arrays for a case
+# ---------------------------------------------------------------------------
+def case_endpoints(case_id: str) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Return ``(src, dst)`` as JAX arrays of ``(lon, lat)`` for a case.
+
+    Parameters
+    ----------
+    case_id : str
+        One of ``"case1"`` through ``"case8"``.
+
+    Returns
+    -------
+    tuple[jnp.ndarray, jnp.ndarray]
+        ``src`` and ``dst``, each shape ``(2,)`` with ``(lon, lat)``.
+
+    Raises
+    ------
+    KeyError
+        If *case_id* is not a valid SWOPP3 case.
+    """
+    case = SWOPP3_CASES[case_id]
+    src_port = PORTS[case["src_port"]]
+    dst_port = PORTS[case["dst_port"]]
+    src = jnp.array([src_port["lon"], src_port["lat"]])
+    dst = jnp.array([dst_port["lon"], dst_port["lat"]])
+    return src, dst
+
+
+def case_travel_time_seconds(case_id: str) -> float:
+    """Return the fixed passage time in seconds for a case.
+
+    Parameters
+    ----------
+    case_id : str
+        One of ``"case1"`` through ``"case8"``.
+
+    Returns
+    -------
+    float
+        Passage time in seconds.
+    """
+    return float(SWOPP3_CASES[case_id]["passage_hours"] * 3600)
+
+
+# ---------------------------------------------------------------------------
+# Great-circle baseline
+# ---------------------------------------------------------------------------
+def great_circle_route(
+    src: jnp.ndarray,
+    dst: jnp.ndarray,
+    n_points: int = 100,
+) -> jnp.ndarray:
+    """Compute a great-circle route between two points.
+
+    Uses spherical interpolation (SLERP) in Cartesian 3-D, then projects
+    back to ``(lon, lat)`` in degrees.  Handles the antimeridian correctly
+    (no 360° wrapping artifacts).
+
+    Parameters
+    ----------
+    src : jnp.ndarray
+        ``(lon, lat)`` in degrees, shape ``(2,)``.
+    dst : jnp.ndarray
+        ``(lon, lat)`` in degrees, shape ``(2,)``.
+    n_points : int
+        Number of waypoints (including endpoints).
+
+    Returns
+    -------
+    jnp.ndarray
+        Shape ``(n_points, 2)`` with ``(lon, lat)`` columns in degrees.
+    """
+    # Convert to radians
+    lon1, lat1 = jnp.deg2rad(src[0]), jnp.deg2rad(src[1])
+    lon2, lat2 = jnp.deg2rad(dst[0]), jnp.deg2rad(dst[1])
+
+    # To Cartesian
+    x1 = jnp.cos(lat1) * jnp.cos(lon1)
+    y1 = jnp.cos(lat1) * jnp.sin(lon1)
+    z1 = jnp.sin(lat1)
+
+    x2 = jnp.cos(lat2) * jnp.cos(lon2)
+    y2 = jnp.cos(lat2) * jnp.sin(lon2)
+    z2 = jnp.sin(lat2)
+
+    # Central angle
+    dot = x1 * x2 + y1 * y2 + z1 * z2
+    omega = jnp.arccos(jnp.clip(dot, -1.0, 1.0))
+
+    # SLERP
+    t = jnp.linspace(0.0, 1.0, n_points)
+    sin_omega = jnp.sin(omega)
+    is_coincident = sin_omega < 1e-10
+
+    # For coincident points, fall back to linear interpolation (a=1-t, b=t)
+    safe_sin = jnp.where(is_coincident, 1.0, sin_omega)
+    a = jnp.where(is_coincident, 1.0 - t, jnp.sin((1.0 - t) * omega) / safe_sin)
+    b = jnp.where(is_coincident, t, jnp.sin(t * omega) / safe_sin)
+
+    x = a * x1 + b * x2
+    y = a * y1 + b * y2
+    z = a * z1 + b * z2
+
+    # Back to (lon, lat) degrees
+    lat = jnp.rad2deg(jnp.arcsin(jnp.clip(z, -1.0, 1.0)))
+    lon = jnp.rad2deg(jnp.arctan2(y, x))
+
+    # Unwrap longitude to avoid antimeridian discontinuities
+    # (differences > 180° are wrapped by ±360°)
+    dlon = jnp.diff(lon)
+    dlon_wrapped = (dlon + 180.0) % 360.0 - 180.0
+    lon = jnp.concatenate([lon[:1], lon[0] + jnp.cumsum(dlon_wrapped)])
+
+    return jnp.stack([lon, lat], axis=1)

--- a/routetools/swopp3.py
+++ b/routetools/swopp3.py
@@ -216,7 +216,8 @@ def case_endpoints(case_id: str) -> tuple[jnp.ndarray, jnp.ndarray]:
     Parameters
     ----------
     case_id : str
-        One of ``"case1"`` through ``"case8"``.
+        Identifier of a SWOPP3 case, i.e. one of ``SWOPP3_CASES.keys()`` (for
+        example ``"AO_WPS"``).
 
     Returns
     -------
@@ -242,7 +243,7 @@ def case_travel_time_seconds(case_id: str) -> float:
     Parameters
     ----------
     case_id : str
-        One of ``"case1"`` through ``"case8"``.
+        Identifier of a SWOPP3 case, i.e. one of ``SWOPP3_CASES.keys()``.
 
     Returns
     -------

--- a/routetools/swopp3.py
+++ b/routetools/swopp3.py
@@ -38,30 +38,19 @@ from datetime import UTC, datetime, timedelta
 
 import jax.numpy as jnp
 
+from routetools._ports import DICT_PORTS
+
 # ---------------------------------------------------------------------------
 # Port coordinates  (lon, lat)  — matching routetools._ports.DICT_PORTS
 # ---------------------------------------------------------------------------
-PORTS: dict[str, dict] = {
-    "ESSDR": {
-        "name": "Santander",
-        "lat": 43.6,
-        "lon": -4.0,
-    },
-    "USNYC": {
-        "name": "New York",
-        "lat": 40.53,
-        "lon": -73.80,
-    },
-    "JPTYO": {
-        "name": "Tokyo / Yokohama",
-        "lat": 34.8,
-        "lon": 140.0,
-    },
-    "USLAX": {
-        "name": "Los Angeles",
-        "lat": 34.4,
-        "lon": -121.0,
-    },
+_SWOPP3_PORT_CODES = ("ESSDR", "USNYC", "JPTYO", "USLAX")
+PORTS: dict[str, dict[str, str | float]] = {
+    code: {
+        "name": str(DICT_PORTS[code].get("city", code)),
+        "lat": float(DICT_PORTS[code]["lat"]),
+        "lon": float(DICT_PORTS[code]["lon"]),
+    }
+    for code in _SWOPP3_PORT_CODES
 }
 
 # ---------------------------------------------------------------------------

--- a/routetools/swopp3_output.py
+++ b/routetools/swopp3_output.py
@@ -20,7 +20,7 @@ Naming convention::
 from __future__ import annotations
 
 import csv
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import jax.numpy as jnp
@@ -171,7 +171,7 @@ def file_a_name(submission: int, casename: str) -> str:
     Returns
     -------
     str
-        Filename like ``IEUniversity-1-AOWPS.csv``.
+        Filename like ``IEUniversity-1-AO_WPS.csv``.
     """
     return f"{TEAM}-{submission}-{casename}.csv"
 

--- a/routetools/swopp3_output.py
+++ b/routetools/swopp3_output.py
@@ -78,7 +78,7 @@ def waypoint_times(
     Parameters
     ----------
     curve : jnp.ndarray
-        Shape ``(L, 2)`` waypoints.
+        Shape ``(L, 2)`` waypoints in ``(lon, lat)`` order.
     departure : datetime
         Departure time (UTC).
     passage_hours : float
@@ -88,9 +88,16 @@ def waypoint_times(
     -------
     list[datetime]
         ``L`` UTC datetimes, one per waypoint.
+
+    Raises
+    ------
+    ValueError
+        If *curve* has no waypoints.
     """
     L = curve.shape[0]
-    if L < 2:
+    if L == 0:
+        raise ValueError("curve must contain at least one waypoint")
+    if L == 1:
         return [departure]
     total_seconds = passage_hours * 3600.0
     return [
@@ -216,14 +223,14 @@ def file_b_name(submission: int, casename: str, departure: datetime) -> str:
     submission : int
         Submission number.
     casename : str
-        Case name.
+        Case name (e.g. ``"AO_WPS"``).
     departure : datetime
         Departure date.
 
     Returns
     -------
     str
-        Filename like ``IEUniversity-1-AOWPS-20240101.csv``.
+        Filename like ``IEUniversity-1-AO_WPS-20240101.csv``.
     """
     date_str = departure.strftime("%Y%m%d")
     return f"{TEAM}-{submission}-{casename}-{date_str}.csv"

--- a/routetools/swopp3_output.py
+++ b/routetools/swopp3_output.py
@@ -1,0 +1,266 @@
+"""SWOPP3 output formatters — File A (energy summary) and File B (tracks).
+
+Produces CSV files in the exact format required by the SWOPP3 competition.
+
+**File A** — one CSV per case, 366 rows (one per departure):
+
+    departure_time_utc, arrival_time_utc, energy_cons_mwh,
+    max_wind_mps, max_hs_m, sailed_distance_nm, details_filename
+
+**File B** — one CSV per departure (referenced by ``details_filename``):
+
+    time_utc, lat_deg, lon_deg
+
+Naming convention::
+
+    IEUniversity-{submission}-{casename}.csv      (File A)
+    IEUniversity-{submission}-{casename}-{dep}.csv (File B)
+"""
+
+from __future__ import annotations
+
+import csv
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import jax.numpy as jnp
+
+from routetools._cost.haversine import haversine_distance_from_curve
+
+# Nautical mile in metres
+_NM = 1852.0
+
+# SWOPP3 datetime format
+_DTFMT = "%Y-%m-%d %H:%M:%S"
+
+# Team identifier
+TEAM = "IEUniversity"
+
+__all__ = [
+    "TEAM",
+    "file_a_row",
+    "write_file_a",
+    "write_file_b",
+    "sailed_distance_nm",
+    "waypoint_times",
+]
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+def sailed_distance_nm(curve: jnp.ndarray) -> float:
+    """Total sailed distance in nautical miles.
+
+    Parameters
+    ----------
+    curve : jnp.ndarray
+        Shape ``(L, 2)`` with ``(lon, lat)`` in degrees.
+
+    Returns
+    -------
+    float
+        Distance in nautical miles.
+    """
+    segment_m = haversine_distance_from_curve(curve)
+    return float(jnp.sum(segment_m)) / _NM
+
+
+def waypoint_times(
+    curve: jnp.ndarray,
+    departure: datetime,
+    passage_hours: float,
+) -> list[datetime]:
+    """Compute UTC timestamps at each waypoint assuming constant speed.
+
+    Distributes waypoints uniformly in time over the passage duration.
+
+    Parameters
+    ----------
+    curve : jnp.ndarray
+        Shape ``(L, 2)`` waypoints.
+    departure : datetime
+        Departure time (UTC).
+    passage_hours : float
+        Total passage time in hours.
+
+    Returns
+    -------
+    list[datetime]
+        ``L`` UTC datetimes, one per waypoint.
+    """
+    L = curve.shape[0]
+    total_seconds = passage_hours * 3600.0
+    return [
+        departure + timedelta(seconds=total_seconds * i / (L - 1))
+        for i in range(L)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# File A — Energy summary
+# ---------------------------------------------------------------------------
+def file_a_row(
+    departure: datetime,
+    passage_hours: float,
+    energy_mwh: float,
+    max_wind_mps: float,
+    max_hs_m: float,
+    distance_nm: float,
+    details_filename: str,
+) -> dict[str, str]:
+    """Build one row of File A as a dict.
+
+    Parameters
+    ----------
+    departure : datetime
+        Departure time UTC.
+    passage_hours : float
+        Passage time in hours.
+    energy_mwh : float
+        Total energy consumption in MWh.
+    max_wind_mps : float
+        Maximum true wind speed encountered (m/s).
+    max_hs_m : float
+        Maximum significant wave height encountered (m).
+    distance_nm : float
+        Sailed distance in nautical miles.
+    details_filename : str
+        Name of the corresponding File B CSV.
+
+    Returns
+    -------
+    dict[str, str]
+        Column-name → string-value mapping.
+    """
+    arrival = departure + timedelta(hours=passage_hours)
+    return {
+        "departure_time_utc": departure.strftime(_DTFMT),
+        "arrival_time_utc": arrival.strftime(_DTFMT),
+        "energy_cons_mwh": f"{energy_mwh:.6f}",
+        "max_wind_mps": f"{max_wind_mps:.4f}",
+        "max_hs_m": f"{max_hs_m:.4f}",
+        "sailed_distance_nm": f"{distance_nm:.4f}",
+        "details_filename": details_filename,
+    }
+
+
+_FILE_A_COLUMNS = [
+    "departure_time_utc",
+    "arrival_time_utc",
+    "energy_cons_mwh",
+    "max_wind_mps",
+    "max_hs_m",
+    "sailed_distance_nm",
+    "details_filename",
+]
+
+
+def file_a_name(submission: int, casename: str) -> str:
+    """Generate the File A filename.
+
+    Parameters
+    ----------
+    submission : int
+        Submission number (e.g. 1, 2, …).
+    casename : str
+        Case name (e.g. ``"AOWPS"``).
+
+    Returns
+    -------
+    str
+        Filename like ``IEUniversity-1-AOWPS.csv``.
+    """
+    return f"{TEAM}-{submission}-{casename}.csv"
+
+
+def write_file_a(
+    rows: list[dict[str, str]],
+    path: str | Path,
+) -> Path:
+    """Write a File A CSV.
+
+    Parameters
+    ----------
+    rows : list[dict]
+        List of row dicts (from :func:`file_a_row`).
+    path : str or Path
+        Output file path.
+
+    Returns
+    -------
+    Path
+        The written path.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=_FILE_A_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# File B — Track coordinates
+# ---------------------------------------------------------------------------
+_FILE_B_COLUMNS = ["time_utc", "lat_deg", "lon_deg"]
+
+
+def file_b_name(submission: int, casename: str, departure: datetime) -> str:
+    """Generate the File B filename.
+
+    Parameters
+    ----------
+    submission : int
+        Submission number.
+    casename : str
+        Case name.
+    departure : datetime
+        Departure date.
+
+    Returns
+    -------
+    str
+        Filename like ``IEUniversity-1-AOWPS-20240101.csv``.
+    """
+    date_str = departure.strftime("%Y%m%d")
+    return f"{TEAM}-{submission}-{casename}-{date_str}.csv"
+
+
+def write_file_b(
+    curve: jnp.ndarray,
+    times: list[datetime],
+    path: str | Path,
+) -> Path:
+    """Write a File B (track) CSV.
+
+    Parameters
+    ----------
+    curve : jnp.ndarray
+        Shape ``(L, 2)`` with ``(lon, lat)`` in degrees.
+    times : list[datetime]
+        ``L`` UTC timestamps (one per waypoint).
+    path : str or Path
+        Output file path.
+
+    Returns
+    -------
+    Path
+        The written path.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    L = curve.shape[0]
+    assert len(times) == L, f"Expected {L} times, got {len(times)}"
+
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=_FILE_B_COLUMNS)
+        writer.writeheader()
+        for i in range(L):
+            writer.writerow({
+                "time_utc": times[i].strftime(_DTFMT),
+                "lat_deg": f"{float(curve[i, 1]):.6f}",
+                "lon_deg": f"{float(curve[i, 0]):.6f}",
+            })
+    return path

--- a/routetools/swopp3_output.py
+++ b/routetools/swopp3_output.py
@@ -94,8 +94,7 @@ def waypoint_times(
         return [departure]
     total_seconds = passage_hours * 3600.0
     return [
-        departure + timedelta(seconds=total_seconds * i / (L - 1))
-        for i in range(L)
+        departure + timedelta(seconds=total_seconds * i / (L - 1)) for i in range(L)
     ]
 
 
@@ -261,9 +260,11 @@ def write_file_b(
         writer = csv.DictWriter(f, fieldnames=_FILE_B_COLUMNS)
         writer.writeheader()
         for i in range(L):
-            writer.writerow({
-                "time_utc": times[i].strftime(_DTFMT),
-                "lat_deg": f"{float(curve[i, 1]):.6f}",
-                "lon_deg": f"{float(curve[i, 0]):.6f}",
-            })
+            writer.writerow(
+                {
+                    "time_utc": times[i].strftime(_DTFMT),
+                    "lat_deg": f"{float(curve[i, 1]):.6f}",
+                    "lon_deg": f"{float(curve[i, 0]):.6f}",
+                }
+            )
     return path

--- a/routetools/swopp3_output.py
+++ b/routetools/swopp3_output.py
@@ -90,6 +90,8 @@ def waypoint_times(
         ``L`` UTC datetimes, one per waypoint.
     """
     L = curve.shape[0]
+    if L < 2:
+        return [departure]
     total_seconds = passage_hours * 3600.0
     return [
         departure + timedelta(seconds=total_seconds * i / (L - 1))
@@ -164,7 +166,7 @@ def file_a_name(submission: int, casename: str) -> str:
     submission : int
         Submission number (e.g. 1, 2, …).
     casename : str
-        Case name (e.g. ``"AOWPS"``).
+        Case name (e.g. ``"AO_WPS"``).
 
     Returns
     -------
@@ -252,7 +254,8 @@ def write_file_b(
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     L = curve.shape[0]
-    assert len(times) == L, f"Expected {L} times, got {len(times)}"
+    if len(times) != L:
+        raise ValueError(f"Expected {L} times, got {len(times)}")
 
     with path.open("w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=_FILE_B_COLUMNS)

--- a/routetools/swopp3_validate.py
+++ b/routetools/swopp3_validate.py
@@ -1,17 +1,8 @@
 """SWOPP3 output validation — verify File A, File B and submission compliance.
 
-Currently implemented checks:
-
-- File A columns, formats, no NaN/missing values.
-- File B columns and timestamp ordering.
-- Naming convention:  ``IEUniversity-{sub}-{case}.csv``.
-- Energy sanity: WPS ≤ noWPS, optimised ≤ GC (across case pairs).
-
-Planned / not yet wired:
-
-- File B timestamps consistent with File A arrival/departure.
-- Route distance range checks.
-- Fixed passage time enforcement.
+This module provides helpers to validate SWOPP3 output files and submission
+directories. The functions check column presence and formats, file naming,
+timestamp ordering in tracks, and simple cross-case energy sanity rules.
 
 Example
 -------
@@ -50,10 +41,6 @@ _FILE_A_COLUMNS = [
 ]
 
 _FILE_B_COLUMNS = ["time_utc", "lat_deg", "lon_deg"]
-
-# Expected passage hours by route tag
-# Expected passage hours by route tag (reserved for future passage-time validation)
-_PASSAGE_HOURS = {"A": 354, "P": 583}  # Atlantic / Pacific
 
 
 class ValidationError:

--- a/routetools/swopp3_validate.py
+++ b/routetools/swopp3_validate.py
@@ -1,0 +1,414 @@
+"""SWOPP3 output validation — verify File A & File B compliance.
+
+Checks performed:
+
+- File A columns, formats, no NaN/missing values.
+- File B columns, timestamps consistent with File A.
+- Naming convention:  ``IEUniversity-{sub}-{case}.csv``.
+- Route sanity: distance within expected range.
+- Energy sanity: WPS ≤ noWPS, optimised ≤ GC (across case pairs).
+- Constraint compliance reporting.
+
+Example
+-------
+>>> from routetools.swopp3_validate import validate_file_a, validate_file_b
+>>> errors = validate_file_a("output/swopp3/IEUniversity-1-AGC_WPS.csv")
+>>> assert not errors, errors
+"""
+
+from __future__ import annotations
+
+import csv
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
+
+__all__ = [
+    "validate_file_a",
+    "validate_file_b",
+    "validate_case_pair_wps",
+    "validate_case_pair_strategy",
+    "validate_submission_dir",
+    "ValidationError",
+]
+
+_DTFMT = "%Y-%m-%d %H:%M:%S"
+_TEAM = "IEUniversity"
+
+_FILE_A_COLUMNS = [
+    "departure_time_utc",
+    "arrival_time_utc",
+    "energy_cons_mwh",
+    "max_wind_mps",
+    "max_hs_m",
+    "sailed_distance_nm",
+    "details_filename",
+]
+
+_FILE_B_COLUMNS = ["time_utc", "lat_deg", "lon_deg"]
+
+# Expected passage hours by route tag
+_PASSAGE_HOURS = {"A": 354, "P": 583}  # Atlantic / Pacific
+
+
+class ValidationError:
+    """A single validation issue."""
+
+    def __init__(self, file: str, row: int | None, message: str):
+        self.file = file
+        self.row = row
+        self.message = message
+
+    def __repr__(self) -> str:
+        loc = f"row {self.row}" if self.row is not None else "file"
+        return f"ValidationError({self.file}, {loc}: {self.message})"
+
+
+# ---------------------------------------------------------------------------
+# File A validation
+# ---------------------------------------------------------------------------
+def validate_file_a(
+    path: str | Path,
+    expected_rows: int = 366,
+) -> list[ValidationError]:
+    """Validate a File A CSV.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the File A CSV.
+    expected_rows : int
+        Expected number of data rows (default 366).
+
+    Returns
+    -------
+    list[ValidationError]
+        Empty list if valid.
+    """
+    path = Path(path)
+    errors: list[ValidationError] = []
+    fname = path.name
+
+    # ---- Naming convention ----
+    pattern = re.compile(rf"^{_TEAM}-\d+-\w+\.csv$")
+    if not pattern.match(fname):
+        errors.append(ValidationError(fname, None, f"Name '{fname}' doesn't match pattern"))
+
+    if not path.exists():
+        errors.append(ValidationError(fname, None, "File not found"))
+        return errors
+
+    with path.open() as f:
+        reader = csv.DictReader(f)
+
+        # ---- Columns ----
+        if reader.fieldnames is None:
+            errors.append(ValidationError(fname, None, "No header row"))
+            return errors
+
+        missing = set(_FILE_A_COLUMNS) - set(reader.fieldnames)
+        extra = set(reader.fieldnames) - set(_FILE_A_COLUMNS)
+        if missing:
+            errors.append(ValidationError(fname, None, f"Missing columns: {missing}"))
+        if extra:
+            errors.append(ValidationError(fname, None, f"Extra columns: {extra}"))
+
+        rows = list(reader)
+
+    # ---- Row count ----
+    if len(rows) != expected_rows:
+        errors.append(
+            ValidationError(fname, None, f"Expected {expected_rows} rows, got {len(rows)}")
+        )
+
+    for i, row in enumerate(rows, 1):
+        # ---- No empty values ----
+        for col in _FILE_A_COLUMNS:
+            val = row.get(col, "")
+            if not val.strip():
+                errors.append(ValidationError(fname, i, f"Empty value in '{col}'"))
+
+        # ---- Datetime format ----
+        for col in ("departure_time_utc", "arrival_time_utc"):
+            try:
+                datetime.strptime(row[col], _DTFMT)
+            except (ValueError, KeyError):
+                errors.append(ValidationError(fname, i, f"Bad datetime in '{col}': {row.get(col)}"))
+
+        # ---- Numeric fields ----
+        for col in ("energy_cons_mwh", "max_wind_mps", "max_hs_m", "sailed_distance_nm"):
+            try:
+                v = float(row[col])
+                if v != v:  # NaN check
+                    errors.append(ValidationError(fname, i, f"NaN in '{col}'"))
+                if v < 0:
+                    errors.append(ValidationError(fname, i, f"Negative value in '{col}': {v}"))
+            except (ValueError, KeyError):
+                errors.append(ValidationError(fname, i, f"Non-numeric '{col}': {row.get(col)}"))
+
+        # ---- Passage time vs arrival - departure ----
+        try:
+            dep = datetime.strptime(row["departure_time_utc"], _DTFMT)
+            arr = datetime.strptime(row["arrival_time_utc"], _DTFMT)
+            passage_h = (arr - dep).total_seconds() / 3600
+            if passage_h <= 0:
+                errors.append(ValidationError(fname, i, f"Arrival before departure"))
+        except (ValueError, KeyError):
+            pass  # already reported above
+
+        # ---- details_filename ----
+        details = row.get("details_filename", "")
+        if details and not details.endswith(".csv"):
+            errors.append(ValidationError(fname, i, f"details_filename not .csv: {details}"))
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# File B validation
+# ---------------------------------------------------------------------------
+def validate_file_b(
+    path: str | Path,
+    min_waypoints: int = 2,
+) -> list[ValidationError]:
+    """Validate a File B (track) CSV.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the File B CSV.
+    min_waypoints : int
+        Minimum number of waypoints (default 2).
+
+    Returns
+    -------
+    list[ValidationError]
+        Empty list if valid.
+    """
+    path = Path(path)
+    errors: list[ValidationError] = []
+    fname = path.name
+
+    if not path.exists():
+        errors.append(ValidationError(fname, None, "File not found"))
+        return errors
+
+    with path.open() as f:
+        reader = csv.DictReader(f)
+
+        if reader.fieldnames is None:
+            errors.append(ValidationError(fname, None, "No header row"))
+            return errors
+
+        missing = set(_FILE_B_COLUMNS) - set(reader.fieldnames)
+        if missing:
+            errors.append(ValidationError(fname, None, f"Missing columns: {missing}"))
+
+        rows = list(reader)
+
+    if len(rows) < min_waypoints:
+        errors.append(
+            ValidationError(fname, None, f"Only {len(rows)} waypoints (min {min_waypoints})")
+        )
+
+    prev_time = None
+    for i, row in enumerate(rows, 1):
+        # ---- Datetime ----
+        try:
+            t = datetime.strptime(row["time_utc"], _DTFMT)
+            if prev_time is not None and t <= prev_time:
+                errors.append(ValidationError(fname, i, "Timestamps not strictly increasing"))
+            prev_time = t
+        except (ValueError, KeyError):
+            errors.append(ValidationError(fname, i, f"Bad time_utc: {row.get('time_utc')}"))
+
+        # ---- Coordinates ----
+        for col, lo, hi in [("lat_deg", -90, 90), ("lon_deg", -360, 360)]:
+            try:
+                v = float(row[col])
+                if v != v:
+                    errors.append(ValidationError(fname, i, f"NaN in '{col}'"))
+                elif v < lo or v > hi:
+                    errors.append(ValidationError(fname, i, f"'{col}'={v} out of range [{lo},{hi}]"))
+            except (ValueError, KeyError):
+                errors.append(ValidationError(fname, i, f"Non-numeric '{col}': {row.get(col)}"))
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Cross-case comparisons
+# ---------------------------------------------------------------------------
+def _load_energies(path: Path) -> list[float]:
+    """Load energy_cons_mwh column from a File A CSV."""
+    with path.open() as f:
+        reader = csv.DictReader(f)
+        return [float(row["energy_cons_mwh"]) for row in reader]
+
+
+def validate_case_pair_wps(
+    wps_path: str | Path,
+    nowps_path: str | Path,
+) -> list[ValidationError]:
+    """Check that WPS energy ≤ noWPS energy for each departure.
+
+    Returns
+    -------
+    list[ValidationError]
+        One error per departure where WPS > noWPS.
+    """
+    errors: list[ValidationError] = []
+    wps_e = _load_energies(Path(wps_path))
+    nowps_e = _load_energies(Path(nowps_path))
+    n = min(len(wps_e), len(nowps_e))
+    violations = 0
+    for i in range(n):
+        if wps_e[i] > nowps_e[i] + 1e-6:
+            violations += 1
+    if violations:
+        errors.append(
+            ValidationError(
+                f"{Path(wps_path).name} vs {Path(nowps_path).name}",
+                None,
+                f"WPS energy > noWPS in {violations}/{n} departures",
+            )
+        )
+    return errors
+
+
+def validate_case_pair_strategy(
+    opt_path: str | Path,
+    gc_path: str | Path,
+) -> list[ValidationError]:
+    """Check that optimised energy ≤ GC energy for most departures.
+
+    We allow up to 10% of departures where optimised is worse (stochastic
+    optimisation may not always beat the baseline).
+
+    Returns
+    -------
+    list[ValidationError]
+        Error if too many departures show optimised > GC.
+    """
+    errors: list[ValidationError] = []
+    opt_e = _load_energies(Path(opt_path))
+    gc_e = _load_energies(Path(gc_path))
+    n = min(len(opt_e), len(gc_e))
+    worse = sum(1 for i in range(n) if opt_e[i] > gc_e[i] + 1e-6)
+    pct = worse / n * 100 if n else 0
+    if pct > 10:
+        errors.append(
+            ValidationError(
+                f"{Path(opt_path).name} vs {Path(gc_path).name}",
+                None,
+                f"Optimised worse than GC in {worse}/{n} ({pct:.1f}%) departures",
+            )
+        )
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Full submission directory validation
+# ---------------------------------------------------------------------------
+def validate_submission_dir(
+    output_dir: str | Path,
+    submission: int = 1,
+    expected_departures: int = 366,
+    verbose: bool = True,
+) -> list[ValidationError]:
+    """Validate all files in a submission directory.
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Directory containing File A CSVs and ``tracks/`` subdirectory.
+    submission : int
+        Submission number.
+    expected_departures : int
+        Expected departures per case.
+    verbose : bool
+        Print progress.
+
+    Returns
+    -------
+    list[ValidationError]
+        All errors found.
+    """
+    output_dir = Path(output_dir)
+    errors: list[ValidationError] = []
+
+    case_names = [
+        "AO_WPS", "AO_noWPS", "AGC_WPS", "AGC_noWPS",
+        "PO_WPS", "PO_noWPS", "PGC_WPS", "PGC_noWPS",
+    ]
+
+    # ---- File A ----
+    for cname in case_names:
+        fa = output_dir / f"{_TEAM}-{submission}-{cname}.csv"
+        if verbose:
+            print(f"Validating File A: {fa.name} ... ", end="")
+        errs = validate_file_a(fa, expected_rows=expected_departures)
+        errors.extend(errs)
+        if verbose:
+            print(f"{'FAIL' if errs else 'OK'} ({len(errs)} issues)")
+
+        # ---- File B for each departure ----
+        if fa.exists():
+            with fa.open() as f:
+                reader = csv.DictReader(f)
+                for row_i, row in enumerate(reader, 1):
+                    fb_name = row.get("details_filename", "")
+                    if fb_name:
+                        fb_path = output_dir / "tracks" / fb_name
+                        fb_errs = validate_file_b(fb_path)
+                        errors.extend(fb_errs)
+
+    # ---- WPS vs noWPS comparisons ----
+    pairs_wps = [
+        ("AO_WPS", "AO_noWPS"),
+        ("AGC_WPS", "AGC_noWPS"),
+        ("PO_WPS", "PO_noWPS"),
+        ("PGC_WPS", "PGC_noWPS"),
+    ]
+    for wps_case, nowps_case in pairs_wps:
+        wps_fa = output_dir / f"{_TEAM}-{submission}-{wps_case}.csv"
+        nowps_fa = output_dir / f"{_TEAM}-{submission}-{nowps_case}.csv"
+        if wps_fa.exists() and nowps_fa.exists():
+            if verbose:
+                print(f"Comparing {wps_case} vs {nowps_case} ... ", end="")
+            errs = validate_case_pair_wps(wps_fa, nowps_fa)
+            errors.extend(errs)
+            if verbose:
+                print(f"{'FAIL' if errs else 'OK'}")
+
+    # ---- Optimised vs GC comparisons ----
+    pairs_strategy = [
+        ("AO_WPS", "AGC_WPS"),
+        ("AO_noWPS", "AGC_noWPS"),
+        ("PO_WPS", "PGC_WPS"),
+        ("PO_noWPS", "PGC_noWPS"),
+    ]
+    for opt_case, gc_case in pairs_strategy:
+        opt_fa = output_dir / f"{_TEAM}-{submission}-{opt_case}.csv"
+        gc_fa = output_dir / f"{_TEAM}-{submission}-{gc_case}.csv"
+        if opt_fa.exists() and gc_fa.exists():
+            if verbose:
+                print(f"Comparing {opt_case} vs {gc_case} ... ", end="")
+            errs = validate_case_pair_strategy(opt_fa, gc_fa)
+            errors.extend(errs)
+            if verbose:
+                print(f"{'FAIL' if errs else 'OK'}")
+
+    # ---- Summary ----
+    if verbose:
+        print(f"\n{'='*50}")
+        if errors:
+            print(f"VALIDATION FAILED: {len(errors)} issue(s)")
+            for e in errors[:20]:
+                print(f"  {e}")
+            if len(errors) > 20:
+                print(f"  ... and {len(errors) - 20} more")
+        else:
+            print("VALIDATION PASSED: all checks OK")
+
+    return errors

--- a/routetools/swopp3_validate.py
+++ b/routetools/swopp3_validate.py
@@ -1,13 +1,17 @@
-"""SWOPP3 output validation — verify File A & File B compliance.
+"""SWOPP3 output validation — verify File A, File B and submission compliance.
 
-Checks performed:
+Currently implemented checks:
 
 - File A columns, formats, no NaN/missing values.
-- File B columns, timestamps consistent with File A.
+- File B columns and timestamp ordering.
 - Naming convention:  ``IEUniversity-{sub}-{case}.csv``.
-- Route sanity: distance within expected range.
 - Energy sanity: WPS ≤ noWPS, optimised ≤ GC (across case pairs).
-- Constraint compliance reporting.
+
+Planned / not yet wired:
+
+- File B timestamps consistent with File A arrival/departure.
+- Route distance range checks.
+- Fixed passage time enforcement.
 
 Example
 -------
@@ -240,7 +244,17 @@ def validate_file_b(
 # Cross-case comparisons
 # ---------------------------------------------------------------------------
 def _load_energies(path: Path) -> list[float]:
-    """Load energy_cons_mwh column from a File A CSV."""
+    """Load energy_cons_mwh column from a File A CSV.
+
+    Raises
+    ------
+    FileNotFoundError
+        If *path* does not exist.
+    KeyError
+        If the ``energy_cons_mwh`` column is missing.
+    ValueError
+        If a cell value is not numeric.
+    """
     with path.open() as f:
         reader = csv.DictReader(f)
         return [float(row["energy_cons_mwh"]) for row in reader]
@@ -258,8 +272,12 @@ def validate_case_pair_wps(
         One error per departure where WPS > noWPS.
     """
     errors: list[ValidationError] = []
-    wps_e = _load_energies(Path(wps_path))
-    nowps_e = _load_energies(Path(nowps_path))
+    try:
+        wps_e = _load_energies(Path(wps_path))
+        nowps_e = _load_energies(Path(nowps_path))
+    except (FileNotFoundError, KeyError, ValueError) as exc:
+        errors.append(ValidationError(str(wps_path), None, f"Cannot load energies: {exc}"))
+        return errors
     n = min(len(wps_e), len(nowps_e))
     violations = 0
     for i in range(n):
@@ -291,8 +309,12 @@ def validate_case_pair_strategy(
         Error if too many departures show optimised > GC.
     """
     errors: list[ValidationError] = []
-    opt_e = _load_energies(Path(opt_path))
-    gc_e = _load_energies(Path(gc_path))
+    try:
+        opt_e = _load_energies(Path(opt_path))
+        gc_e = _load_energies(Path(gc_path))
+    except (FileNotFoundError, KeyError, ValueError) as exc:
+        errors.append(ValidationError(str(opt_path), None, f"Cannot load energies: {exc}"))
+        return errors
     n = min(len(opt_e), len(gc_e))
     worse = sum(1 for i in range(n) if opt_e[i] > gc_e[i] + 1e-6)
     pct = worse / n * 100 if n else 0

--- a/routetools/swopp3_validate.py
+++ b/routetools/swopp3_validate.py
@@ -65,6 +65,7 @@ class ValidationError:
         self.message = message
 
     def __repr__(self) -> str:
+        """Return a readable representation for debugging output."""
         loc = f"row {self.row}" if self.row is not None else "file"
         return f"ValidationError({self.file}, {loc}: {self.message})"
 
@@ -97,7 +98,9 @@ def validate_file_a(
     # ---- Naming convention ----
     pattern = re.compile(rf"^{_TEAM}-\d+-\w+\.csv$")
     if not pattern.match(fname):
-        errors.append(ValidationError(fname, None, f"Name '{fname}' doesn't match pattern"))
+        errors.append(
+            ValidationError(fname, None, f"Name '{fname}' doesn't match pattern")
+        )
 
     if not path.exists():
         errors.append(ValidationError(fname, None, "File not found"))
@@ -123,7 +126,9 @@ def validate_file_a(
     # ---- Row count ----
     if len(rows) != expected_rows:
         errors.append(
-            ValidationError(fname, None, f"Expected {expected_rows} rows, got {len(rows)}")
+            ValidationError(
+                fname, None, f"Expected {expected_rows} rows, got {len(rows)}"
+            )
         )
 
     for i, row in enumerate(rows, 1):
@@ -138,18 +143,31 @@ def validate_file_a(
             try:
                 datetime.strptime(row[col], _DTFMT)
             except (ValueError, KeyError):
-                errors.append(ValidationError(fname, i, f"Bad datetime in '{col}': {row.get(col)}"))
+                errors.append(
+                    ValidationError(
+                        fname, i, f"Bad datetime in '{col}': {row.get(col)}"
+                    )
+                )
 
         # ---- Numeric fields ----
-        for col in ("energy_cons_mwh", "max_wind_mps", "max_hs_m", "sailed_distance_nm"):
+        for col in (
+            "energy_cons_mwh",
+            "max_wind_mps",
+            "max_hs_m",
+            "sailed_distance_nm",
+        ):
             try:
                 v = float(row[col])
                 if v != v:  # NaN check
                     errors.append(ValidationError(fname, i, f"NaN in '{col}'"))
                 if v < 0:
-                    errors.append(ValidationError(fname, i, f"Negative value in '{col}': {v}"))
+                    errors.append(
+                        ValidationError(fname, i, f"Negative value in '{col}': {v}")
+                    )
             except (ValueError, KeyError):
-                errors.append(ValidationError(fname, i, f"Non-numeric '{col}': {row.get(col)}"))
+                errors.append(
+                    ValidationError(fname, i, f"Non-numeric '{col}': {row.get(col)}")
+                )
 
         # ---- Passage time vs arrival - departure ----
         try:
@@ -157,14 +175,16 @@ def validate_file_a(
             arr = datetime.strptime(row["arrival_time_utc"], _DTFMT)
             passage_h = (arr - dep).total_seconds() / 3600
             if passage_h <= 0:
-                errors.append(ValidationError(fname, i, f"Arrival before departure"))
+                errors.append(ValidationError(fname, i, "Arrival before departure"))
         except (ValueError, KeyError):
             pass  # already reported above
 
         # ---- details_filename ----
         details = row.get("details_filename", "")
         if details and not details.endswith(".csv"):
-            errors.append(ValidationError(fname, i, f"details_filename not .csv: {details}"))
+            errors.append(
+                ValidationError(fname, i, f"details_filename not .csv: {details}")
+            )
 
     return errors
 
@@ -213,7 +233,9 @@ def validate_file_b(
 
     if len(rows) < min_waypoints:
         errors.append(
-            ValidationError(fname, None, f"Only {len(rows)} waypoints (min {min_waypoints})")
+            ValidationError(
+                fname, None, f"Only {len(rows)} waypoints (min {min_waypoints})"
+            )
         )
 
     prev_time = None
@@ -222,10 +244,14 @@ def validate_file_b(
         try:
             t = datetime.strptime(row["time_utc"], _DTFMT)
             if prev_time is not None and t <= prev_time:
-                errors.append(ValidationError(fname, i, "Timestamps not strictly increasing"))
+                errors.append(
+                    ValidationError(fname, i, "Timestamps not strictly increasing")
+                )
             prev_time = t
         except (ValueError, KeyError):
-            errors.append(ValidationError(fname, i, f"Bad time_utc: {row.get('time_utc')}"))
+            errors.append(
+                ValidationError(fname, i, f"Bad time_utc: {row.get('time_utc')}")
+            )
 
         # ---- Coordinates ----
         for col, lo, hi in [("lat_deg", -90, 90), ("lon_deg", -360, 360)]:
@@ -234,9 +260,15 @@ def validate_file_b(
                 if v != v:
                     errors.append(ValidationError(fname, i, f"NaN in '{col}'"))
                 elif v < lo or v > hi:
-                    errors.append(ValidationError(fname, i, f"'{col}'={v} out of range [{lo},{hi}]"))
+                    errors.append(
+                        ValidationError(
+                            fname, i, f"'{col}'={v} out of range [{lo},{hi}]"
+                        )
+                    )
             except (ValueError, KeyError):
-                errors.append(ValidationError(fname, i, f"Non-numeric '{col}': {row.get(col)}"))
+                errors.append(
+                    ValidationError(fname, i, f"Non-numeric '{col}': {row.get(col)}")
+                )
 
     return errors
 
@@ -277,7 +309,9 @@ def validate_case_pair_wps(
         wps_e = _load_energies(Path(wps_path))
         nowps_e = _load_energies(Path(nowps_path))
     except (FileNotFoundError, KeyError, ValueError) as exc:
-        errors.append(ValidationError(str(wps_path), None, f"Cannot load energies: {exc}"))
+        errors.append(
+            ValidationError(str(wps_path), None, f"Cannot load energies: {exc}")
+        )
         return errors
     n = min(len(wps_e), len(nowps_e))
     violations = 0
@@ -314,7 +348,9 @@ def validate_case_pair_strategy(
         opt_e = _load_energies(Path(opt_path))
         gc_e = _load_energies(Path(gc_path))
     except (FileNotFoundError, KeyError, ValueError) as exc:
-        errors.append(ValidationError(str(opt_path), None, f"Cannot load energies: {exc}"))
+        errors.append(
+            ValidationError(str(opt_path), None, f"Cannot load energies: {exc}")
+        )
         return errors
     n = min(len(opt_e), len(gc_e))
     worse = sum(1 for i in range(n) if opt_e[i] > gc_e[i] + 1e-6)
@@ -361,8 +397,14 @@ def validate_submission_dir(
     errors: list[ValidationError] = []
 
     case_names = [
-        "AO_WPS", "AO_noWPS", "AGC_WPS", "AGC_noWPS",
-        "PO_WPS", "PO_noWPS", "PGC_WPS", "PGC_noWPS",
+        "AO_WPS",
+        "AO_noWPS",
+        "AGC_WPS",
+        "AGC_noWPS",
+        "PO_WPS",
+        "PO_noWPS",
+        "PGC_WPS",
+        "PGC_noWPS",
     ]
 
     # ---- File A ----
@@ -379,7 +421,7 @@ def validate_submission_dir(
         if fa.exists():
             with fa.open() as f:
                 reader = csv.DictReader(f)
-                for row_i, row in enumerate(reader, 1):
+                for _row_i, row in enumerate(reader, 1):
                     fb_name = row.get("details_filename", "")
                     if fb_name:
                         fb_path = output_dir / "tracks" / fb_name
@@ -424,7 +466,7 @@ def validate_submission_dir(
 
     # ---- Summary ----
     if verbose:
-        print(f"\n{'='*50}")
+        print(f"\n{'=' * 50}")
         if errors:
             print(f"VALIDATION FAILED: {len(errors)} issue(s)")
             for e in errors[:20]:

--- a/routetools/swopp3_validate.py
+++ b/routetools/swopp3_validate.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import csv
 import re
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 
 __all__ = [
@@ -52,6 +52,7 @@ _FILE_A_COLUMNS = [
 _FILE_B_COLUMNS = ["time_utc", "lat_deg", "lon_deg"]
 
 # Expected passage hours by route tag
+# Expected passage hours by route tag (reserved for future passage-time validation)
 _PASSAGE_HOURS = {"A": 354, "P": 583}  # Atlantic / Pacific
 
 

--- a/tests/test_swopp3.py
+++ b/tests/test_swopp3.py
@@ -1,0 +1,255 @@
+"""Tests for routetools.swopp3 — SWOPP3 configuration and helpers."""
+
+from datetime import datetime, timezone
+
+import jax.numpy as jnp
+import pytest
+
+from routetools.swopp3 import (
+    PORTS,
+    ROUTE_ATLANTIC,
+    ROUTE_PACIFIC,
+    SWOPP3_CASES,
+    case_endpoints,
+    case_travel_time_seconds,
+    departure_strings,
+    departures_2024,
+    great_circle_route,
+)
+
+
+# ---------------------------------------------------------------------------
+# Port definitions
+# ---------------------------------------------------------------------------
+class TestPorts:
+    def test_all_four_ports_defined(self):
+        assert set(PORTS.keys()) == {"ESSDR", "USNYC", "JPTYO", "USLAX"}
+
+    def test_santander_coords(self):
+        assert PORTS["ESSDR"]["lat"] == 43.6
+        assert PORTS["ESSDR"]["lon"] == -4.0
+
+    def test_new_york_coords(self):
+        assert PORTS["USNYC"]["lat"] == 40.53
+        assert PORTS["USNYC"]["lon"] == -73.80
+
+    def test_tokyo_coords(self):
+        assert PORTS["JPTYO"]["lat"] == 34.8
+        assert PORTS["JPTYO"]["lon"] == 140.0
+
+    def test_la_coords(self):
+        assert PORTS["USLAX"]["lat"] == 34.4
+        assert PORTS["USLAX"]["lon"] == -121.0
+
+
+# ---------------------------------------------------------------------------
+# Route definitions
+# ---------------------------------------------------------------------------
+class TestRoutes:
+    def test_atlantic_passage(self):
+        assert ROUTE_ATLANTIC["passage_hours"] == 354
+
+    def test_pacific_passage(self):
+        assert ROUTE_PACIFIC["passage_hours"] == 583
+
+    def test_atlantic_ports(self):
+        assert ROUTE_ATLANTIC["src_port"] == "ESSDR"
+        assert ROUTE_ATLANTIC["dst_port"] == "USNYC"
+
+    def test_pacific_ports(self):
+        assert ROUTE_PACIFIC["src_port"] == "JPTYO"
+        assert ROUTE_PACIFIC["dst_port"] == "USLAX"
+
+
+# ---------------------------------------------------------------------------
+# 8 SWOPP3 cases
+# ---------------------------------------------------------------------------
+_CASE_IDS = ["AO_WPS", "AO_noWPS", "AGC_WPS", "AGC_noWPS",
+             "PO_WPS", "PO_noWPS", "PGC_WPS", "PGC_noWPS"]
+
+_ATLANTIC_CASES = ["AO_WPS", "AO_noWPS", "AGC_WPS", "AGC_noWPS"]
+_PACIFIC_CASES = ["PO_WPS", "PO_noWPS", "PGC_WPS", "PGC_noWPS"]
+
+
+class TestCases:
+    def test_eight_cases(self):
+        assert len(SWOPP3_CASES) == 8
+
+    def test_case_ids(self):
+        assert set(SWOPP3_CASES.keys()) == set(_CASE_IDS)
+
+    @pytest.mark.parametrize("cid", _CASE_IDS)
+    def test_case_has_required_keys(self, cid):
+        case = SWOPP3_CASES[cid]
+        for key in ("name", "label", "src_port", "dst_port",
+                     "passage_hours", "route", "strategy", "wps"):
+            assert key in case, f"{cid} missing key {key}"
+
+    @pytest.mark.parametrize("cid", _CASE_IDS)
+    def test_strategy_values(self, cid):
+        assert SWOPP3_CASES[cid]["strategy"] in ("optimised", "gc")
+
+    def test_optimised_cases(self):
+        for cid in ("AO_WPS", "AO_noWPS", "PO_WPS", "PO_noWPS"):
+            assert SWOPP3_CASES[cid]["strategy"] == "optimised"
+
+    def test_gc_cases(self):
+        for cid in ("AGC_WPS", "AGC_noWPS", "PGC_WPS", "PGC_noWPS"):
+            assert SWOPP3_CASES[cid]["strategy"] == "gc"
+
+    def test_wps_flag(self):
+        for cid in ("AO_WPS", "AGC_WPS", "PO_WPS", "PGC_WPS"):
+            assert SWOPP3_CASES[cid]["wps"] is True
+        for cid in ("AO_noWPS", "AGC_noWPS", "PO_noWPS", "PGC_noWPS"):
+            assert SWOPP3_CASES[cid]["wps"] is False
+
+    def test_atlantic_passage_hours(self):
+        for cid in _ATLANTIC_CASES:
+            assert SWOPP3_CASES[cid]["passage_hours"] == 354
+
+    def test_pacific_passage_hours(self):
+        for cid in _PACIFIC_CASES:
+            assert SWOPP3_CASES[cid]["passage_hours"] == 583
+
+    def test_atlantic_route(self):
+        for cid in _ATLANTIC_CASES:
+            assert SWOPP3_CASES[cid]["src_port"] == "ESSDR"
+            assert SWOPP3_CASES[cid]["dst_port"] == "USNYC"
+
+    def test_pacific_route(self):
+        for cid in _PACIFIC_CASES:
+            assert SWOPP3_CASES[cid]["src_port"] == "JPTYO"
+            assert SWOPP3_CASES[cid]["dst_port"] == "USLAX"
+
+
+# ---------------------------------------------------------------------------
+# Departures
+# ---------------------------------------------------------------------------
+class TestDepartures:
+    def test_366_departures(self):
+        deps = departures_2024()
+        assert len(deps) == 366
+
+    def test_first_departure(self):
+        deps = departures_2024()
+        expected = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        assert deps[0] == expected
+
+    def test_last_departure(self):
+        deps = departures_2024()
+        expected = datetime(2024, 12, 31, 12, 0, 0, tzinfo=timezone.utc)
+        assert deps[-1] == expected
+
+    def test_all_noon_utc(self):
+        for d in departures_2024():
+            assert d.hour == 12
+            assert d.minute == 0
+            assert d.second == 0
+
+    def test_consecutive_days(self):
+        deps = departures_2024()
+        for i in range(1, len(deps)):
+            delta = deps[i] - deps[i - 1]
+            assert delta.days == 1
+            assert delta.seconds == 0
+
+    def test_departure_strings_iso(self):
+        strings = departure_strings()
+        assert len(strings) == 366
+        assert strings[0] == "2024-01-01T12:00:00"
+        assert strings[-1] == "2024-12-31T12:00:00"
+
+    def test_departure_strings_custom_format(self):
+        strings = departure_strings(fmt="%Y-%m-%d")
+        assert strings[0] == "2024-01-01"
+
+
+# ---------------------------------------------------------------------------
+# case_endpoints
+# ---------------------------------------------------------------------------
+class TestCaseEndpoints:
+    def test_ao_wps_src_dst(self):
+        src, dst = case_endpoints("AO_WPS")
+        assert src.shape == (2,)
+        assert dst.shape == (2,)
+        # src should be Santander (lon, lat)
+        assert jnp.allclose(src, jnp.array([-4.0, 43.6]))
+        # dst should be New York (lon, lat)
+        assert jnp.allclose(dst, jnp.array([-73.80, 40.53]))
+
+    def test_all_atlantic_same_endpoints(self):
+        src_ref, dst_ref = case_endpoints("AO_WPS")
+        for cid in _ATLANTIC_CASES:
+            src, dst = case_endpoints(cid)
+            assert jnp.allclose(src, src_ref)
+            assert jnp.allclose(dst, dst_ref)
+
+    def test_po_wps_pacific(self):
+        src, dst = case_endpoints("PO_WPS")
+        # Tokyo
+        assert jnp.allclose(src, jnp.array([140.0, 34.8]))
+        # LA
+        assert jnp.allclose(dst, jnp.array([-121.0, 34.4]))
+
+    def test_all_pacific_same_endpoints(self):
+        src_ref, dst_ref = case_endpoints("PO_WPS")
+        for cid in _PACIFIC_CASES:
+            src, dst = case_endpoints(cid)
+            assert jnp.allclose(src, src_ref)
+            assert jnp.allclose(dst, dst_ref)
+
+    def test_invalid_case_raises(self):
+        with pytest.raises(KeyError):
+            case_endpoints("case99")
+
+
+# ---------------------------------------------------------------------------
+# case_travel_time_seconds
+# ---------------------------------------------------------------------------
+class TestCaseTravelTime:
+    def test_atlantic(self):
+        assert case_travel_time_seconds("AO_WPS") == 354 * 3600.0
+
+    def test_pacific(self):
+        assert case_travel_time_seconds("PO_WPS") == 583 * 3600.0
+
+
+# ---------------------------------------------------------------------------
+# Great-circle route
+# ---------------------------------------------------------------------------
+class TestGreatCircle:
+    def test_endpoints_match(self):
+        src = jnp.array([-4.0, 43.6])
+        dst = jnp.array([-73.80, 40.53])
+        route = great_circle_route(src, dst, n_points=50)
+        assert route.shape == (50, 2)
+        assert jnp.allclose(route[0], src, atol=1e-4)
+        assert jnp.allclose(route[-1], dst, atol=1e-4)
+
+    def test_pacific_antimeridian(self):
+        """Pacific route crosses the antimeridian — no wrapping artifact."""
+        src = jnp.array([140.0, 34.8])  # Tokyo
+        dst = jnp.array([-121.0, 34.4])  # LA
+        route = great_circle_route(src, dst, n_points=200)
+        # Route should go eastward across the Pacific (longitudes > 140 or < -121)
+        # The key test: no sudden 360° jumps between consecutive points
+        dlon = jnp.diff(route[:, 0])
+        assert jnp.all(jnp.abs(dlon) < 10.0), "Large longitude jump detected — antimeridian bug"
+
+    def test_coincident_points(self):
+        """Degenerate case: src == dst."""
+        pt = jnp.array([10.0, 50.0])
+        route = great_circle_route(pt, pt, n_points=10)
+        assert route.shape == (10, 2)
+        # All points should be at the same location
+        for i in range(10):
+            assert jnp.allclose(route[i], pt, atol=1e-4)
+
+    def test_route_latitude_range(self):
+        """Atlantic GC route should curve northward (higher than both endpoints)."""
+        src = jnp.array([-4.0, 43.6])  # Santander
+        dst = jnp.array([-73.80, 40.53])  # NYC
+        route = great_circle_route(src, dst, n_points=100)
+        max_lat = jnp.max(route[:, 1])
+        # GC route from Santander to NYC curves north — max latitude > both endpoints
+        assert max_lat > max(43.6, 40.53), f"max_lat {max_lat} should exceed endpoint lats"

--- a/tests/test_swopp3.py
+++ b/tests/test_swopp3.py
@@ -1,6 +1,6 @@
 """Tests for routetools.swopp3 — SWOPP3 configuration and helpers."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import jax.numpy as jnp
 import pytest
@@ -64,8 +64,16 @@ class TestRoutes:
 # ---------------------------------------------------------------------------
 # 8 SWOPP3 cases
 # ---------------------------------------------------------------------------
-_CASE_IDS = ["AO_WPS", "AO_noWPS", "AGC_WPS", "AGC_noWPS",
-             "PO_WPS", "PO_noWPS", "PGC_WPS", "PGC_noWPS"]
+_CASE_IDS = [
+    "AO_WPS",
+    "AO_noWPS",
+    "AGC_WPS",
+    "AGC_noWPS",
+    "PO_WPS",
+    "PO_noWPS",
+    "PGC_WPS",
+    "PGC_noWPS",
+]
 
 _ATLANTIC_CASES = ["AO_WPS", "AO_noWPS", "AGC_WPS", "AGC_noWPS"]
 _PACIFIC_CASES = ["PO_WPS", "PO_noWPS", "PGC_WPS", "PGC_noWPS"]
@@ -81,8 +89,16 @@ class TestCases:
     @pytest.mark.parametrize("cid", _CASE_IDS)
     def test_case_has_required_keys(self, cid):
         case = SWOPP3_CASES[cid]
-        for key in ("name", "label", "src_port", "dst_port",
-                     "passage_hours", "route", "strategy", "wps"):
+        for key in (
+            "name",
+            "label",
+            "src_port",
+            "dst_port",
+            "passage_hours",
+            "route",
+            "strategy",
+            "wps",
+        ):
             assert key in case, f"{cid} missing key {key}"
 
     @pytest.mark.parametrize("cid", _CASE_IDS)
@@ -132,12 +148,12 @@ class TestDepartures:
 
     def test_first_departure(self):
         deps = departures_2024()
-        expected = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        expected = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
         assert deps[0] == expected
 
     def test_last_departure(self):
         deps = departures_2024()
-        expected = datetime(2024, 12, 31, 12, 0, 0, tzinfo=timezone.utc)
+        expected = datetime(2024, 12, 31, 12, 0, 0, tzinfo=UTC)
         assert deps[-1] == expected
 
     def test_all_noon_utc(self):
@@ -234,7 +250,9 @@ class TestGreatCircle:
         # Route should go eastward across the Pacific (longitudes > 140 or < -121)
         # The key test: no sudden 360° jumps between consecutive points
         dlon = jnp.diff(route[:, 0])
-        assert jnp.all(jnp.abs(dlon) < 10.0), "Large longitude jump detected — antimeridian bug"
+        assert jnp.all(
+            jnp.abs(dlon) < 10.0
+        ), "Large longitude jump detected — antimeridian bug"
 
     def test_coincident_points(self):
         """Degenerate case: src == dst."""
@@ -252,4 +270,6 @@ class TestGreatCircle:
         route = great_circle_route(src, dst, n_points=100)
         max_lat = jnp.max(route[:, 1])
         # GC route from Santander to NYC curves north — max latitude > both endpoints
-        assert max_lat > max(43.6, 40.53), f"max_lat {max_lat} should exceed endpoint lats"
+        assert max_lat > max(
+            43.6, 40.53
+        ), f"max_lat {max_lat} should exceed endpoint lats"

--- a/tests/test_swopp3_output.py
+++ b/tests/test_swopp3_output.py
@@ -114,11 +114,11 @@ class TestFileARow:
 # ---------------------------------------------------------------------------
 class TestNaming:
     def test_file_a_name(self):
-        assert file_a_name(1, "AOWPS") == "IEUniversity-1-AOWPS.csv"
+        assert file_a_name(1, "AO_WPS") == "IEUniversity-1-AO_WPS.csv"
 
     def test_file_b_name(self):
-        name = file_b_name(1, "AOWPS", _DEP)
-        assert name == "IEUniversity-1-AOWPS-20240101.csv"
+        name = file_b_name(1, "AO_WPS", _DEP)
+        assert name == "IEUniversity-1-AO_WPS-20240101.csv"
 
     def test_team(self):
         assert TEAM == "IEUniversity"
@@ -178,7 +178,7 @@ class TestWriteFileB:
     def test_mismatched_lengths_raises(self, tmp_path: Path):
         curve = _straight_curve(5)
         times = waypoint_times(curve, _DEP, passage_hours=10)
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             write_file_b(curve, times[:3], tmp_path / "bad.csv")
 
     def test_lon_lat_order(self, tmp_path: Path):

--- a/tests/test_swopp3_output.py
+++ b/tests/test_swopp3_output.py
@@ -1,16 +1,16 @@
 """Tests for routetools.swopp3_output — File A / File B formatters."""
 
 import csv
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import jax.numpy as jnp
 import pytest
 
 from routetools.swopp3_output import (
-    TEAM,
     _FILE_A_COLUMNS,
     _FILE_B_COLUMNS,
+    TEAM,
     file_a_name,
     file_a_row,
     file_b_name,
@@ -31,7 +31,7 @@ def _straight_curve(n: int = 10) -> jnp.ndarray:
     return jnp.linspace(src, dst, n)
 
 
-_DEP = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+_DEP = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_swopp3_output.py
+++ b/tests/test_swopp3_output.py
@@ -1,0 +1,194 @@
+"""Tests for routetools.swopp3_output — File A / File B formatters."""
+
+import csv
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import jax.numpy as jnp
+import pytest
+
+from routetools.swopp3_output import (
+    TEAM,
+    _FILE_A_COLUMNS,
+    _FILE_B_COLUMNS,
+    file_a_name,
+    file_a_row,
+    file_b_name,
+    sailed_distance_nm,
+    waypoint_times,
+    write_file_a,
+    write_file_b,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _straight_curve(n: int = 10) -> jnp.ndarray:
+    """Straight line from (0, 0) to (1, 0) — ~111 km ≈ 60 nm."""
+    src = jnp.array([0.0, 0.0])
+    dst = jnp.array([1.0, 0.0])
+    return jnp.linspace(src, dst, n)
+
+
+_DEP = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# sailed_distance_nm
+# ---------------------------------------------------------------------------
+class TestSailedDistance:
+    def test_positive(self):
+        curve = _straight_curve()
+        d = sailed_distance_nm(curve)
+        assert d > 0
+
+    def test_equator_one_degree(self):
+        """1° of longitude at the equator ≈ 60 nm."""
+        curve = _straight_curve(100)
+        d = sailed_distance_nm(curve)
+        assert 59.0 < d < 61.0, f"Expected ~60 nm, got {d}"
+
+
+# ---------------------------------------------------------------------------
+# waypoint_times
+# ---------------------------------------------------------------------------
+class TestWaypointTimes:
+    def test_count(self):
+        curve = _straight_curve(50)
+        times = waypoint_times(curve, _DEP, passage_hours=354)
+        assert len(times) == 50
+
+    def test_first_is_departure(self):
+        curve = _straight_curve()
+        times = waypoint_times(curve, _DEP, passage_hours=10)
+        assert times[0] == _DEP
+
+    def test_last_is_arrival(self):
+        curve = _straight_curve()
+        times = waypoint_times(curve, _DEP, passage_hours=10)
+        expected = _DEP + timedelta(hours=10)
+        # Allow tiny floating-point rounding
+        delta = abs((times[-1] - expected).total_seconds())
+        assert delta < 1.0, f"Last time off by {delta}s"
+
+    def test_uniform_spacing(self):
+        curve = _straight_curve(11)
+        times = waypoint_times(curve, _DEP, passage_hours=10)
+        deltas = [(times[i + 1] - times[i]).total_seconds() for i in range(10)]
+        assert all(abs(d - deltas[0]) < 0.01 for d in deltas)
+
+
+# ---------------------------------------------------------------------------
+# file_a_row
+# ---------------------------------------------------------------------------
+class TestFileARow:
+    def test_keys(self):
+        row = file_a_row(
+            departure=_DEP,
+            passage_hours=354,
+            energy_mwh=12.5,
+            max_wind_mps=18.0,
+            max_hs_m=5.0,
+            distance_nm=2800.0,
+            details_filename="test.csv",
+        )
+        assert set(row.keys()) == set(_FILE_A_COLUMNS)
+
+    def test_departure_format(self):
+        row = file_a_row(_DEP, 354, 1.0, 1.0, 1.0, 1.0, "x.csv")
+        assert row["departure_time_utc"] == "2024-01-01 12:00:00"
+
+    def test_arrival_format(self):
+        row = file_a_row(_DEP, 354, 1.0, 1.0, 1.0, 1.0, "x.csv")
+        expected_arrival = _DEP + timedelta(hours=354)
+        assert row["arrival_time_utc"] == expected_arrival.strftime("%Y-%m-%d %H:%M:%S")
+
+    def test_details_filename_passthrough(self):
+        row = file_a_row(_DEP, 354, 1.0, 1.0, 1.0, 1.0, "my_track.csv")
+        assert row["details_filename"] == "my_track.csv"
+
+
+# ---------------------------------------------------------------------------
+# file_a_name / file_b_name
+# ---------------------------------------------------------------------------
+class TestNaming:
+    def test_file_a_name(self):
+        assert file_a_name(1, "AOWPS") == "IEUniversity-1-AOWPS.csv"
+
+    def test_file_b_name(self):
+        name = file_b_name(1, "AOWPS", _DEP)
+        assert name == "IEUniversity-1-AOWPS-20240101.csv"
+
+    def test_team(self):
+        assert TEAM == "IEUniversity"
+
+
+# ---------------------------------------------------------------------------
+# write_file_a
+# ---------------------------------------------------------------------------
+class TestWriteFileA:
+    def test_roundtrip(self, tmp_path: Path):
+        rows = [
+            file_a_row(_DEP, 354, 12.5, 18.0, 5.1, 2800.0, "track1.csv"),
+            file_a_row(
+                _DEP + timedelta(days=1), 354, 13.0, 19.0, 6.0, 2810.0, "track2.csv"
+            ),
+        ]
+        out = write_file_a(rows, tmp_path / "output" / "file_a.csv")
+        assert out.exists()
+
+        # Parse back
+        with out.open() as f:
+            reader = csv.DictReader(f)
+            parsed = list(reader)
+        assert len(parsed) == 2
+        assert parsed[0]["departure_time_utc"] == "2024-01-01 12:00:00"
+        assert parsed[1]["energy_cons_mwh"] == "13.000000"
+        assert set(reader.fieldnames) == set(_FILE_A_COLUMNS)
+
+    def test_creates_parent_dirs(self, tmp_path: Path):
+        rows = [file_a_row(_DEP, 10, 1.0, 1.0, 1.0, 100.0, "x.csv")]
+        out = write_file_a(rows, tmp_path / "a" / "b" / "c" / "file.csv")
+        assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# write_file_b
+# ---------------------------------------------------------------------------
+class TestWriteFileB:
+    def test_roundtrip(self, tmp_path: Path):
+        curve = _straight_curve(5)
+        times = waypoint_times(curve, _DEP, passage_hours=10)
+        out = write_file_b(curve, times, tmp_path / "track.csv")
+        assert out.exists()
+
+        with out.open() as f:
+            reader = csv.DictReader(f)
+            parsed = list(reader)
+        assert len(parsed) == 5
+        assert set(reader.fieldnames) == set(_FILE_B_COLUMNS)
+        # First row: time is departure, lat=0, lon=0
+        assert parsed[0]["time_utc"] == "2024-01-01 12:00:00"
+        assert float(parsed[0]["lat_deg"]) == pytest.approx(0.0, abs=1e-4)
+        assert float(parsed[0]["lon_deg"]) == pytest.approx(0.0, abs=1e-4)
+        # Last row: lon=1, lat=0
+        assert float(parsed[-1]["lon_deg"]) == pytest.approx(1.0, abs=1e-4)
+
+    def test_mismatched_lengths_raises(self, tmp_path: Path):
+        curve = _straight_curve(5)
+        times = waypoint_times(curve, _DEP, passage_hours=10)
+        with pytest.raises(AssertionError):
+            write_file_b(curve, times[:3], tmp_path / "bad.csv")
+
+    def test_lon_lat_order(self, tmp_path: Path):
+        """Curve is (lon, lat) but File B columns are lat_deg, lon_deg."""
+        # Point with lon=10, lat=50
+        curve = jnp.array([[10.0, 50.0], [11.0, 51.0]])
+        times = [_DEP, _DEP + timedelta(hours=5)]
+        out = write_file_b(curve, times, tmp_path / "coords.csv")
+        with out.open() as f:
+            reader = csv.DictReader(f)
+            row = next(reader)
+        assert float(row["lon_deg"]) == pytest.approx(10.0, abs=1e-4)
+        assert float(row["lat_deg"]) == pytest.approx(50.0, abs=1e-4)

--- a/tests/test_swopp3_output.py
+++ b/tests/test_swopp3_output.py
@@ -59,6 +59,16 @@ class TestWaypointTimes:
         times = waypoint_times(curve, _DEP, passage_hours=354)
         assert len(times) == 50
 
+    def test_single_waypoint(self):
+        curve = jnp.array([[10.0, 50.0]])
+        times = waypoint_times(curve, _DEP, passage_hours=10)
+        assert times == [_DEP]
+
+    def test_empty_curve_raises(self):
+        curve = jnp.empty((0, 2))
+        with pytest.raises(ValueError):
+            waypoint_times(curve, _DEP, passage_hours=10)
+
     def test_first_is_departure(self):
         curve = _straight_curve()
         times = waypoint_times(curve, _DEP, passage_hours=10)

--- a/tests/test_swopp3_validate.py
+++ b/tests/test_swopp3_validate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import csv
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from routetools.swopp3_validate import (
@@ -15,11 +15,16 @@ from routetools.swopp3_validate import (
 )
 
 _DTFMT = "%Y-%m-%d %H:%M:%S"
-_DEP = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+_DEP = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
 
 _FILE_A_COLS = [
-    "departure_time_utc", "arrival_time_utc", "energy_cons_mwh",
-    "max_wind_mps", "max_hs_m", "sailed_distance_nm", "details_filename",
+    "departure_time_utc",
+    "arrival_time_utc",
+    "energy_cons_mwh",
+    "max_wind_mps",
+    "max_hs_m",
+    "sailed_distance_nm",
+    "details_filename",
 ]
 
 _FILE_B_COLS = ["time_utc", "lat_deg", "lon_deg"]
@@ -34,15 +39,19 @@ def _write_file_a(path: Path, n: int = 2) -> None:
         for i in range(n):
             dep = _DEP + timedelta(days=i)
             arr = dep + timedelta(hours=354)
-            writer.writerow({
-                "departure_time_utc": dep.strftime(_DTFMT),
-                "arrival_time_utc": arr.strftime(_DTFMT),
-                "energy_cons_mwh": f"{10.0 + i:.6f}",
-                "max_wind_mps": f"{15.0:.4f}",
-                "max_hs_m": f"{3.0:.4f}",
-                "sailed_distance_nm": f"{2800.0:.4f}",
-                "details_filename": f"IEUniversity-1-TEST-{dep.strftime('%Y%m%d')}.csv",
-            })
+            writer.writerow(
+                {
+                    "departure_time_utc": dep.strftime(_DTFMT),
+                    "arrival_time_utc": arr.strftime(_DTFMT),
+                    "energy_cons_mwh": f"{10.0 + i:.6f}",
+                    "max_wind_mps": f"{15.0:.4f}",
+                    "max_hs_m": f"{3.0:.4f}",
+                    "sailed_distance_nm": f"{2800.0:.4f}",
+                    "details_filename": (
+                        f"IEUniversity-1-TEST-{dep.strftime('%Y%m%d')}.csv"
+                    ),
+                }
+            )
 
 
 def _write_file_b(path: Path, n_waypoints: int = 5) -> None:
@@ -53,11 +62,13 @@ def _write_file_b(path: Path, n_waypoints: int = 5) -> None:
         writer.writeheader()
         for i in range(n_waypoints):
             t = _DEP + timedelta(hours=i * 10)
-            writer.writerow({
-                "time_utc": t.strftime(_DTFMT),
-                "lat_deg": f"{43.6 - i * 0.5:.6f}",
-                "lon_deg": f"{-4.0 - i * 10:.6f}",
-            })
+            writer.writerow(
+                {
+                    "time_utc": t.strftime(_DTFMT),
+                    "lat_deg": f"{43.6 - i * 0.5:.6f}",
+                    "lon_deg": f"{-4.0 - i * 10:.6f}",
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -97,15 +108,17 @@ class TestValidateFileA:
         with fa.open("w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=_FILE_A_COLS)
             writer.writeheader()
-            writer.writerow({
-                "departure_time_utc": "not-a-date",
-                "arrival_time_utc": "2024-01-01 12:00:00",
-                "energy_cons_mwh": "10.0",
-                "max_wind_mps": "5.0",
-                "max_hs_m": "2.0",
-                "sailed_distance_nm": "2800",
-                "details_filename": "track.csv",
-            })
+            writer.writerow(
+                {
+                    "departure_time_utc": "not-a-date",
+                    "arrival_time_utc": "2024-01-01 12:00:00",
+                    "energy_cons_mwh": "10.0",
+                    "max_wind_mps": "5.0",
+                    "max_hs_m": "2.0",
+                    "sailed_distance_nm": "2800",
+                    "details_filename": "track.csv",
+                }
+            )
         errs = validate_file_a(fa, expected_rows=1)
         assert any("Bad datetime" in e.message for e in errs)
 
@@ -115,15 +128,17 @@ class TestValidateFileA:
         with fa.open("w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=_FILE_A_COLS)
             writer.writeheader()
-            writer.writerow({
-                "departure_time_utc": "2024-01-01 12:00:00",
-                "arrival_time_utc": "2024-01-16 18:00:00",
-                "energy_cons_mwh": "nan",
-                "max_wind_mps": "5.0",
-                "max_hs_m": "2.0",
-                "sailed_distance_nm": "2800",
-                "details_filename": "track.csv",
-            })
+            writer.writerow(
+                {
+                    "departure_time_utc": "2024-01-01 12:00:00",
+                    "arrival_time_utc": "2024-01-16 18:00:00",
+                    "energy_cons_mwh": "nan",
+                    "max_wind_mps": "5.0",
+                    "max_hs_m": "2.0",
+                    "sailed_distance_nm": "2800",
+                    "details_filename": "track.csv",
+                }
+            )
         errs = validate_file_a(fa, expected_rows=1)
         assert any("NaN" in e.message for e in errs)
 
@@ -161,8 +176,12 @@ class TestValidateFileB:
         with fb.open("w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=_FILE_B_COLS)
             writer.writeheader()
-            writer.writerow({"time_utc": "2024-01-02 12:00:00", "lat_deg": "43", "lon_deg": "-4"})
-            writer.writerow({"time_utc": "2024-01-01 12:00:00", "lat_deg": "42", "lon_deg": "-5"})
+            writer.writerow(
+                {"time_utc": "2024-01-02 12:00:00", "lat_deg": "43", "lon_deg": "-4"}
+            )
+            writer.writerow(
+                {"time_utc": "2024-01-01 12:00:00", "lat_deg": "42", "lon_deg": "-5"}
+            )
         errs = validate_file_b(fb)
         assert any("not strictly increasing" in e.message for e in errs)
 
@@ -172,7 +191,9 @@ class TestValidateFileB:
         with fb.open("w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=_FILE_B_COLS)
             writer.writeheader()
-            writer.writerow({"time_utc": "2024-01-01 12:00:00", "lat_deg": "100", "lon_deg": "-4"})
+            writer.writerow(
+                {"time_utc": "2024-01-01 12:00:00", "lat_deg": "100", "lon_deg": "-4"}
+            )
         errs = validate_file_b(fb)
         assert any("out of range" in e.message for e in errs)
 
@@ -211,15 +232,17 @@ def _write_file_a_custom(path: Path, energies: list[float]) -> None:
         for i, e in enumerate(energies):
             dep = _DEP + timedelta(days=i)
             arr = dep + timedelta(hours=354)
-            writer.writerow({
-                "departure_time_utc": dep.strftime(_DTFMT),
-                "arrival_time_utc": arr.strftime(_DTFMT),
-                "energy_cons_mwh": f"{e:.6f}",
-                "max_wind_mps": "15.0000",
-                "max_hs_m": "3.0000",
-                "sailed_distance_nm": "2800.0000",
-                "details_filename": f"track_{i}.csv",
-            })
+            writer.writerow(
+                {
+                    "departure_time_utc": dep.strftime(_DTFMT),
+                    "arrival_time_utc": arr.strftime(_DTFMT),
+                    "energy_cons_mwh": f"{e:.6f}",
+                    "max_wind_mps": "15.0000",
+                    "max_hs_m": "3.0000",
+                    "sailed_distance_nm": "2800.0000",
+                    "details_filename": f"track_{i}.csv",
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -267,4 +290,6 @@ class TestValidateCasePairStrategy:
         _write_file_a_custom(gc, gc_energies)
         errs = validate_case_pair_strategy(opt, gc)
         assert len(errs) == 1
-        assert "worse" in errs[0].message.lower() or "optimised" in errs[0].message.lower()
+        assert (
+            "worse" in errs[0].message.lower() or "optimised" in errs[0].message.lower()
+        )

--- a/tests/test_swopp3_validate.py
+++ b/tests/test_swopp3_validate.py
@@ -6,10 +6,9 @@ import csv
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-import pytest
-
 from routetools.swopp3_validate import (
     ValidationError,
+    validate_case_pair_strategy,
     validate_case_pair_wps,
     validate_file_a,
     validate_file_b,
@@ -233,3 +232,40 @@ class TestValidateSubmissionDir:
         # Should report missing File A for all 8 cases
         missing = [e for e in errs if "not found" in e.message]
         assert len(missing) == 8
+
+
+# ---------------------------------------------------------------------------
+# validate_case_pair_strategy (optimised vs GC baseline)
+# ---------------------------------------------------------------------------
+class TestValidateCasePairStrategy:
+    def test_optimised_always_better_no_errors(self, tmp_path: Path):
+        """All departures have optimised ≤ GC → no errors."""
+        opt = tmp_path / "opt.csv"
+        gc = tmp_path / "gc.csv"
+        _write_file_a_custom(opt, [90.0, 85.0, 80.0])
+        _write_file_a_custom(gc, [100.0, 100.0, 100.0])
+        errs = validate_case_pair_strategy(opt, gc)
+        assert errs == []
+
+    def test_under_threshold_no_errors(self, tmp_path: Path):
+        """Exactly 10% worse departures (1 of 10) → allowed, no errors."""
+        opt_energies = [90.0] * 9 + [110.0]  # 1 out of 10 worse
+        gc_energies = [100.0] * 10
+        opt = tmp_path / "opt.csv"
+        gc = tmp_path / "gc.csv"
+        _write_file_a_custom(opt, opt_energies)
+        _write_file_a_custom(gc, gc_energies)
+        errs = validate_case_pair_strategy(opt, gc)
+        assert errs == []
+
+    def test_over_threshold_reports_error(self, tmp_path: Path):
+        """More than 10% worse departures → returns errors."""
+        opt_energies = [110.0] * 10  # all worse
+        gc_energies = [100.0] * 10
+        opt = tmp_path / "opt.csv"
+        gc = tmp_path / "gc.csv"
+        _write_file_a_custom(opt, opt_energies)
+        _write_file_a_custom(gc, gc_energies)
+        errs = validate_case_pair_strategy(opt, gc)
+        assert len(errs) == 1
+        assert "worse" in errs[0].message.lower() or "optimised" in errs[0].message.lower()

--- a/tests/test_swopp3_validate.py
+++ b/tests/test_swopp3_validate.py
@@ -1,0 +1,235 @@
+"""Tests for routetools.swopp3_validate — output validation."""
+
+from __future__ import annotations
+
+import csv
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from routetools.swopp3_validate import (
+    ValidationError,
+    validate_case_pair_wps,
+    validate_file_a,
+    validate_file_b,
+    validate_submission_dir,
+)
+
+_DTFMT = "%Y-%m-%d %H:%M:%S"
+_DEP = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+_FILE_A_COLS = [
+    "departure_time_utc", "arrival_time_utc", "energy_cons_mwh",
+    "max_wind_mps", "max_hs_m", "sailed_distance_nm", "details_filename",
+]
+
+_FILE_B_COLS = ["time_utc", "lat_deg", "lon_deg"]
+
+
+def _write_file_a(path: Path, n: int = 2) -> None:
+    """Write a valid File A CSV for testing."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=_FILE_A_COLS)
+        writer.writeheader()
+        for i in range(n):
+            dep = _DEP + timedelta(days=i)
+            arr = dep + timedelta(hours=354)
+            writer.writerow({
+                "departure_time_utc": dep.strftime(_DTFMT),
+                "arrival_time_utc": arr.strftime(_DTFMT),
+                "energy_cons_mwh": f"{10.0 + i:.6f}",
+                "max_wind_mps": f"{15.0:.4f}",
+                "max_hs_m": f"{3.0:.4f}",
+                "sailed_distance_nm": f"{2800.0:.4f}",
+                "details_filename": f"IEUniversity-1-TEST-{dep.strftime('%Y%m%d')}.csv",
+            })
+
+
+def _write_file_b(path: Path, n_waypoints: int = 5) -> None:
+    """Write a valid File B CSV for testing."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=_FILE_B_COLS)
+        writer.writeheader()
+        for i in range(n_waypoints):
+            t = _DEP + timedelta(hours=i * 10)
+            writer.writerow({
+                "time_utc": t.strftime(_DTFMT),
+                "lat_deg": f"{43.6 - i * 0.5:.6f}",
+                "lon_deg": f"{-4.0 - i * 10:.6f}",
+            })
+
+
+# ---------------------------------------------------------------------------
+# validate_file_a
+# ---------------------------------------------------------------------------
+class TestValidateFileA:
+    def test_valid_file(self, tmp_path: Path):
+        fa = tmp_path / "IEUniversity-1-AGC_WPS.csv"
+        _write_file_a(fa)
+        errs = validate_file_a(fa, expected_rows=2)
+        assert not errs, errs
+
+    def test_missing_file(self, tmp_path: Path):
+        fa = tmp_path / "IEUniversity-1-AGC_WPS.csv"
+        errs = validate_file_a(fa)
+        assert any("not found" in e.message for e in errs)
+
+    def test_wrong_row_count(self, tmp_path: Path):
+        fa = tmp_path / "IEUniversity-1-AGC_WPS.csv"
+        _write_file_a(fa, n=3)
+        errs = validate_file_a(fa, expected_rows=5)
+        assert any("Expected 5 rows" in e.message for e in errs)
+
+    def test_missing_column(self, tmp_path: Path):
+        fa = tmp_path / "IEUniversity-1-AGC_WPS.csv"
+        fa.parent.mkdir(parents=True, exist_ok=True)
+        with fa.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=["departure_time_utc"])
+            writer.writeheader()
+            writer.writerow({"departure_time_utc": "2024-01-01 12:00:00"})
+        errs = validate_file_a(fa, expected_rows=1)
+        assert any("Missing columns" in e.message for e in errs)
+
+    def test_bad_datetime(self, tmp_path: Path):
+        fa = tmp_path / "IEUniversity-1-AGC_WPS.csv"
+        fa.parent.mkdir(parents=True, exist_ok=True)
+        with fa.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=_FILE_A_COLS)
+            writer.writeheader()
+            writer.writerow({
+                "departure_time_utc": "not-a-date",
+                "arrival_time_utc": "2024-01-01 12:00:00",
+                "energy_cons_mwh": "10.0",
+                "max_wind_mps": "5.0",
+                "max_hs_m": "2.0",
+                "sailed_distance_nm": "2800",
+                "details_filename": "track.csv",
+            })
+        errs = validate_file_a(fa, expected_rows=1)
+        assert any("Bad datetime" in e.message for e in errs)
+
+    def test_nan_energy(self, tmp_path: Path):
+        fa = tmp_path / "IEUniversity-1-AGC_WPS.csv"
+        fa.parent.mkdir(parents=True, exist_ok=True)
+        with fa.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=_FILE_A_COLS)
+            writer.writeheader()
+            writer.writerow({
+                "departure_time_utc": "2024-01-01 12:00:00",
+                "arrival_time_utc": "2024-01-16 18:00:00",
+                "energy_cons_mwh": "nan",
+                "max_wind_mps": "5.0",
+                "max_hs_m": "2.0",
+                "sailed_distance_nm": "2800",
+                "details_filename": "track.csv",
+            })
+        errs = validate_file_a(fa, expected_rows=1)
+        assert any("NaN" in e.message for e in errs)
+
+    def test_naming_convention(self, tmp_path: Path):
+        fa = tmp_path / "wrong_name.csv"
+        _write_file_a(fa)
+        errs = validate_file_a(fa, expected_rows=2)
+        assert any("doesn't match pattern" in e.message for e in errs)
+
+
+# ---------------------------------------------------------------------------
+# validate_file_b
+# ---------------------------------------------------------------------------
+class TestValidateFileB:
+    def test_valid_file(self, tmp_path: Path):
+        fb = tmp_path / "track.csv"
+        _write_file_b(fb)
+        errs = validate_file_b(fb)
+        assert not errs, errs
+
+    def test_missing_file(self, tmp_path: Path):
+        fb = tmp_path / "missing.csv"
+        errs = validate_file_b(fb)
+        assert any("not found" in e.message for e in errs)
+
+    def test_too_few_waypoints(self, tmp_path: Path):
+        fb = tmp_path / "short.csv"
+        _write_file_b(fb, n_waypoints=1)
+        errs = validate_file_b(fb, min_waypoints=5)
+        assert any("waypoints" in e.message for e in errs)
+
+    def test_non_increasing_time(self, tmp_path: Path):
+        fb = tmp_path / "bad_time.csv"
+        fb.parent.mkdir(parents=True, exist_ok=True)
+        with fb.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=_FILE_B_COLS)
+            writer.writeheader()
+            writer.writerow({"time_utc": "2024-01-02 12:00:00", "lat_deg": "43", "lon_deg": "-4"})
+            writer.writerow({"time_utc": "2024-01-01 12:00:00", "lat_deg": "42", "lon_deg": "-5"})
+        errs = validate_file_b(fb)
+        assert any("not strictly increasing" in e.message for e in errs)
+
+    def test_lat_out_of_range(self, tmp_path: Path):
+        fb = tmp_path / "bad_lat.csv"
+        fb.parent.mkdir(parents=True, exist_ok=True)
+        with fb.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=_FILE_B_COLS)
+            writer.writeheader()
+            writer.writerow({"time_utc": "2024-01-01 12:00:00", "lat_deg": "100", "lon_deg": "-4"})
+        errs = validate_file_b(fb)
+        assert any("out of range" in e.message for e in errs)
+
+
+# ---------------------------------------------------------------------------
+# validate_case_pair_wps
+# ---------------------------------------------------------------------------
+class TestValidateCasePairWPS:
+    def test_wps_leq_nowps(self, tmp_path: Path):
+        """WPS energy ≤ noWPS → no errors."""
+        wps = tmp_path / "IEUniversity-1-AGC_WPS.csv"
+        nowps = tmp_path / "IEUniversity-1-AGC_noWPS.csv"
+        # WPS has lower energy
+        _write_file_a_custom(wps, [8.0, 9.0])
+        _write_file_a_custom(nowps, [10.0, 11.0])
+        errs = validate_case_pair_wps(wps, nowps)
+        assert not errs
+
+    def test_wps_greater_nowps(self, tmp_path: Path):
+        """WPS energy > noWPS → one error."""
+        wps = tmp_path / "IEUniversity-1-AGC_WPS.csv"
+        nowps = tmp_path / "IEUniversity-1-AGC_noWPS.csv"
+        _write_file_a_custom(wps, [12.0, 13.0])
+        _write_file_a_custom(nowps, [10.0, 11.0])
+        errs = validate_case_pair_wps(wps, nowps)
+        assert len(errs) == 1
+        assert "WPS energy > noWPS" in errs[0].message
+
+
+def _write_file_a_custom(path: Path, energies: list[float]) -> None:
+    """Helper: write File A with specified energies."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=_FILE_A_COLS)
+        writer.writeheader()
+        for i, e in enumerate(energies):
+            dep = _DEP + timedelta(days=i)
+            arr = dep + timedelta(hours=354)
+            writer.writerow({
+                "departure_time_utc": dep.strftime(_DTFMT),
+                "arrival_time_utc": arr.strftime(_DTFMT),
+                "energy_cons_mwh": f"{e:.6f}",
+                "max_wind_mps": "15.0000",
+                "max_hs_m": "3.0000",
+                "sailed_distance_nm": "2800.0000",
+                "details_filename": f"track_{i}.csv",
+            })
+
+
+# ---------------------------------------------------------------------------
+# validate_submission_dir (integration test)
+# ---------------------------------------------------------------------------
+class TestValidateSubmissionDir:
+    def test_empty_dir_reports_missing(self, tmp_path: Path):
+        errs = validate_submission_dir(tmp_path, expected_departures=2, verbose=False)
+        # Should report missing File A for all 8 cases
+        missing = [e for e in errs if "not found" in e.message]
+        assert len(missing) == 8

--- a/tests/test_swopp3_validate.py
+++ b/tests/test_swopp3_validate.py
@@ -222,6 +222,15 @@ class TestValidateCasePairWPS:
         assert len(errs) == 1
         assert "WPS energy > noWPS" in errs[0].message
 
+    def test_missing_file_returns_validation_error(self, tmp_path: Path):
+        """Missing input should be reported as ValidationError, not exception."""
+        wps = tmp_path / "IEUniversity-1-AGC_WPS.csv"
+        nowps = tmp_path / "IEUniversity-1-AGC_noWPS.csv"
+        _write_file_a_custom(wps, [12.0, 13.0])
+        errs = validate_case_pair_wps(wps, nowps)
+        assert len(errs) == 1
+        assert "Cannot load energies" in errs[0].message
+
 
 def _write_file_a_custom(path: Path, energies: list[float]) -> None:
     """Helper: write File A with specified energies."""
@@ -293,3 +302,12 @@ class TestValidateCasePairStrategy:
         assert (
             "worse" in errs[0].message.lower() or "optimised" in errs[0].message.lower()
         )
+
+    def test_missing_file_returns_validation_error(self, tmp_path: Path):
+        """Missing baseline file should be reported as ValidationError."""
+        opt = tmp_path / "opt.csv"
+        gc = tmp_path / "gc.csv"
+        _write_file_a_custom(opt, [90.0, 85.0, 80.0])
+        errs = validate_case_pair_strategy(opt, gc)
+        assert len(errs) == 1
+        assert "Cannot load energies" in errs[0].message

--- a/tests/test_swopp3_validate.py
+++ b/tests/test_swopp3_validate.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from routetools.swopp3_validate import (
-    ValidationError,
     validate_case_pair_strategy,
     validate_case_pair_wps,
     validate_file_a,


### PR DESCRIPTION
## Summary
Add SWOPP3 competition infrastructure (types, output formatting, validation).

### New files
- `routetools/swopp3.py`: Case definitions (8 cases: Atlantic/Pacific × WPS/noWPS × Optimized/GC), waypoint generation, departure dates (366 days of 2024), coordinate transforms
- `routetools/swopp3_output.py`: Generate submission CSV files matching SWOPP3 format (waypoints, timestamps, headings)
- `routetools/swopp3_validate.py`: Validate routes against SWOPP3 rules (fixed travel time, waypoint limits, great-circle deviation)
- `tests/test_swopp3.py`, `tests/test_swopp3_output.py`, `tests/test_swopp3_validate.py`

### Dependencies
- #41 (feat/era5) — for ERA5 loader
- #42 (feat/performance-model) — for RISE model
- #45 (feat/cost-improvements) — for RISE cost function

---
*Part 7 of 9 — extracted from vangelis branch for clean review*

---
Closes #24, #28
Relates to #26, #30