### PR TITLE
chore: fix hooks and ERA5 lint issues

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,8 @@
 
 This repository implements weather-routing optimization with JAX and CMA-ES. Keep changes focused, reproducible, and validated.
 
+Write and reason in English.
+
 ## Required Workflow
 
 1. Read relevant source files and matching tests before editing.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,34 @@
+# Copilot Instructions for routetools
+
+This repository implements weather-routing optimization with JAX and CMA-ES. Keep changes focused, reproducible, and validated.
+
+## Required Workflow
+
+1. Read relevant source files and matching tests before editing.
+2. Make the smallest change that satisfies the request.
+3. Add or update tests when behavior changes.
+4. After each update, run both commands:
+   - `make hooks`
+   - `make test`
+5. If either command fails, fix the issues and rerun both commands.
+6. Do not finalize work until both commands pass.
+
+## Code Conventions
+
+- Use the repository toolchain (`uv` via `make` targets).
+- Preserve existing public APIs unless the request explicitly requires a breaking change.
+- Follow `ruff` and `pytest` settings in `pyproject.toml`.
+- Keep docstrings in NumPy style for public functions.
+- Prefer vectorized/JAX-friendly implementations in performance-sensitive code paths.
+
+## Testing Conventions
+
+- Place tests in `tests/` near the relevant domain file.
+- For bug fixes, add a regression test first whenever practical.
+- Keep tests deterministic and lightweight unless a larger benchmark is explicitly requested.
+
+## Data and Artifacts
+
+- Do not commit large generated outputs.
+- Treat `data/` contents as potentially large and optional in local environments.
+- Fail with clear error messages when optional datasets are missing.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ JAX_PLATFORMS=cpu uv run scripts/single_run.py
 ### ERA5 weather data pipeline
 
 The `routetools.era5` module provides real-world ERA5 wind and wave fields
-for weather routing.  Two download backends are available:
+for weather routing. Two download backends are available:
 
 - **GCS** (default) — Google Cloud archive, no API key required.
 - **CDS** — Copernicus Climate Data Store (requires `cdsapi` + API key).

--- a/docs/parametric_model.md
+++ b/docs/parametric_model.md
@@ -7,20 +7,20 @@ from the SWOPP3 performance model binary (`swopp3_performance_model`).
 
 The SWOPP3 model exposes two scalar functions:
 
-| Function | Description |
-|----------|-------------|
-| `predict_no_wps(tws, twa, swh, mwa, v)` | Power without Wind Propulsion System |
+| Function                                  | Description                               |
+| ----------------------------------------- | ----------------------------------------- |
+| `predict_no_wps(tws, twa, swh, mwa, v)`   | Power without Wind Propulsion System      |
 | `predict_with_wps(tws, twa, swh, mwa, v)` | Power with Wind Propulsion System (sails) |
 
 Both return propulsion power in **kW** and accept:
 
-| Parameter | Symbol | Unit | Range |
-|-----------|--------|------|-------|
-| True wind speed | $\text{tws}$ | m/s | $[0, 30]$ |
-| True wind angle | $\text{twa}$ | deg | $[0, 180]$ (symmetric) |
-| Significant wave height | $\text{swh}$ | m | $[0, 10]$ |
-| Mean wave angle | $\text{mwa}$ | deg | $[0, 180]$ (symmetric) |
-| Ship speed | $v$ | m/s | $[0, 14.5]$ |
+| Parameter               | Symbol       | Unit | Range                  |
+| ----------------------- | ------------ | ---- | ---------------------- |
+| True wind speed         | $\text{tws}$ | m/s  | $[0, 30]$              |
+| True wind angle         | $\text{twa}$ | deg  | $[0, 180]$ (symmetric) |
+| Significant wave height | $\text{swh}$ | m    | $[0, 10]$              |
+| Mean wave angle         | $\text{mwa}$ | deg  | $[0, 180]$ (symmetric) |
+| Ship speed              | $v$          | m/s  | $[0, 14.5]$            |
 
 ## `predict_no_wps` — Closed-Form Model
 
@@ -56,8 +56,8 @@ where $\Delta$ is displacement and $L$ is the length of the vessel.
 
 **References:**
 
-- Molland, A.F., Turnock, S.R., Hudson, D.A. (2017). *Ship Resistance and Propulsion*, 2nd ed. Cambridge University Press. Chapter 3. [doi:10.1017/9781316494196](https://doi.org/10.1017/9781316494196)
-- Holtrop, J., Mennen, G.G.J. (1982). "An approximate power prediction method." *International Shipbuilding Progress*, 29(335), 166–170. [doi:10.3233/ISP-1982-2933501](https://doi.org/10.3233/ISP-1982-2933501)
+- Molland, A.F., Turnock, S.R., Hudson, D.A. (2017). _Ship Resistance and Propulsion_, 2nd ed. Cambridge University Press. Chapter 3. [doi:10.1017/9781316494196](https://doi.org/10.1017/9781316494196)
+- Holtrop, J., Mennen, G.G.J. (1982). "An approximate power prediction method." _International Shipbuilding Progress_, 29(335), 166–170. [doi:10.3233/ISP-1982-2933501](https://doi.org/10.3233/ISP-1982-2933501)
 
 ### Aerodynamic (Wind) Resistance
 
@@ -111,8 +111,8 @@ Here $C_X$ is the longitudinal aerodynamic force coefficient, $A_x$ is the proje
 
 **References:**
 
-- Blendermann, W. (1994). "Parameter identification of wind loads on ships." *Journal of Wind Engineering and Industrial Aerodynamics*, 51(3), 339–351. [doi:10.1016/0167-6105(94)90067-1](https://doi.org/10.1016/0167-6105(94)90067-1)
-- Fujiwara, T., Ueno, M., Nimura, T. (1998). "Estimation of wind forces and moments acting on ships." *Journal of the Society of Naval Architects of Japan*, 183, 77–90. [doi:10.2534/jjasnaoe1968.1998.77](https://doi.org/10.2534/jjasnaoe1968.1998.77)
+- Blendermann, W. (1994). "Parameter identification of wind loads on ships." _Journal of Wind Engineering and Industrial Aerodynamics_, 51(3), 339–351. [doi:10.1016/0167-6105(94)90067-1](<https://doi.org/10.1016/0167-6105(94)90067-1>)
+- Fujiwara, T., Ueno, M., Nimura, T. (1998). "Estimation of wind forces and moments acting on ships." _Journal of the Society of Naval Architects of Japan_, 183, 77–90. [doi:10.2534/jjasnaoe1968.1998.77](https://doi.org/10.2534/jjasnaoe1968.1998.77)
 - ITTC (2014). "Recommended Procedures and Guidelines: Speed and Power Trials." 7.5-04-01-01.1. [ittc.info](https://www.ittc.info/media/8370/75-04-01-011.pdf)
 
 ### Wave-Added Resistance
@@ -152,20 +152,20 @@ Quadratic dependence on wave height follows from linear wave theory, since wave 
 
 **References:**
 
-- Gerritsma, J., Beukelman, W. (1972). "Analysis of the resistance increase in waves of a fast cargo ship." *International Shipbuilding Progress*, 19(217), 285–293. [doi:10.3233/ISP-1972-1921701](https://journals.sagepub.com/doi/abs/10.3233/ISP-1972-1921701)
-- Salvesen, N. (1978). "Added resistance of ships in waves." *Journal of Hydronautics*, 12(1), 24–34. [doi:10.2514/3.63110](https://doi.org/10.2514/3.63110)
-- Faltinsen, O.M., Minsaas, K.J., Liapis, N., Skjørdal, S.O. (1980). "Prediction of resistance and propulsion of a ship in a seaway." *Proc. 13th Symposium on Naval Hydrodynamics*, Tokyo, 505–529. ([Google Scholar](https://scholar.google.com/scholar?q=%22Prediction+of+resistance+and+propulsion+of+a+ship+in+a+seaway%22+Faltinsen+1980) — conference proceedings, no DOI available)
+- Gerritsma, J., Beukelman, W. (1972). "Analysis of the resistance increase in waves of a fast cargo ship." _International Shipbuilding Progress_, 19(217), 285–293. [doi:10.3233/ISP-1972-1921701](https://journals.sagepub.com/doi/abs/10.3233/ISP-1972-1921701)
+- Salvesen, N. (1978). "Added resistance of ships in waves." _Journal of Hydronautics_, 12(1), 24–34. [doi:10.2514/3.63110](https://doi.org/10.2514/3.63110)
+- Faltinsen, O.M., Minsaas, K.J., Liapis, N., Skjørdal, S.O. (1980). "Prediction of resistance and propulsion of a ship in a seaway." _Proc. 13th Symposium on Naval Hydrodynamics_, Tokyo, 505–529. ([Google Scholar](https://scholar.google.com/scholar?q=%22Prediction+of+resistance+and+propulsion+of+a+ship+in+a+seaway%22+Faltinsen+1980) — conference proceedings, no DOI available)
 
 ### Accuracy
 
 Tested against the reference binary on 10,000 random inputs:
 
-| Metric | Value |
-|--------|-------|
+| Metric              | Value    |
+| ------------------- | -------- |
 | Mean absolute error | 0.008 kW |
-| p99 absolute error | 0.064 kW |
-| Max absolute error | 0.114 kW |
-| Max relative error | 0.031% |
+| p99 absolute error  | 0.064 kW |
+| Max absolute error  | 0.114 kW |
+| Max relative error  | 0.031%   |
 
 ---
 
@@ -239,26 +239,26 @@ the $A_w$ and $k_w$ constants in the wave term.
 
 Tested against the reference binary on 50,000 random inputs:
 
-| Metric | Value |
-|--------|-------|
-| Mean absolute error | 0.004 kW |
-| p99 absolute error | 0.030 kW |
-| Max absolute error | 0.050 kW |
-| Errors > 0.1 kW | 0 / 50,000 |
+| Metric              | Value      |
+| ------------------- | ---------- |
+| Mean absolute error | 0.004 kW   |
+| p99 absolute error  | 0.030 kW   |
+| Max absolute error  | 0.050 kW   |
+| Errors > 0.1 kW     | 0 / 50,000 |
 
 ---
 
 ## Summary of Constants
 
-| Constant | Symbol | Value | Exact |
-|----------|--------|-------|-------|
-| Hull coefficient | $K_h$ | 4.28761… | $969/226$ |
-| Air drag coefficient | $K_a$ | 0.153125 | $49/320$ |
-| Wave amplitude | $A_w$ | 11.1395 | fitted |
-| Wave directional decay | $k_w$ | 0.28935 | fitted |
-| Sail thrust coefficient | $K_s$ | 0.85903125 | exact |
-| Sail dead zone angle | — | 10° | exact |
-| Sail quadratic correction | — | 3/20 = 0.15 | exact |
+| Constant                  | Symbol | Value       | Exact     |
+| ------------------------- | ------ | ----------- | --------- |
+| Hull coefficient          | $K_h$  | 4.28761…    | $969/226$ |
+| Air drag coefficient      | $K_a$  | 0.153125    | $49/320$  |
+| Wave amplitude            | $A_w$  | 11.1395     | fitted    |
+| Wave directional decay    | $k_w$  | 0.28935     | fitted    |
+| Sail thrust coefficient   | $K_s$  | 0.85903125  | exact     |
+| Sail dead zone angle      | —      | 10°         | exact     |
+| Sail quadratic correction | —      | 3/20 = 0.15 | exact     |
 
 ## Clamping Rule
 

--- a/routetools/era5/__init__.py
+++ b/routetools/era5/__init__.py
@@ -18,8 +18,14 @@ JAX-compatible field closures matching the interface expected by
 
 from routetools.era5.loader import (
     load_era5_vectorfield as load_era5_vectorfield,
+)
+from routetools.era5.loader import (
     load_era5_wavefield as load_era5_wavefield,
+)
+from routetools.era5.loader import (
     load_era5_windfield as load_era5_windfield,
+)
+from routetools.era5.loader import (
     load_natural_earth_land_mask as load_natural_earth_land_mask,
 )
 

--- a/routetools/era5/download_cds.py
+++ b/routetools/era5/download_cds.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ DEFAULT_DAYS = [f"{d:02d}" for d in range(1, 32)]
 DEFAULT_TIMES = [f"{h:02d}:00" for h in range(0, 24, 6)]  # 6-hourly
 
 
-def _ensure_cdsapi() -> "cdsapi.Client":  # type: ignore[name-defined]
+def _ensure_cdsapi() -> Any:
     """Import and return a CDS API client, raising a clear error if missing."""
     try:
         import cdsapi

--- a/routetools/era5/download_gcs.py
+++ b/routetools/era5/download_gcs.py
@@ -14,15 +14,18 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    import xarray as xr
 
 logger = logging.getLogger(__name__)
 
 # Google Cloud Storage paths for ERA5 (ARCO-ERA5, 0.25° hourly)
 GCS_ERA5_SINGLE_LEVEL = (
-    "gs://gcp-public-data-arco-era5/ar/"
-    "full_37-1h-0p25deg-chunk-1.zarr-v3"
+    "gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3"
 )
 
 # Route corridor bounds: {name: (lat_min, lat_max, lon_min, lon_max)}
@@ -55,7 +58,7 @@ def _ensure_deps() -> None:
         )
 
 
-def _open_era5_zarr(variables: list[str]) -> "xarray.Dataset":  # type: ignore[name-defined]
+def _open_era5_zarr(variables: list[str]) -> xr.Dataset:
     """Open the ERA5 Zarr store on GCS and select the given variables."""
     import gcsfs
     import xarray as xr
@@ -67,11 +70,11 @@ def _open_era5_zarr(variables: list[str]) -> "xarray.Dataset":  # type: ignore[n
 
 
 def _select_corridor(
-    ds: "xarray.Dataset",  # type: ignore[name-defined]
+    ds: xr.Dataset,
     corridor: str,
     year: str = "2024",
     time_step: int = 6,
-) -> "xarray.Dataset":  # type: ignore[name-defined]
+) -> xr.Dataset:
     """Subset dataset to a corridor, year, and temporal step.
 
     Parameters
@@ -121,12 +124,8 @@ def _select_corridor(
         import xarray as xr
 
         lon_min_360 = lon_min % 360  # -80 → 280
-        part_west = ds.sel(
-            {lat_dim: lat_slice, lon_dim: slice(lon_min_360, 360.0)}
-        )
-        part_east = ds.sel(
-            {lat_dim: lat_slice, lon_dim: slice(0.0, lon_max)}
-        )
+        part_west = ds.sel({lat_dim: lat_slice, lon_dim: slice(lon_min_360, 360.0)})
+        part_east = ds.sel({lat_dim: lat_slice, lon_dim: slice(0.0, lon_max)})
         ds = xr.concat([part_west, part_east], dim=lon_dim)
         # Relabel longitudes to [-180, 180) convention
         new_lons = ds[lon_dim].values.copy()
@@ -139,14 +138,10 @@ def _select_corridor(
             ds = ds.assign_coords({lon_dim: np.mod(lons, 360)})
             ds = ds.sortby(lon_dim)
 
-        ds = ds.sel(
-            {lat_dim: lat_slice, lon_dim: slice(lon_min, lon_max)}
-        )
+        ds = ds.sel({lat_dim: lat_slice, lon_dim: slice(lon_min, lon_max)})
     else:
         # Both corridor and dataset are in compatible ranges
-        ds = ds.sel(
-            {lat_dim: lat_slice, lon_dim: slice(lon_min, lon_max)}
-        )
+        ds = ds.sel({lat_dim: lat_slice, lon_dim: slice(lon_min, lon_max)})
 
     return ds
 
@@ -266,13 +261,17 @@ def download_all_gcs(
     for corridor in corridors:
         files.append(
             download_era5_wind_gcs(
-                output_dir=output_dir, corridor=corridor, year=year,
+                output_dir=output_dir,
+                corridor=corridor,
+                year=year,
                 time_step=time_step,
             )
         )
         files.append(
             download_era5_waves_gcs(
-                output_dir=output_dir, corridor=corridor, year=year,
+                output_dir=output_dir,
+                corridor=corridor,
+                year=year,
                 time_step=time_step,
             )
         )

--- a/routetools/era5/loader.py
+++ b/routetools/era5/loader.py
@@ -24,6 +24,7 @@ from collections.abc import Callable
 from datetime import datetime
 from math import ceil
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
@@ -31,6 +32,9 @@ import numpy as np
 import xarray as xr
 
 from routetools.vectorfield import time_variant
+
+if TYPE_CHECKING:
+    from routetools.land import Land
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +73,7 @@ def _get_coord_name(ds: xr.Dataset, candidates: list[str]) -> str:
         if name in ds.coords or name in ds.dims:
             return name
     raise KeyError(
-        f"None of {candidates} found in dataset coordinates: "
-        f"{list(ds.coords)}"
+        f"None of {candidates} found in dataset coordinates: {list(ds.coords)}"
     )
 
 
@@ -113,13 +116,9 @@ def _prepare_grid(
 
     # Compute departure offset
     if departure_time is not None:
-        if isinstance(departure_time, str):
+        if isinstance(departure_time, str | datetime):
             departure_time = np.datetime64(departure_time)
-        elif isinstance(departure_time, datetime):
-            departure_time = np.datetime64(departure_time)
-        departure_offset_h = float(
-            (departure_time - t0_np) / np.timedelta64(1, "h")
-        )
+        departure_offset_h = float((departure_time - t0_np) / np.timedelta64(1, "h"))
     else:
         departure_offset_h = 0.0
 
@@ -128,9 +127,7 @@ def _prepare_grid(
     dlat = float(lats[1] - lats[0]) if len(lats) > 1 else 1.0
     dlon = float(lons[1] - lons[0]) if len(lons) > 1 else 1.0
 
-    begin = jnp.array(
-        [times_hours[0], lats[0], lons[0]], dtype=jnp.float32
-    )[None, :]
+    begin = jnp.array([times_hours[0], lats[0], lons[0]], dtype=jnp.float32)[None, :]
     spacing = jnp.array([dt, dlat, dlon], dtype=jnp.float32)[None, :]
 
     return {
@@ -191,7 +188,7 @@ def _build_field_closure(
         ts: jnp.ndarray | int | float,
     ) -> tuple[jnp.ndarray, jnp.ndarray]:
         # Normalise ts
-        if isinstance(ts, (int, float)):
+        if isinstance(ts, int | float):
             ts = jnp.array([ts], dtype=jnp.float32)
         ts = jnp.atleast_1d(ts)
 
@@ -225,12 +222,8 @@ def _build_field_closure(
         coords = (x - begin) / spacing  # shape (N, 3)
 
         # Interpolate
-        a = jax.scipy.ndimage.map_coordinates(
-            data_a, coords.T, order=order, mode=mode
-        )
-        b = jax.scipy.ndimage.map_coordinates(
-            data_b, coords.T, order=order, mode=mode
-        )
+        a = jax.scipy.ndimage.map_coordinates(data_a, coords.T, order=order, mode=mode)
+        b = jax.scipy.ndimage.map_coordinates(data_b, coords.T, order=order, mode=mode)
 
         # Reshape if needed
         if shape is not None:
@@ -314,7 +307,6 @@ def load_era5_windfield(
     ds = grid["ds"]  # use the reindexed dataset from _prepare_grid
 
     # Extract data as JAX arrays: shape (T, lat, lon)
-    lat_name = grid["lat_name"]
     udata = ds[u_var]
     vdata = ds[v_var]
 
@@ -369,8 +361,11 @@ def load_era5_vectorfield(
     See :func:`load_era5_windfield` for parameter docs.
     """
     return load_era5_windfield(
-        path, departure_time=departure_time, order=order,
-        u_var=u_var, v_var=v_var,
+        path,
+        departure_time=departure_time,
+        order=order,
+        u_var=u_var,
+        v_var=v_var,
     )
 
 
@@ -445,7 +440,6 @@ def load_era5_wavefield(
     grid = _prepare_grid(ds, departure_time)
     ds = grid["ds"]  # use the reindexed dataset from _prepare_grid
 
-    lat_name = grid["lat_name"]
     hsdata = ds[hs_var]
     dirdata = ds[dir_var]
 
@@ -485,7 +479,7 @@ def load_era5_wavefield(
 def load_era5_land_mask(
     wave_path: str | Path,
     hs_var: str | None = None,
-) -> "Land":
+) -> Land:
     """Create a :class:`~routetools.land.Land` mask from ERA5 wave NaN values.
 
     ERA5 wave variables (SWH, MWD) are NaN over land.  This function
@@ -543,9 +537,7 @@ def load_era5_land_mask(
         ds = ds.isel({lon_name: slice(None, None, -1)})
 
     # First timestep of wave height: NaN → land
-    hs_t0 = ds[hs_var].isel(
-        {_get_coord_name(ds, ["time", "valid_time"]): 0}
-    ).values
+    hs_t0 = ds[hs_var].isel({_get_coord_name(ds, ["time", "valid_time"]): 0}).values
 
     ds.close()
 
@@ -579,7 +571,7 @@ def load_era5_land_mask(
     land.random_seed = None
     land.water_level = 0.5
     land.shape = land_array.shape
-    land.interpolate = 10       # insert 10 sub-points between waypoints to catch narrow land
+    land.interpolate = 10  # insert 10 sub-points between waypoints to catch narrow land
     land.outbounds_is_land = True
     land.penalize_segments = False
     land._map_mode = "nearest"
@@ -598,8 +590,14 @@ def load_era5_land_mask(
     logger.info(
         "ERA5 land mask: %d/%d cells are land (%.1f%%), "
         "lon=[%.1f, %.1f], lat=[%.1f, %.1f], shape=%s",
-        n_land, n_total, 100 * n_land / n_total,
-        lon_min, lon_max, lat_min, lat_max, land_array.shape,
+        n_land,
+        n_total,
+        100 * n_land / n_total,
+        lon_min,
+        lon_max,
+        lat_min,
+        lat_max,
+        land_array.shape,
     )
 
     return land
@@ -611,7 +609,7 @@ def load_natural_earth_land_mask(
     resolution: float = 0.01,
     ne_resolution: str = "10m",
     interpolate: int = 50,
-) -> "Land":
+) -> Land:
     """Create a high-resolution land mask from Natural Earth shapefiles.
 
     Uses cartopy's Natural Earth 1:10m land polygons rasterized onto a
@@ -653,7 +651,6 @@ def load_natural_earth_land_mask(
 
     try:
         import rasterio  # noqa: F401 — validate availability early
-        from rasterio import features, transform
     except ImportError as exc:
         raise ImportError(
             "Natural Earth land mask requires rasterio. "
@@ -779,9 +776,16 @@ def load_natural_earth_land_mask(
     logger.info(
         "Natural Earth land mask (%s): %d/%d cells are land (%.1f%%), "
         "lon=[%.1f, %.1f], lat=[%.1f, %.1f], res=%.3f°, shape=%s",
-        ne_resolution, n_land, n_total, 100 * n_land / n_total,
-        lon_min, lon_max, lat_min, lat_max, resolution, land_array.shape,
+        ne_resolution,
+        n_land,
+        n_total,
+        100 * n_land / n_total,
+        lon_min,
+        lon_max,
+        lat_min,
+        lat_max,
+        resolution,
+        land_array.shape,
     )
 
     return land
-

--- a/routetools/era5/loader.py
+++ b/routetools/era5/loader.py
@@ -188,7 +188,7 @@ def _build_field_closure(
         ts: jnp.ndarray | int | float,
     ) -> tuple[jnp.ndarray, jnp.ndarray]:
         # Normalise ts
-        if isinstance(ts, int | float):
+        if isinstance(ts, (int, float)):
             ts = jnp.array([ts], dtype=jnp.float32)
         ts = jnp.atleast_1d(ts)
 

--- a/routetools/era5/loader.py
+++ b/routetools/era5/loader.py
@@ -116,7 +116,7 @@ def _prepare_grid(
 
     # Compute departure offset
     if departure_time is not None:
-        if isinstance(departure_time, (str, datetime)):
+        if isinstance(departure_time, str | datetime):
             departure_time = np.datetime64(departure_time)
         departure_offset_h = float((departure_time - t0_np) / np.timedelta64(1, "h"))
     else:
@@ -188,7 +188,7 @@ def _build_field_closure(
         ts: jnp.ndarray | int | float,
     ) -> tuple[jnp.ndarray, jnp.ndarray]:
         # Normalise ts
-        if isinstance(ts, (int, float)):
+        if isinstance(ts, int | float):
             ts = jnp.array([ts], dtype=jnp.float32)
         ts = jnp.atleast_1d(ts)
 

--- a/routetools/era5/loader.py
+++ b/routetools/era5/loader.py
@@ -116,7 +116,7 @@ def _prepare_grid(
 
     # Compute departure offset
     if departure_time is not None:
-        if isinstance(departure_time, str | datetime):
+        if isinstance(departure_time, (str, datetime)):
             departure_time = np.datetime64(departure_time)
         departure_offset_h = float((departure_time - t0_np) / np.timedelta64(1, "h"))
     else:

--- a/routetools/performance.py
+++ b/routetools/performance.py
@@ -74,10 +74,16 @@ K_H: float = 969 / 226
 """Hull drag coefficient (≈ 4.28761).  ``P_hull = K_H · v³``."""
 
 K_A: float = 49 / 320
-"""Aerodynamic drag coefficient (≈ 0.153125).  ``P_wind = K_A · v · (VR · u_x − v²)``."""
+"""Aerodynamic drag coefficient (≈ 0.153125).
+
+``P_wind = K_A · v · (VR · u_x − v²)``.
+"""
 
 A_W: float = 11.1395
-"""Wave added-resistance amplitude (exact).  ``P_wave = A_W · SWH² · v^{1.5} · exp(…)``."""
+"""Wave added-resistance amplitude (exact).
+
+``P_wave = A_W · SWH² · v^{1.5} · exp(…)``.
+"""
 
 K_W: float = 0.28935
 """Wave directional decay rate.  ``exp(−K_W · |MWA_rad|³)``."""

--- a/routetools/weather.py
+++ b/routetools/weather.py
@@ -117,8 +117,10 @@ def _segment_midpoints(
     # Compute segment distances
     if spherical_correction:
         dx, dy = haversine_meters_components(
-            curve[:, :-1, 1], curve[:, :-1, 0],
-            curve[:, 1:, 1], curve[:, 1:, 0],
+            curve[:, :-1, 1],
+            curve[:, :-1, 0],
+            curve[:, 1:, 1],
+            curve[:, 1:, 0],
         )
     else:
         dx = jnp.diff(curve[:, :, 0], axis=1)
@@ -209,7 +211,9 @@ def evaluate_weather(
 
     # Midpoints of each segment
     mid_lon, mid_lat, t_mid = _segment_midpoints(
-        curve, travel_stw=travel_stw, travel_time=travel_time,
+        curve,
+        travel_stw=travel_stw,
+        travel_time=travel_time,
         spherical_correction=spherical_correction,
     )
 
@@ -291,7 +295,9 @@ def weather_penalty(
         Penalty per route, shape ``(B,)``.
     """
     mid_lon, mid_lat, t_mid = _segment_midpoints(
-        curve, travel_stw=travel_stw, travel_time=travel_time,
+        curve,
+        travel_stw=travel_stw,
+        travel_time=travel_time,
         spherical_correction=spherical_correction,
     )
 
@@ -370,7 +376,9 @@ def weather_penalty_smooth(
         Smooth penalty per route, shape ``(B,)``.
     """
     mid_lon, mid_lat, t_mid = _segment_midpoints(
-        curve, travel_stw=travel_stw, travel_time=travel_time,
+        curve,
+        travel_stw=travel_stw,
+        travel_time=travel_time,
         spherical_correction=spherical_correction,
     )
 

--- a/routetools/wrr_bench/__init__.py
+++ b/routetools/wrr_bench/__init__.py
@@ -10,14 +10,14 @@
 
 import warnings
 
+from routetools.wrr_bench.load import load_real_instance
+from routetools.wrr_bench.ocean import Ocean
+
 warnings.warn(
     "routetools.wrr_bench is deprecated and will be removed in a future release. "
     "Use routetools.era5 instead for real-world weather data.",
     DeprecationWarning,
     stacklevel=2,
 )
-
-from routetools.wrr_bench.load import load_real_instance
-from routetools.wrr_bench.ocean import Ocean
 
 __all__ = ["load_real_instance", "Ocean"]

--- a/routetools/wrr_bench/__init__.py
+++ b/routetools/wrr_bench/__init__.py
@@ -10,14 +10,14 @@
 
 import warnings
 
-from routetools.wrr_bench.load import load_real_instance
-from routetools.wrr_bench.ocean import Ocean
-
 warnings.warn(
     "routetools.wrr_bench is deprecated and will be removed in a future release. "
     "Use routetools.era5 instead for real-world weather data.",
     DeprecationWarning,
     stacklevel=2,
 )
+
+from routetools.wrr_bench.load import load_real_instance  # noqa: E402
+from routetools.wrr_bench.ocean import Ocean  # noqa: E402
 
 __all__ = ["load_real_instance", "Ocean"]

--- a/scripts/download_era5.py
+++ b/scripts/download_era5.py
@@ -60,6 +60,7 @@ CORRIDORS = ("atlantic", "pacific")
 
 
 def main() -> None:
+    """Parse CLI arguments and download ERA5 files for selected corridors."""
     parser = argparse.ArgumentParser(
         description="Download ERA5 wind and wave data for SWOPP3 corridors.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -100,7 +101,10 @@ def main() -> None:
 
     logger.info(
         "Backend=%s  Year=%s  Corridors=%s  Output=%s",
-        args.backend, args.year, corridors, output_dir,
+        args.backend,
+        args.year,
+        corridors,
+        output_dir,
     )
 
     if args.backend == "gcs":

--- a/scripts/era5_benchmark.py
+++ b/scripts/era5_benchmark.py
@@ -111,7 +111,7 @@ def main() -> None:
 
     # ── Load ERA5 fields ──────────────────────────────────────────────
     print(f"[ERA5] Loading wind from {wind_file}")
-    load_era5_windfield(wind_file, departure_time=args.departure)
+    windfield = load_era5_windfield(wind_file, departure_time=args.departure)
 
     print(f"[ERA5] Loading waves from {wave_file}")
     wavefield = load_era5_wavefield(wave_file, departure_time=args.departure)

--- a/scripts/era5_benchmark.py
+++ b/scripts/era5_benchmark.py
@@ -141,6 +141,7 @@ def main() -> None:
         dst=dst,
         land=land,
         wavefield=wavefield,
+        windfield=windfield,
         travel_stw=args.vel_ship,
         travel_time=None,
         penalty=1e10,

--- a/scripts/era5_benchmark.py
+++ b/scripts/era5_benchmark.py
@@ -39,9 +39,9 @@ from pathlib import Path
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 
+from routetools._ports import DICT_PORTS
 from routetools.cmaes import optimize
 from routetools.cost import haversine_distance_from_curve
-from routetools._ports import DICT_PORTS
 from routetools.era5 import (
     load_era5_wavefield,
     load_era5_windfield,
@@ -52,6 +52,7 @@ from routetools.plot import plot_curve
 
 
 def main() -> None:
+    """Run an end-to-end ERA5 benchmark from USNYC to DEHAM."""
     parser = argparse.ArgumentParser(
         description="ERA5-based benchmark: USNYC → DEHAM.",
     )
@@ -110,7 +111,7 @@ def main() -> None:
 
     # ── Load ERA5 fields ──────────────────────────────────────────────
     print(f"[ERA5] Loading wind from {wind_file}")
-    windfield = load_era5_windfield(wind_file, departure_time=args.departure)
+    load_era5_windfield(wind_file, departure_time=args.departure)
 
     print(f"[ERA5] Loading waves from {wave_file}")
     wavefield = load_era5_wavefield(wave_file, departure_time=args.departure)
@@ -186,9 +187,7 @@ def main() -> None:
     print(f"\n{'Route':<12} {'Cost (h)':>10} {'Distance (km)':>14}")
     print("-" * 38)
     print(f"{'CMA-ES':<12} {dict_cmaes['cost'] / 3600:>10.1f} {dist_cmaes:>14.0f}")
-    print(
-        f"{'FMS':<12} {sum(dict_fms['cost']) / 3600:>10.1f} {dist_fms:>14.0f}"
-    )
+    print(f"{'FMS':<12} {sum(dict_fms['cost']) / 3600:>10.1f} {dist_fms:>14.0f}")
 
     # ── Plot ─────────────────────────────────────────────────────────
     fig, ax = plot_curve(

--- a/scripts/parametric_benchmark.py
+++ b/scripts/parametric_benchmark.py
@@ -24,11 +24,15 @@ except ImportError:
     sys.exit(1)
 
 from routetools.performance import (
+    A_W,
     K_A,
     K_H,
     K_W,
-    A_W,
+)
+from routetools.performance import (
     predict_power_no_wps as parametric_no_wps,
+)
+from routetools.performance import (
     predict_power_with_wps as parametric_with_wps,
 )
 
@@ -37,6 +41,7 @@ from routetools.performance import (
 # Helpers
 # -----------------------------------------------------------------------
 def error_stats(errs: np.ndarray) -> dict[str, float]:
+    """Return aggregate statistics for an array of absolute or relative errors."""
     return {
         "mean": float(np.mean(errs)),
         "std": float(np.std(errs)),
@@ -48,6 +53,7 @@ def error_stats(errs: np.ndarray) -> dict[str, float]:
 
 
 def print_stats(label: str, stats: dict[str, float]) -> None:
+    """Print a compact one-line summary of precomputed error statistics."""
     print(f"  {label}:")
     print(
         f"    mean={stats['mean']:.6f}  std={stats['std']:.6f}  "
@@ -60,6 +66,7 @@ def print_stats(label: str, stats: dict[str, float]) -> None:
 # Benchmark routines
 # -----------------------------------------------------------------------
 def benchmark_no_wps(n: int = 10_000, seed: int = 42) -> None:
+    """Benchmark no-WPS parametric predictions against SWOPP3 reference."""
     print(f"\n{'=' * 72}")
     print(f"  predict_no_wps  —  {n:,} random samples  (seed={seed})")
     print(f"{'=' * 72}")
@@ -90,9 +97,11 @@ def benchmark_no_wps(n: int = 10_000, seed: int = 42) -> None:
     rel_errs = np.full(n, np.nan)
     rel_errs[mask] = abs_errs[mask] / refs[mask] * 100  # percent
 
-    print(f"\n  Timing:  reference {t_ref:.3f}s ({t_ref/n*1e6:.1f} µs/call)  |  "
-          f"parametric {t_par:.3f}s ({t_par/n*1e6:.1f} µs/call)")
-    print(f"\n  Absolute error (kW):")
+    print(
+        f"\n  Timing:  reference {t_ref:.3f}s ({t_ref / n * 1e6:.1f} µs/call)  |  "
+        f"parametric {t_par:.3f}s ({t_par / n * 1e6:.1f} µs/call)"
+    )
+    print("\n  Absolute error (kW):")
     print_stats("all", error_stats(abs_errs))
     if mask.sum() > 0:
         print(f"\n  Relative error (%, where ref > 1 kW, n={mask.sum():,}):")
@@ -100,9 +109,11 @@ def benchmark_no_wps(n: int = 10_000, seed: int = 42) -> None:
 
     # Worst cases
     worst_idx = np.argsort(abs_errs)[-5:][::-1]
-    print(f"\n  Top-5 worst absolute errors:")
-    print(f"    {'TWS':>6} {'TWA':>6} {'SWH':>6} {'MWA':>6} {'V':>6}  "
-          f"{'Ref':>10} {'Par':>10} {'Err':>10}")
+    print("\n  Top-5 worst absolute errors:")
+    print(
+        f"    {'TWS':>6} {'TWA':>6} {'SWH':>6} {'MWA':>6} {'V':>6}  "
+        f"{'Ref':>10} {'Par':>10} {'Err':>10}"
+    )
     for idx in worst_idx:
         print(
             f"    {tws[idx]:6.2f} {twa[idx]:6.1f} {swh[idx]:6.2f} "
@@ -113,17 +124,18 @@ def benchmark_no_wps(n: int = 10_000, seed: int = 42) -> None:
     n_exact = np.sum(abs_errs < 0.001)
     n_good = np.sum(abs_errs < 0.01)
     n_ok = np.sum(abs_errs < 0.1)
-    print(f"\n  Error distribution:")
-    print(f"    < 0.001 kW : {n_exact:6,} / {n:,}  ({n_exact/n*100:.1f}%)")
-    print(f"    < 0.01  kW : {n_good:6,} / {n:,}  ({n_good/n*100:.1f}%)")
-    print(f"    < 0.1   kW : {n_ok:6,} / {n:,}  ({n_ok/n*100:.1f}%)")
-    print(f"    ≥ 0.1   kW : {n - n_ok:6,} / {n:,}  ({(n - n_ok)/n*100:.1f}%)")
+    print("\n  Error distribution:")
+    print(f"    < 0.001 kW : {n_exact:6,} / {n:,}  ({n_exact / n * 100:.1f}%)")
+    print(f"    < 0.01  kW : {n_good:6,} / {n:,}  ({n_good / n * 100:.1f}%)")
+    print(f"    < 0.1   kW : {n_ok:6,} / {n:,}  ({n_ok / n * 100:.1f}%)")
+    print(f"    ≥ 0.1   kW : {n - n_ok:6,} / {n:,}  ({(n - n_ok) / n * 100:.1f}%)")
 
 
 def benchmark_with_wps(
     n: int = 10_000,
     seed: int = 99,
 ) -> None:
+    """Benchmark with-WPS parametric predictions against SWOPP3 reference."""
     print(f"\n{'=' * 72}")
     print(f"  predict_with_wps  —  {n:,} random samples  (seed={seed})")
     print(f"{'=' * 72}")
@@ -146,7 +158,11 @@ def benchmark_with_wps(
     t0 = time.perf_counter()
     for i in range(n):
         pars[i] = parametric_with_wps(
-            tws[i], twa[i], swh[i], mwa[i], v[i],
+            tws[i],
+            twa[i],
+            swh[i],
+            mwa[i],
+            v[i],
         )
     t_par = time.perf_counter() - t0
 
@@ -155,18 +171,22 @@ def benchmark_with_wps(
     rel_errs = np.full(n, np.nan)
     rel_errs[mask] = abs_errs[mask] / refs[mask] * 100
 
-    print(f"\n  Timing:  reference {t_ref:.3f}s ({t_ref/n*1e6:.1f} µs/call)  |  "
-          f"parametric {t_par:.3f}s ({t_par/n*1e6:.1f} µs/call)")
-    print(f"\n  Absolute error (kW):")
+    print(
+        f"\n  Timing:  reference {t_ref:.3f}s ({t_ref / n * 1e6:.1f} µs/call)  |  "
+        f"parametric {t_par:.3f}s ({t_par / n * 1e6:.1f} µs/call)"
+    )
+    print("\n  Absolute error (kW):")
     print_stats("all", error_stats(abs_errs))
     if mask.sum() > 0:
         print(f"\n  Relative error (%, where ref > 1 kW, n={mask.sum():,}):")
         print_stats("filtered", error_stats(rel_errs[mask]))
 
     worst_idx = np.argsort(abs_errs)[-5:][::-1]
-    print(f"\n  Top-5 worst absolute errors:")
-    print(f"    {'TWS':>6} {'TWA':>6} {'SWH':>6} {'MWA':>6} {'V':>6}  "
-          f"{'Ref':>10} {'Par':>10} {'Err':>10}")
+    print("\n  Top-5 worst absolute errors:")
+    print(
+        f"    {'TWS':>6} {'TWA':>6} {'SWH':>6} {'MWA':>6} {'V':>6}  "
+        f"{'Ref':>10} {'Par':>10} {'Err':>10}"
+    )
     for idx in worst_idx:
         print(
             f"    {tws[idx]:6.2f} {twa[idx]:6.1f} {swh[idx]:6.2f} "
@@ -177,17 +197,17 @@ def benchmark_with_wps(
     n_exact = np.sum(abs_errs < 0.01)
     n_good = np.sum(abs_errs < 0.1)
     n_ok = np.sum(abs_errs < 1.0)
-    print(f"\n  Error distribution:")
-    print(f"    < 0.01 kW : {n_exact:6,} / {n:,}  ({n_exact/n*100:.1f}%)")
-    print(f"    < 0.1  kW : {n_good:6,} / {n:,}  ({n_good/n*100:.1f}%)")
-    print(f"    < 1.0  kW : {n_ok:6,} / {n:,}  ({n_ok/n*100:.1f}%)")
-    print(f"    ≥ 1.0  kW : {n - n_ok:6,} / {n:,}  ({(n - n_ok)/n*100:.1f}%)")
+    print("\n  Error distribution:")
+    print(f"    < 0.01 kW : {n_exact:6,} / {n:,}  ({n_exact / n * 100:.1f}%)")
+    print(f"    < 0.1  kW : {n_good:6,} / {n:,}  ({n_good / n * 100:.1f}%)")
+    print(f"    < 1.0  kW : {n_ok:6,} / {n:,}  ({n_ok / n * 100:.1f}%)")
+    print(f"    ≥ 1.0  kW : {n - n_ok:6,} / {n:,}  ({(n - n_ok) / n * 100:.1f}%)")
 
 
 def benchmark_component_breakdown() -> None:
     """Show per-component accuracy vs reference decomposition."""
     print(f"\n{'=' * 72}")
-    print(f"  Component breakdown (hull / wind / wave)")
+    print("  Component breakdown (hull / wind / wave)")
     print(f"{'=' * 72}")
 
     speeds = [2, 4, 6, 8, 10, 12, 14]
@@ -198,12 +218,17 @@ def benchmark_component_breakdown() -> None:
     for v in speeds:
         ref = predict_no_wps(0, 0, 0, 0, v)
         par = K_H * v**3
-        print(f"    {v:5.1f}  {ref:10.4f}  {par:10.4f}  {abs(par - ref):10.6f}  "
-              f"{ref / v**3 if v > 0 else 0:10.6f}")
+        print(
+            f"    {v:5.1f}  {ref:10.4f}  {par:10.4f}  {abs(par - ref):10.6f}  "
+            f"{ref / v**3 if v > 0 else 0:10.6f}"
+        )
 
     # Wind (TWA sweep at fixed tws=15, v=8)
     print(f"\n  Wind: K_a · v · (VR·ux − v²)   (K_a = {K_A:.6f})")
-    print(f"    {'TWA':>5}  {'TWS':>5}  {'V':>5}  {'Ref_wind':>10}  {'Par_wind':>10}  {'Err':>10}")
+    print(
+        f"    {'TWA':>5}  {'TWS':>5}  {'V':>5}  "
+        f"{'Ref_wind':>10}  {'Par_wind':>10}  {'Err':>10}"
+    )
     tws_test, v_test = 15.0, 8.0
     p_hull = predict_no_wps(0, 0, 0, 0, v_test)
     for twa in [0, 30, 60, 90, 120, 150, 180]:
@@ -214,35 +239,39 @@ def benchmark_component_breakdown() -> None:
         total_ref = predict_no_wps(tws_test, twa, 0, 0, v_test)
         # If the model clamps total power at zero (strong tailwind),
         # the decomposition total = hull + wind is invalid.
-        if total_ref > 0.0:
-            ref_wind = total_ref - p_hull
-        else:
-            ref_wind = float("nan")
+        ref_wind = total_ref - p_hull if total_ref > 0.0 else float("nan")
         par_wind = K_A * v_test * (vr * ux - v_test**2)
-        print(f"    {twa:5}  {tws_test:5.0f}  {v_test:5.0f}  {ref_wind:10.4f}  "
-              f"{par_wind:10.4f}  {abs(par_wind - ref_wind):10.6f}")
+        print(
+            f"    {twa:5}  {tws_test:5.0f}  {v_test:5.0f}  {ref_wind:10.4f}  "
+            f"{par_wind:10.4f}  {abs(par_wind - ref_wind):10.6f}"
+        )
 
     # Wave (MWA sweep at fixed swh=3, v=8)
-    print(f"\n  Wave: A_w·swh²·v^1.5·exp(−k_w·|mwa|³)")
+    print("\n  Wave: A_w·swh²·v^1.5·exp(−k_w·|mwa|³)")
     print(f"    A_w = {A_W:.4f},  k_w = {K_W:.5f}")
-    print(f"    {'MWA':>5}  {'SWH':>5}  {'V':>5}  {'Ref_wave':>10}  {'Par_wave':>10}  {'Err':>10}")
+    print(
+        f"    {'MWA':>5}  {'SWH':>5}  {'V':>5}  "
+        f"{'Ref_wave':>10}  {'Par_wave':>10}  {'Err':>10}"
+    )
     swh_test, v_test2 = 3.0, 8.0
     p_hull2 = predict_no_wps(0, 0, 0, 0, v_test2)
     for mwa in [0, 20, 40, 60, 80, 100, 120, 140, 160, 180]:
         mwa_rad = np.radians(mwa)
         ref_wave = predict_no_wps(0, 0, swh_test, mwa, v_test2) - p_hull2
-        par_wave = A_W * swh_test**2 * v_test2**1.5 * np.exp(-K_W * abs(mwa_rad)**3)
-        print(f"    {mwa:5}  {swh_test:5.0f}  {v_test2:5.0f}  {ref_wave:10.4f}  "
-              f"{par_wave:10.4f}  {abs(par_wave - ref_wave):10.6f}")
+        par_wave = A_W * swh_test**2 * v_test2**1.5 * np.exp(-K_W * abs(mwa_rad) ** 3)
+        print(
+            f"    {mwa:5}  {swh_test:5.0f}  {v_test2:5.0f}  {ref_wave:10.4f}  "
+            f"{par_wave:10.4f}  {abs(par_wave - ref_wave):10.6f}"
+        )
 
 
 def benchmark_sail_savings() -> None:
     """Show sail power savings across conditions."""
     print(f"\n{'=' * 72}")
-    print(f"  Sail power savings P_sail = P_no_wps − P_with_wps")
+    print("  Sail power savings P_sail = P_no_wps − P_with_wps")
     print(f"{'=' * 72}")
 
-    print(f"\n  P_sail at v=8 m/s, varying TWS and TWA:")
+    print("\n  P_sail at v=8 m/s, varying TWS and TWA:")
     print(f"    {'TWS':>5}  " + "  ".join(f"TWA={t:>3}°" for t in range(0, 181, 30)))
     for tws in [0, 5, 10, 15, 20, 25, 30]:
         row = f"    {tws:5}"
@@ -253,7 +282,7 @@ def benchmark_sail_savings() -> None:
             row += f"  {p_sail:8.1f}"
         print(row)
 
-    print(f"\n  Savings % at v=8 m/s (where P_no_wps > 0):")
+    print("\n  Savings % at v=8 m/s (where P_no_wps > 0):")
     print(f"    {'TWS':>5}  " + "  ".join(f"TWA={t:>3}°" for t in range(0, 181, 30)))
     for tws in [5, 10, 15, 20, 25, 30]:
         row = f"    {tws:5}"
@@ -264,7 +293,7 @@ def benchmark_sail_savings() -> None:
                 pct = (p_no - p_wp) / p_no * 100
                 row += f"  {pct:7.1f}%"
             else:
-                row += f"       n/a"
+                row += "       n/a"
         print(row)
 
 
@@ -272,6 +301,7 @@ def benchmark_sail_savings() -> None:
 # Main
 # -----------------------------------------------------------------------
 def main() -> None:
+    """Execute all benchmark sections and print final summary output."""
     print("=" * 72)
     print("  PARAMETRIC MODEL vs SWOPP3 REFERENCE  —  BENCHMARK")
     print("  (Fully closed-form — no lookup tables)")

--- a/tests/test_era5.py
+++ b/tests/test_era5.py
@@ -15,7 +15,6 @@ import numpy as np
 import pytest
 import xarray as xr
 
-
 # ---------------------------------------------------------------------------
 # Fixtures: small synthetic ERA5-like NetCDF files
 # ---------------------------------------------------------------------------
@@ -25,8 +24,12 @@ def _make_wind_nc(path: Path) -> None:
     """Create a small synthetic ERA5 wind NetCDF file."""
     # 4 time steps (6-hourly over one day), 5 lats, 6 lons
     times = np.array(
-        ["2024-01-15T00:00", "2024-01-15T06:00",
-         "2024-01-15T12:00", "2024-01-15T18:00"],
+        [
+            "2024-01-15T00:00",
+            "2024-01-15T06:00",
+            "2024-01-15T12:00",
+            "2024-01-15T18:00",
+        ],
         dtype="datetime64[ns]",
     )
     lats = np.array([30.0, 35.0, 40.0, 45.0, 50.0])
@@ -58,8 +61,12 @@ def _make_wind_nc(path: Path) -> None:
 def _make_wave_nc(path: Path) -> None:
     """Create a small synthetic ERA5 wave NetCDF file."""
     times = np.array(
-        ["2024-01-15T00:00", "2024-01-15T06:00",
-         "2024-01-15T12:00", "2024-01-15T18:00"],
+        [
+            "2024-01-15T00:00",
+            "2024-01-15T06:00",
+            "2024-01-15T12:00",
+            "2024-01-15T18:00",
+        ],
         dtype="datetime64[ns]",
     )
     lats = np.array([30.0, 35.0, 40.0, 45.0, 50.0])
@@ -196,9 +203,7 @@ class TestLoadERA5Windfield:
             _make_wind_nc(nc_path)
 
             # Departure at 12:00 (third time step, index 2)
-            wf = load_era5_windfield(
-                nc_path, departure_time="2024-01-15T12:00"
-            )
+            wf = load_era5_windfield(nc_path, departure_time="2024-01-15T12:00")
 
             lon = jnp.array([-50.0])
             lat = jnp.array([40.0])
@@ -344,8 +349,8 @@ class TestLoadERA5LandMask:
         mwd = np.ones((1, 5, 6), dtype=np.float32) * 180.0
 
         # Mark some cells as land (NaN)
-        swh[0, 0, 0] = np.nan   # (lat=30, lon=-70) → land
-        swh[0, 2, 3] = np.nan   # (lat=40, lon=-40) → land
+        swh[0, 0, 0] = np.nan  # (lat=30, lon=-70) → land
+        swh[0, 2, 3] = np.nan  # (lat=40, lon=-40) → land
         mwd[0, 0, 0] = np.nan
         mwd[0, 2, 3] = np.nan
 
@@ -385,8 +390,12 @@ class TestLoadERA5LandMask:
         lats = np.array([30.0, 35.0])
         lons = np.array([-70.0, -60.0])
         ds = xr.Dataset(
-            {"temperature": (["time", "latitude", "longitude"],
-                             np.ones((1, 2, 2), dtype=np.float32))},
+            {
+                "temperature": (
+                    ["time", "latitude", "longitude"],
+                    np.ones((1, 2, 2), dtype=np.float32),
+                )
+            },
             coords={"time": times, "latitude": lats, "longitude": lons},
         )
         nc_path = tmp_path / "no_wave.nc"

--- a/tests/test_parametric_model.py
+++ b/tests/test_parametric_model.py
@@ -14,10 +14,13 @@ import pytest
 
 from routetools.performance import (
     K_H,
-    K_A,
     predict_power,
     predict_power_batch,
+)
+from routetools.performance import (
     predict_power_no_wps as parametric_no_wps,
+)
+from routetools.performance import (
     predict_power_with_wps as parametric_with_wps,
 )
 
@@ -44,17 +47,18 @@ class TestNoWPS:
 
     # ------ Structured grid ------
     @pytest.mark.parametrize(
-        "tws", [0, 2, 5, 10, 15, 20, 25, 30],
+        "tws",
+        [0, 2, 5, 10, 15, 20, 25, 30],
     )
     @pytest.mark.parametrize(
-        "twa", [0, 30, 60, 90, 120, 150, 180],
+        "twa",
+        [0, 30, 60, 90, 120, 150, 180],
     )
     @pytest.mark.parametrize(
-        "v", [0, 2, 5, 8, 10, 12, 14],
+        "v",
+        [0, 2, 5, 8, 10, 12, 14],
     )
-    def test_structured_grid_calm_sea(
-        self, tws: float, twa: float, v: float
-    ) -> None:
+    def test_structured_grid_calm_sea(self, tws: float, twa: float, v: float) -> None:
         """No waves (swh=0, mwa=0): hull + wind only."""
         ref = swopp3.predict_no_wps(tws, twa, 0.0, 0.0, v)
         par = parametric_no_wps(tws, twa, 0.0, 0.0, v)
@@ -64,17 +68,18 @@ class TestNoWPS:
         )
 
     @pytest.mark.parametrize(
-        "swh", [0, 1, 2, 4, 6, 8],
+        "swh",
+        [0, 1, 2, 4, 6, 8],
     )
     @pytest.mark.parametrize(
-        "mwa", [0, 45, 90, 135, 180],
+        "mwa",
+        [0, 45, 90, 135, 180],
     )
     @pytest.mark.parametrize(
-        "v", [0, 3, 7, 10, 14],
+        "v",
+        [0, 3, 7, 10, 14],
     )
-    def test_structured_grid_wave_only(
-        self, swh: float, mwa: float, v: float
-    ) -> None:
+    def test_structured_grid_wave_only(self, swh: float, mwa: float, v: float) -> None:
         """No wind (tws=0): hull + wave only."""
         ref = swopp3.predict_no_wps(0.0, 0.0, swh, mwa, v)
         par = parametric_no_wps(0.0, 0.0, swh, mwa, v)
@@ -167,7 +172,12 @@ class TestNoWPS:
         mwa = rng.uniform(0, 180, n)
         v = rng.uniform(0, 14.5, n)
 
-        ref_vals = np.array([swopp3.predict_no_wps(tws[i], twa[i], swh[i], mwa[i], v[i]) for i in range(n)])
+        ref_vals = np.array(
+            [
+                swopp3.predict_no_wps(tws[i], twa[i], swh[i], mwa[i], v[i])
+                for i in range(n)
+            ]
+        )
         par_vals = predict_power_batch(tws, twa, swh, mwa, v, wps=False)
         abs_errs = np.abs(par_vals - ref_vals)
 
@@ -222,13 +232,16 @@ class TestWithWPS:
         )
 
     @pytest.mark.parametrize(
-        "tws", [0, 5, 10, 15, 20, 25, 30],
+        "tws",
+        [0, 5, 10, 15, 20, 25, 30],
     )
     @pytest.mark.parametrize(
-        "twa", [0, 45, 90, 135, 180],
+        "twa",
+        [0, 45, 90, 135, 180],
     )
     @pytest.mark.parametrize(
-        "v", [0, 4, 8, 12],
+        "v",
+        [0, 4, 8, 12],
     )
     def test_grid_on_nodes(
         self,
@@ -271,7 +284,12 @@ class TestWithWPS:
         mwa = rng.uniform(0, 180, n)
         v = rng.uniform(0, 14.5, n)
 
-        ref_vals = np.array([swopp3.predict_with_wps(tws[i], twa[i], swh[i], mwa[i], v[i]) for i in range(n)])
+        ref_vals = np.array(
+            [
+                swopp3.predict_with_wps(tws[i], twa[i], swh[i], mwa[i], v[i])
+                for i in range(n)
+            ]
+        )
         par_vals = predict_power_batch(tws, twa, swh, mwa, v, wps=True)
         abs_errs = np.abs(par_vals - ref_vals)
 
@@ -303,9 +321,9 @@ class TestDecomposition:
             # Hull-only = no wind, no waves
             ref = swopp3.predict_no_wps(0, 0, 0, 0, v)
             expected = K_H * v**3
-            assert abs(ref - expected) < 0.01, (
-                f"v={v}: ref={ref:.4f}, K_h·v³={expected:.4f}"
-            )
+            assert (
+                abs(ref - expected) < 0.01
+            ), f"v={v}: ref={ref:.4f}, K_h·v³={expected:.4f}"
 
     def test_additivity_wind_wave(self) -> None:
         """Wind and wave components are additive (no cross-terms)."""
@@ -325,17 +343,23 @@ class TestDecomposition:
 
             # Only compare if not clamped
             if p_all > 0 and combined > 0:
-                assert abs(p_all - combined) < 0.01, (
-                    f"Additivity fail: combined={combined:.4f}, ref={p_all:.4f}"
-                )
+                assert (
+                    abs(p_all - combined) < 0.01
+                ), f"Additivity fail: combined={combined:.4f}, ref={p_all:.4f}"
 
     def test_wave_swh_squared(self) -> None:
         """Wave power ∝ swh² at fixed (mwa, v)."""
         v = 8.0
         mwa = 45.0
-        p1 = swopp3.predict_no_wps(0, 0, 1.0, mwa, v) - swopp3.predict_no_wps(0, 0, 0, 0, v)
-        p2 = swopp3.predict_no_wps(0, 0, 2.0, mwa, v) - swopp3.predict_no_wps(0, 0, 0, 0, v)
-        p4 = swopp3.predict_no_wps(0, 0, 4.0, mwa, v) - swopp3.predict_no_wps(0, 0, 0, 0, v)
+        p1 = swopp3.predict_no_wps(0, 0, 1.0, mwa, v) - swopp3.predict_no_wps(
+            0, 0, 0, 0, v
+        )
+        p2 = swopp3.predict_no_wps(0, 0, 2.0, mwa, v) - swopp3.predict_no_wps(
+            0, 0, 0, 0, v
+        )
+        p4 = swopp3.predict_no_wps(0, 0, 4.0, mwa, v) - swopp3.predict_no_wps(
+            0, 0, 0, 0, v
+        )
         assert abs(p2 / p1 - 4.0) < 1e-6, f"ratio p2/p1 = {p2/p1:.6f}, expected 4"
         assert abs(p4 / p1 - 16.0) < 1e-6, f"ratio p4/p1 = {p4/p1:.6f}, expected 16"
 
@@ -346,15 +370,17 @@ class TestDecomposition:
         powers = []
         speeds = [4.0, 6.0, 8.0, 10.0]
         for v in speeds:
-            p = swopp3.predict_no_wps(0, 0, swh, mwa, v) - swopp3.predict_no_wps(0, 0, 0, 0, v)
+            p = swopp3.predict_no_wps(0, 0, swh, mwa, v) - swopp3.predict_no_wps(
+                0, 0, 0, 0, v
+            )
             powers.append(p)
 
         for i in range(1, len(speeds)):
             ratio = powers[i] / powers[0]
             expected = (speeds[i] / speeds[0]) ** 1.5
-            assert abs(ratio - expected) < 1e-4, (
-                f"v={speeds[i]}: ratio={ratio:.6f}, expected={expected:.6f}"
-            )
+            assert (
+                abs(ratio - expected) < 1e-4
+            ), f"v={speeds[i]}: ratio={ratio:.6f}, expected={expected:.6f}"
 
     def test_sail_wave_independent(self) -> None:
         """Sail power P_sail(tws,twa,v) is independent of waves.
@@ -422,9 +448,9 @@ class TestPublicAPI:
         batch = predict_power_batch(tws, twa, swh, mwa, v, wps=False)
         for i in range(n):
             scalar = parametric_no_wps(tws[i], twa[i], swh[i], mwa[i], v[i])
-            assert abs(batch[i] - scalar) < 1e-10, (
-                f"i={i}: batch={batch[i]:.6f}, scalar={scalar:.6f}"
-            )
+            assert (
+                abs(batch[i] - scalar) < 1e-10
+            ), f"i={i}: batch={batch[i]:.6f}, scalar={scalar:.6f}"
 
     def test_batch_matches_scalar_wps(self) -> None:
         """Batch output matches scalar loop for WPS mode."""
@@ -439,9 +465,9 @@ class TestPublicAPI:
         batch = predict_power_batch(tws, twa, swh, mwa, v, wps=True)
         for i in range(n):
             scalar = parametric_with_wps(tws[i], twa[i], swh[i], mwa[i], v[i])
-            assert abs(batch[i] - scalar) < 1e-10, (
-                f"i={i}: batch={batch[i]:.6f}, scalar={scalar:.6f}"
-            )
+            assert (
+                abs(batch[i] - scalar) < 1e-10
+            ), f"i={i}: batch={batch[i]:.6f}, scalar={scalar:.6f}"
 
     def test_batch_broadcasting(self) -> None:
         """Batch supports broadcasting (scalar v with array tws)."""
@@ -485,7 +511,10 @@ class TestJaxParity:
         )
 
         np.testing.assert_allclose(
-            jax_result, np_result, rtol=1e-5, atol=0.02,
+            jax_result,
+            np_result,
+            rtol=1e-5,
+            atol=0.02,
             err_msg="predict_power_jax (no WPS) diverges from predict_power_batch",
         )
 
@@ -518,6 +547,9 @@ class TestJaxParity:
         )
 
         np.testing.assert_allclose(
-            jax_result, np_result, rtol=1e-5, atol=0.02,
+            jax_result,
+            np_result,
+            rtol=1e-5,
+            atol=0.02,
             err_msg="predict_power_jax (WPS) diverges from predict_power_batch",
         )

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -325,8 +325,11 @@ class TestTimeVariation:
         # Segment midpoints at t = 0.5, 1.5, 2.5 days
         # Only t=1.5 days (segment 2) → TWS=30 → 1 violation
         pen = weather_penalty(
-            curve, windfield=wf, penalty=1.0,
-            travel_time=total_time, spherical_correction=False,
+            curve,
+            windfield=wf,
+            penalty=1.0,
+            travel_time=total_time,
+            spherical_correction=False,
         )
         assert jnp.allclose(pen, 1.0)
 
@@ -343,8 +346,11 @@ class TestTimeVariation:
         stw = 1.0 / day  # degrees per second
         # Midpoints at t = 0.5, 1.5, 2.5 days → middle violates
         pen = weather_penalty(
-            curve, windfield=wf, penalty=1.0,
-            travel_stw=stw, spherical_correction=False,
+            curve,
+            windfield=wf,
+            penalty=1.0,
+            travel_stw=stw,
+            spherical_correction=False,
         )
         assert jnp.allclose(pen, 1.0)
 
@@ -356,12 +362,19 @@ class TestTimeVariation:
         total_time = 3.0 * day
         # Without time info → all at t=0 → TWS=10 → pen=0
         pen_no_time = weather_penalty_smooth(
-            curve, windfield=wf, penalty=1.0, sharpness=1.0,
+            curve,
+            windfield=wf,
+            penalty=1.0,
+            sharpness=1.0,
         )
         # With time info → middle segment at t=1.5d → TWS=30 → pen>0
         pen_with_time = weather_penalty_smooth(
-            curve, windfield=wf, penalty=1.0, sharpness=1.0,
-            travel_time=total_time, spherical_correction=False,
+            curve,
+            windfield=wf,
+            penalty=1.0,
+            sharpness=1.0,
+            travel_time=total_time,
+            spherical_correction=False,
         )
         assert jnp.allclose(pen_no_time, 0.0)
         assert pen_with_time > 0
@@ -376,8 +389,10 @@ class TestTimeVariation:
         total_time = 3.0 * day
         stats_no_time = evaluate_weather(curve, windfield=wf)
         stats_with_time = evaluate_weather(
-            curve, windfield=wf,
-            travel_time=total_time, spherical_correction=False,
+            curve,
+            windfield=wf,
+            travel_time=total_time,
+            spherical_correction=False,
         )
         # Without time: all at t=0 → TWS=10 → not exceeded
         assert jnp.allclose(stats_no_time.max_tws, 10.0, atol=1e-5)

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,62 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/42/32cf8e7704ceb4481406eb87161349abb46a57fee3f008ba9cb610968646/aiohttp-3.13.3.tar.gz", hash = "sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88", size = 7844556, upload-time = "2026-01-03T17:33:05.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/be/4fc11f202955a69e0db803a12a062b8379c970c7c84f4882b6da17337cc1/aiohttp-3.13.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b903a4dfee7d347e2d87697d0713be59e0b87925be030c9178c5faa58ea58d5c", size = 739732, upload-time = "2026-01-03T17:30:14.23Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2c/621d5b851f94fa0bb7430d6089b3aa970a9d9b75196bc93bb624b0db237a/aiohttp-3.13.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a45530014d7a1e09f4a55f4f43097ba0fd155089372e105e4bff4ca76cb1b168", size = 494293, upload-time = "2026-01-03T17:30:15.96Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/43/4be01406b78e1be8320bb8316dc9c42dbab553d281c40364e0f862d5661c/aiohttp-3.13.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27234ef6d85c914f9efeb77ff616dbf4ad2380be0cda40b4db086ffc7ddd1b7d", size = 493533, upload-time = "2026-01-03T17:30:17.431Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a8/5a35dc56a06a2c90d4742cbf35294396907027f80eea696637945a106f25/aiohttp-3.13.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d32764c6c9aafb7fb55366a224756387cd50bfa720f32b88e0e6fa45b27dcf29", size = 1737839, upload-time = "2026-01-03T17:30:19.422Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/62/4b9eeb331da56530bf2e198a297e5303e1c1ebdceeb00fe9b568a65c5a0c/aiohttp-3.13.3-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b1a6102b4d3ebc07dad44fbf07b45bb600300f15b552ddf1851b5390202ea2e3", size = 1703932, upload-time = "2026-01-03T17:30:21.756Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f6/af16887b5d419e6a367095994c0b1332d154f647e7dc2bd50e61876e8e3d/aiohttp-3.13.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c014c7ea7fb775dd015b2d3137378b7be0249a448a1612268b5a90c2d81de04d", size = 1771906, upload-time = "2026-01-03T17:30:23.932Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/83/397c634b1bcc24292fa1e0c7822800f9f6569e32934bdeef09dae7992dfb/aiohttp-3.13.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2b8d8ddba8f95ba17582226f80e2de99c7a7948e66490ef8d947e272a93e9463", size = 1871020, upload-time = "2026-01-03T17:30:26Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f6/a62cbbf13f0ac80a70f71b1672feba90fdb21fd7abd8dbf25c0105fb6fa3/aiohttp-3.13.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ae8dd55c8e6c4257eae3a20fd2c8f41edaea5992ed67156642493b8daf3cecc", size = 1755181, upload-time = "2026-01-03T17:30:27.554Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/87/20a35ad487efdd3fba93d5843efdfaa62d2f1479eaafa7453398a44faf13/aiohttp-3.13.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:01ad2529d4b5035578f5081606a465f3b814c542882804e2e8cda61adf5c71bf", size = 1561794, upload-time = "2026-01-03T17:30:29.254Z" },
+    { url = "https://files.pythonhosted.org/packages/de/95/8fd69a66682012f6716e1bc09ef8a1a2a91922c5725cb904689f112309c4/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bb4f7475e359992b580559e008c598091c45b5088f28614e855e42d39c2f1033", size = 1697900, upload-time = "2026-01-03T17:30:31.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/66/7b94b3b5ba70e955ff597672dad1691333080e37f50280178967aff68657/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c19b90316ad3b24c69cd78d5c9b4f3aa4497643685901185b65166293d36a00f", size = 1728239, upload-time = "2026-01-03T17:30:32.703Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/6f72f77f9f7d74719692ab65a2a0252584bf8d5f301e2ecb4c0da734530a/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:96d604498a7c782cb15a51c406acaea70d8c027ee6b90c569baa6e7b93073679", size = 1740527, upload-time = "2026-01-03T17:30:34.695Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b4/75ec16cbbd5c01bdaf4a05b19e103e78d7ce1ef7c80867eb0ace42ff4488/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:084911a532763e9d3dd95adf78a78f4096cd5f58cdc18e6fdbc1b58417a45423", size = 1554489, upload-time = "2026-01-03T17:30:36.864Z" },
+    { url = "https://files.pythonhosted.org/packages/52/8f/bc518c0eea29f8406dcf7ed1f96c9b48e3bc3995a96159b3fc11f9e08321/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:7a4a94eb787e606d0a09404b9c38c113d3b099d508021faa615d70a0131907ce", size = 1767852, upload-time = "2026-01-03T17:30:39.433Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f2/a07a75173124f31f11ea6f863dc44e6f09afe2bca45dd4e64979490deab1/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87797e645d9d8e222e04160ee32aa06bc5c163e8499f24db719e7852ec23093a", size = 1722379, upload-time = "2026-01-03T17:30:41.081Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4a/1a3fee7c21350cac78e5c5cef711bac1b94feca07399f3d406972e2d8fcd/aiohttp-3.13.3-cp312-cp312-win32.whl", hash = "sha256:b04be762396457bef43f3597c991e192ee7da460a4953d7e647ee4b1c28e7046", size = 428253, upload-time = "2026-01-03T17:30:42.644Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b7/76175c7cb4eb73d91ad63c34e29fc4f77c9386bba4a65b53ba8e05ee3c39/aiohttp-3.13.3-cp312-cp312-win_amd64.whl", hash = "sha256:e3531d63d3bdfa7e3ac5e9b27b2dd7ec9df3206a98e0b3445fa906f233264c57", size = 455407, upload-time = "2026-01-03T17:30:44.195Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -156,6 +212,20 @@ sdist = { hash = "sha256:610a20720b5e2d0749d2867d1b18d82c69e9b140ac28552477a7dc3
 requires-dist = [{ name = "setuptools", specifier = ">=51.1.1" }]
 
 [[package]]
+name = "cdsapi"
+version = "0.7.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ecmwf-datastores-client" },
+    { name = "requests" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/f3/6cb5b4bf077c441978c5d5be3a568d37e1f07f3e7177a17fa66aec2594b6/cdsapi-0.7.7.tar.gz", hash = "sha256:bc0cf807c1b78aceba6a11c3a5180f885f47f71a4e58205e324cfedcee16f10b", size = 13322, upload-time = "2025-09-30T19:11:22.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/f4/4a65460d5cb6784128019fd707a87993f378db25e796eba01400a0903f62/cdsapi-0.7.7-py2.py3-none-any.whl", hash = "sha256:384c1658572d6dc53f4111f6dd46fcdfe6fea54a688af9756d71f6fe9118b66d", size = 12293, upload-time = "2025-09-30T19:11:21.184Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -215,6 +285,31 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/35/02daf95b9cd686320bb622eb148792655c9412dbb9b67abb5694e5910a24/charset_normalizer-3.4.5.tar.gz", hash = "sha256:95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644", size = 134804, upload-time = "2026-03-06T06:03:19.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/b6/9ee9c1a608916ca5feae81a344dffbaa53b26b90be58cc2159e3332d44ec/charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed97c282ee4f994ef814042423a529df9497e3c666dca19be1d4cd1129dc7ade", size = 280976, upload-time = "2026-03-06T06:01:15.276Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d8/a54f7c0b96f1df3563e9190f04daf981e365a9b397eedfdfb5dbef7e5c6c/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0294916d6ccf2d069727d65973c3a1ca477d68708db25fd758dd28b0827cff54", size = 189356, upload-time = "2026-03-06T06:01:16.511Z" },
+    { url = "https://files.pythonhosted.org/packages/42/69/2bf7f76ce1446759a5787cb87d38f6a61eb47dbbdf035cfebf6347292a65/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dc57a0baa3eeedd99fafaef7511b5a6ef4581494e8168ee086031744e2679467", size = 206369, upload-time = "2026-03-06T06:01:17.853Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9c/949d1a46dab56b959d9a87272482195f1840b515a3380e39986989a893ae/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ed1a9a204f317ef879b32f9af507d47e49cd5e7f8e8d5d96358c98373314fc60", size = 203285, upload-time = "2026-03-06T06:01:19.473Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5c/ae30362a88b4da237d71ea214a8c7eb915db3eec941adda511729ac25fa2/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ad83b8f9379176c841f8865884f3514d905bcd2a9a3b210eaa446e7d2223e4d", size = 196274, upload-time = "2026-03-06T06:01:20.728Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/07/c9f2cb0e46cb6d64fdcc4f95953747b843bb2181bda678dc4e699b8f0f9a/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:a118e2e0b5ae6b0120d5efa5f866e58f2bb826067a646431da4d6a2bdae7950e", size = 184715, upload-time = "2026-03-06T06:01:22.194Z" },
+    { url = "https://files.pythonhosted.org/packages/36/64/6b0ca95c44fddf692cd06d642b28f63009d0ce325fad6e9b2b4d0ef86a52/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:754f96058e61a5e22e91483f823e07df16416ce76afa4ebf306f8e1d1296d43f", size = 193426, upload-time = "2026-03-06T06:01:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bc/a730690d726403743795ca3f5bb2baf67838c5fea78236098f324b965e40/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0c300cefd9b0970381a46394902cd18eaf2aa00163f999590ace991989dcd0fc", size = 191780, upload-time = "2026-03-06T06:01:25.053Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4f/6c0bc9af68222b22951552d73df4532b5be6447cee32d58e7e8c74ecbb7b/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c108f8619e504140569ee7de3f97d234f0fbae338a7f9f360455071ef9855a95", size = 185805, upload-time = "2026-03-06T06:01:26.294Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/b9/a523fb9b0ee90814b503452b2600e4cbc118cd68714d57041564886e7325/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d1028de43596a315e2720a9849ee79007ab742c06ad8b45a50db8cdb7ed4a82a", size = 208342, upload-time = "2026-03-06T06:01:27.55Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/61/c59e761dee4464050713e50e27b58266cc8e209e518c0b378c1580c959ba/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:19092dde50335accf365cce21998a1c6dd8eafd42c7b226eb54b2747cdce2fac", size = 193661, upload-time = "2026-03-06T06:01:29.051Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/43/729fa30aad69783f755c5ad8649da17ee095311ca42024742701e202dc59/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4354e401eb6dab9aed3c7b4030514328a6c748d05e1c3e19175008ca7de84fb1", size = 204819, upload-time = "2026-03-06T06:01:30.298Z" },
+    { url = "https://files.pythonhosted.org/packages/87/33/d9b442ce5a91b96fc0840455a9e49a611bbadae6122778d0a6a79683dd31/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a68766a3c58fde7f9aaa22b3786276f62ab2f594efb02d0a1421b6282e852e98", size = 198080, upload-time = "2026-03-06T06:01:31.478Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5a/b8b5a23134978ee9885cee2d6995f4c27cc41f9baded0a9685eabc5338f0/charset_normalizer-3.4.5-cp312-cp312-win32.whl", hash = "sha256:1827734a5b308b65ac54e86a618de66f935a4f63a8a462ff1e19a6788d6c2262", size = 132630, upload-time = "2026-03-06T06:01:33.056Z" },
+    { url = "https://files.pythonhosted.org/packages/70/53/e44a4c07e8904500aec95865dc3f6464dc3586a039ef0df606eb3ac38e35/charset_normalizer-3.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:728c6a963dfab66ef865f49286e45239384249672cd598576765acc2a640a636", size = 142856, upload-time = "2026-03-06T06:01:34.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/aa/c5628f7cad591b1cf45790b7a61483c3e36cf41349c98af7813c483fd6e8/charset_normalizer-3.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:75dfd1afe0b1647449e852f4fb428195a7ed0588947218f7ba929f6538487f02", size = 132982, upload-time = "2026-03-06T06:01:35.641Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/60/3a621758945513adfd4db86827a5bafcc615f913dbd0b4c2ed64a65731be/charset_normalizer-3.4.5-py3-none-any.whl", hash = "sha256:9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0", size = 55455, upload-time = "2026-03-06T06:03:17.827Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -224,15 +319,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
-]
-
-[[package]]
-name = "cloudpickle"
-version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
 ]
 
 [[package]]
@@ -288,30 +374,51 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "46.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289, upload-time = "2026-02-10T19:17:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
+    { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
+    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230, upload-time = "2026-02-10T19:17:30.518Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909, upload-time = "2026-02-10T19:17:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514, upload-time = "2026-02-10T19:17:56.267Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
+    { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
+    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
+    { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
-]
-
-[[package]]
-name = "dask"
-version = "2026.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "cloudpickle" },
-    { name = "fsspec" },
-    { name = "packaging" },
-    { name = "partd" },
-    { name = "pyyaml" },
-    { name = "toolz" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/52/b0f9172b22778def907db1ff173249e4eb41f054b46a9c83b1528aaf811f/dask-2026.1.2.tar.gz", hash = "sha256:1136683de2750d98ea792670f7434e6c1cfce90cab2cc2f2495a9e60fd25a4fc", size = 10997838, upload-time = "2026-01-30T21:04:20.54Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/23/d39ccc4ed76222db31530b0a7d38876fdb7673e23f838e8d8f0ed4651a4f/dask-2026.1.2-py3-none-any.whl", hash = "sha256:46a0cf3b8d87f78a3d2e6b145aea4418a6d6d606fe6a16c79bd8ca2bb862bc91", size = 1482084, upload-time = "2026-01-30T21:04:18.363Z" },
 ]
 
 [[package]]
@@ -352,6 +459,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "donfig"
+version = "0.8.1.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl", hash = "sha256:2a3175ce74a06109ff9307d90a230f81215cbac9a751f4d1c6194644b8204f9d", size = 21592, upload-time = "2024-05-23T14:13:55.283Z" },
+]
+
+[[package]]
+name = "ecmwf-datastores-client"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "multiurl" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/60/f86eb3e57baf2b1780a7046148c234e9e57b0aeb550d30f39e50991da253/ecmwf_datastores_client-0.4.2.tar.gz", hash = "sha256:7cee1f5e5dab34edcc794cd62bee02c603fafb6f4cc2121c5f012806e0f7934d", size = 48205, upload-time = "2026-01-21T15:27:31.665Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/40/2ccf4c87a5f9c8198fe71600d5f307f5dada201c091af8774a9c1e360865/ecmwf_datastores_client-0.4.2-py3-none-any.whl", hash = "sha256:d22a675b35263286de09969502ec897da9ceb9e4c8ec4d709f7ebb3b90d3ae98", size = 29092, upload-time = "2026-01-21T15:27:30.452Z" },
 ]
 
 [[package]]
@@ -423,12 +557,243 @@ wheels = [
 ]
 
 [[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
+    { url = "https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b", size = 50594, upload-time = "2025-10-06T05:36:07.69Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4", size = 50448, upload-time = "2025-10-06T05:36:08.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bb/852b9d6db2fa40be96f29c0d1205c306288f0684df8fd26ca1951d461a56/frozenlist-1.8.0-cp312-cp312-win32.whl", hash = "sha256:433403ae80709741ce34038da08511d4a77062aa924baf411ef73d1146e74faf", size = 39985, upload-time = "2025-10-06T05:36:23.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:34187385b08f866104f0c0617404c8eb08165ab1272e884abc89c112e9c00746", size = 44591, upload-time = "2025-10-06T05:36:24.958Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1dc65480ab147339fecc70797e9c2f69d9cea9cf38934ce08df070fdb9cb/frozenlist-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd", size = 40102, upload-time = "2025-10-06T05:36:26.333Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
 name = "fsspec"
 version = "2026.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+]
+
+[[package]]
+name = "gcsfs"
+version = "2026.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "decorator" },
+    { name = "fsspec" },
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
+    { name = "google-cloud-storage" },
+    { name = "google-cloud-storage-control" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/91/e7a2f237d51436a4fc947f30f039d2c277bb4f4ce02f86628ba0a094a3ce/gcsfs-2026.2.0.tar.gz", hash = "sha256:d58a885d9e9c6227742b86da419c7a458e1f33c1de016e826ea2909f6338ed84", size = 163376, upload-time = "2026-02-06T18:35:52.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/6b/c2f68ac51229fc94f094c7f802648fc1de3d19af36434def5e64c0caa32b/gcsfs-2026.2.0-py3-none-any.whl", hash = "sha256:407feaa2af0de81ebce44ea7e6f68598a3753e5e42257b61d6a9f8c0d6d4754e", size = 57557, upload-time = "2026-02-06T18:35:51.09Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/98/586ec94553b569080caef635f98a3723db36a38eac0e3d7eb3ea9d2e4b9a/google_api_core-2.30.0.tar.gz", hash = "sha256:02edfa9fab31e17fc0befb5f161b3bf93c9096d99aed584625f38065c511ad9b", size = 176959, upload-time = "2026-02-18T20:28:11.926Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/27/09c33d67f7e0dcf06d7ac17d196594e66989299374bfb0d4331d1038e76b/google_api_core-2.30.0-py3-none-any.whl", hash = "sha256:80be49ee937ff9aba0fd79a6eddfde35fe658b9953ab9b79c57dd7061afa8df5", size = 173288, upload-time = "2026-02-18T20:28:10.367Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/59/7371175bfd949abfb1170aa076352131d7281bd9449c0f978604fc4431c3/google_auth-2.49.0.tar.gz", hash = "sha256:9cc2d9259d3700d7a257681f81052db6737495a1a46b610597f4b8bafe5286ae", size = 333444, upload-time = "2026-03-06T21:53:06.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/45/de64b823b639103de4b63dd193480dce99526bd36be6530c2dba85bf7817/google_auth-2.49.0-py3-none-any.whl", hash = "sha256:f893ef7307f19cf53700b7e2f61b5a6affe3aa0edf9943b13788920ab92d8d87", size = 240676, upload-time = "2026-03-06T21:52:38.304Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/b4/1b19567e4c567b796f5c593d89895f3cfae5a38e04f27c6af87618fd0942/google_auth_oauthlib-1.3.0.tar.gz", hash = "sha256:cd39e807ac7229d6b8b9c1e297321d36fcc8a9e4857dff4301870985df51a528", size = 21777, upload-time = "2026-02-27T14:13:01.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/56/909fd5632226d3fba31d7aeffd4754410735d49362f5809956fe3e9af344/google_auth_oauthlib-1.3.0-py3-none-any.whl", hash = "sha256:386b3fb85cf4a5b819c6ad23e3128d975216b4cac76324de1d90b128aaf38f29", size = 19308, upload-time = "2026-02-27T14:12:47.865Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/03/ef0bc99d0e0faf4fdbe67ac445e18cdaa74824fd93cd069e7bb6548cb52d/google_cloud_core-2.5.0.tar.gz", hash = "sha256:7c1b7ef5c92311717bd05301aa1a91ffbc565673d3b0b4163a52d8413a186963", size = 36027, upload-time = "2025-10-29T23:17:39.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/20/bfa472e327c8edee00f04beecc80baeddd2ab33ee0e86fd7654da49d45e9/google_cloud_core-2.5.0-py3-none-any.whl", hash = "sha256:67d977b41ae6c7211ee830c7912e41003ea8194bff15ae7d72fd6f51e57acabc", size = 29469, upload-time = "2025-10-29T23:17:38.548Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/b1/4f0798e88285b50dfc60ed3a7de071def538b358db2da468c2e0deecbb40/google_cloud_storage-3.9.0.tar.gz", hash = "sha256:f2d8ca7db2f652be757e92573b2196e10fbc09649b5c016f8b422ad593c641cc", size = 17298544, upload-time = "2026-02-02T13:36:34.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/0b/816a6ae3c9fd096937d2e5f9670558908811d57d59ddf69dd4b83b326fd1/google_cloud_storage-3.9.0-py3-none-any.whl", hash = "sha256:2dce75a9e8b3387078cbbdad44757d410ecdb916101f8ba308abf202b6968066", size = 321324, upload-time = "2026-02-02T13:36:32.271Z" },
+]
+
+[[package]]
+name = "google-cloud-storage-control"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/c0/12dfbf7c5e86e34da4af971bb043f11cdc9be8d204eb06ac8a1f9b1d5c74/google_cloud_storage_control-1.10.0.tar.gz", hash = "sha256:2bcbfa4ca6530d25a5baa8dbe80caf0eeabe4c6804798f4f107279719c316bdb", size = 116845, upload-time = "2026-02-12T14:50:07.096Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/04/96a674d4ee90eed4e99c0f4faec21c9bbe1a470d37a4757508e90e31f5b9/google_cloud_storage_control-1.10.0-py3-none-any.whl", hash = "sha256:81d9dc6b50106836733adca868501f879f0d7a1c41503d887a1a1b9b9ddbf508", size = 89257, upload-time = "2026-02-12T14:50:01.966Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/d7/520b62a35b23038ff005e334dba3ffc75fcf583bee26723f1fd8fd4b6919/google_resumable_media-2.8.0.tar.gz", hash = "sha256:f1157ed8b46994d60a1bc432544db62352043113684d4e030ee02e77ebe9a1ae", size = 2163265, upload-time = "2025-11-17T15:38:06.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/0b/93afde9cfe012260e9fe1522f35c9b72d6ee222f316586b1f23ecf44d518/google_resumable_media-2.8.0-py3-none-any.whl", hash = "sha256:dd14a116af303845a8d932ddae161a26e86cc229645bc98b39f026f9b1717582", size = 81340, upload-time = "2025-11-17T15:38:05.594Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.73.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/96/a0205167fa0154f4a542fd6925bdc63d039d88dab3588b875078107e6f06/googleapis_common_protos-1.73.0.tar.gz", hash = "sha256:778d07cd4fbeff84c6f7c72102f0daf98fa2bfd3fa8bea426edc545588da0b5a", size = 147323, upload-time = "2026-03-06T21:53:09.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/28/23eea8acd65972bbfe295ce3666b28ac510dfcb115fac089d3edb0feb00a/googleapis_common_protos-1.73.0-py3-none-any.whl", hash = "sha256:dfdaaa2e860f242046be561e6d6cb5c5f1541ae02cfbcb034371aadb2942b4e8", size = 297578, upload-time = "2026-03-06T21:52:33.933Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+]
+
+[[package]]
+name = "grpc-google-iam-v1"
+version = "0.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos", extra = ["grpc"] },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/1e/1011451679a983f2f5c6771a1682542ecb027776762ad031fd0d7129164b/grpc_google_iam_v1-0.14.3.tar.gz", hash = "sha256:879ac4ef33136c5491a6300e27575a9ec760f6cdf9a2518798c1b8977a5dc389", size = 23745, upload-time = "2025-10-15T21:14:53.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/bd/330a1bbdb1afe0b96311249e699b6dc9cfc17916394fd4503ac5aca2514b/grpc_google_iam_v1-0.14.3-py3-none-any.whl", hash = "sha256:7a7f697e017a067206a3dfef44e4c634a34d3dee135fe7d7a4613fe3e59217e6", size = 32690, upload-time = "2025-10-15T21:14:51.72Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.78.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/f4/7384ed0178203d6074446b3c4f46c90a22ddf7ae0b3aee521627f54cfc2a/grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97", size = 5913985, upload-time = "2026-02-06T09:55:26.832Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ed/be1caa25f06594463f685b3790b320f18aea49b33166f4141bfdc2bfb236/grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e", size = 11811853, upload-time = "2026-02-06T09:55:29.224Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a7/f06d151afc4e64b7e3cc3e872d331d011c279aaab02831e40a81c691fb65/grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996", size = 6475766, upload-time = "2026-02-06T09:55:31.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a8/4482922da832ec0082d0f2cc3a10976d84a7424707f25780b82814aafc0a/grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7", size = 7170027, upload-time = "2026-02-06T09:55:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bf/f4a3b9693e35d25b24b0b39fa46d7d8a3c439e0a3036c3451764678fec20/grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9", size = 6690766, upload-time = "2026-02-06T09:55:36.902Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/521875265cc99fe5ad4c5a17010018085cae2810a928bf15ebe7d8bcd9cc/grpcio-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:185dea0d5260cbb2d224c507bf2a5444d5abbb1fa3594c1ed7e4c709d5eb8383", size = 7266161, upload-time = "2026-02-06T09:55:39.824Z" },
+    { url = "https://files.pythonhosted.org/packages/05/86/296a82844fd40a4ad4a95f100b55044b4f817dece732bf686aea1a284147/grpcio-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51b13f9aed9d59ee389ad666b8c2214cc87b5de258fa712f9ab05f922e3896c6", size = 8253303, upload-time = "2026-02-06T09:55:42.353Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e4/ea3c0caf5468537f27ad5aab92b681ed7cc0ef5f8c9196d3fd42c8c2286b/grpcio-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd5f135b1bd58ab088930b3c613455796dfa0393626a6972663ccdda5b4ac6ce", size = 7698222, upload-time = "2026-02-06T09:55:44.629Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/47/7f05f81e4bb6b831e93271fb12fd52ba7b319b5402cbc101d588f435df00/grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68", size = 4066123, upload-time = "2026-02-06T09:55:47.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e7/d6914822c88aa2974dbbd10903d801a28a19ce9cd8bad7e694cbbcf61528/grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e", size = 4797657, upload-time = "2026-02-06T09:55:49.86Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.78.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/cd/89ce482a931b543b92cdd9b2888805518c4620e0094409acb8c81dd4610a/grpcio_status-1.78.0.tar.gz", hash = "sha256:a34cfd28101bfea84b5aa0f936b4b423019e9213882907166af6b3bddc59e189", size = 13808, upload-time = "2026-02-06T10:01:48.034Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/8a/1241ec22c41028bddd4a052ae9369267b4475265ad0ce7140974548dc3fa/grpcio_status-1.78.0-py3-none-any.whl", hash = "sha256:b492b693d4bf27b47a6c32590701724f1d3b9444b36491878fb71f6208857f34", size = 14523, upload-time = "2026-02-06T10:01:32.584Z" },
 ]
 
 [[package]]
@@ -820,15 +1185,6 @@ wheels = [
 ]
 
 [[package]]
-name = "locket"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/83/97b29fe05cb6ae28d2dbd30b81e2e402a3eed5f460c26e9eaa5895ceacf5/locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632", size = 4350, upload-time = "2022-04-20T22:04:44.312Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3", size = 4398, upload-time = "2022-04-20T22:04:42.23Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -929,6 +1285,48 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/a9/b98b86426c24900b0c754aad006dce2863df7ce0bb2bcc2c02f9cc7e8489/ml_dtypes-0.5.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b255acada256d1fa8c35ed07b5f6d18bc21d1556f842fbc2d5718aea2cd9e55", size = 4928805, upload-time = "2025-07-29T18:38:38.29Z" },
     { url = "https://files.pythonhosted.org/packages/50/c1/85e6be4fc09c6175f36fb05a45917837f30af9a5146a5151cb3a3f0f9e09/ml_dtypes-0.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:da65e5fd3eea434ccb8984c3624bc234ddcc0d9f4c81864af611aaebcc08a50e", size = 208182, upload-time = "2025-07-29T18:38:39.72Z" },
     { url = "https://files.pythonhosted.org/packages/9e/17/cf5326d6867be057f232d0610de1458f70a8ce7b6290e4b4a277ea62b4cd/ml_dtypes-0.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:8bb9cd1ce63096567f5f42851f5843b5a0ea11511e50039a7649619abfb4ba6d", size = 161560, upload-time = "2025-07-29T18:38:41.072Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cf/18ef143a81610136d3da8193da9d80bfe1cb548a1e2d1c775f26b23d024a/multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fccb473e87eaa1382689053e4a4618e7ba7b9b9b8d6adf2027ee474597128cd", size = 45456, upload-time = "2026-01-26T02:43:53.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7", size = 43872, upload-time = "2026-01-26T02:43:55.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3b/d6bd75dc4f3ff7c73766e04e705b00ed6dbbaccf670d9e05a12b006f5a21/multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53", size = 251018, upload-time = "2026-01-26T02:43:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bd/84c24de512cbafbdbc39439f74e967f19570ce7924e3007174a29c348916/multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3", size = 252059, upload-time = "2026-01-26T02:44:07.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a4/840f5b97339e27846c46307f2530a2805d9d537d8b8bd416af031cad7fa0/multidict-6.7.1-cp312-cp312-win32.whl", hash = "sha256:28ca5ce2fd9716631133d0e9a9b9a745ad7f60bac2bccafb56aa380fc0b6c511", size = 41887, upload-time = "2026-01-26T02:44:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "multiurl"
+version = "0.3.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "requests" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/ce/a00c9b44f43c4620ca004e4acb4c1e266b1ab48d2f6ad9e402f6bdbe44d4/multiurl-0.3.7.tar.gz", hash = "sha256:4201563fc8989baca7b525fdc69d4cd5a6c0cef4f303559710b9890021aab6d9", size = 18945, upload-time = "2025-07-29T11:57:04.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/cf/be4e93afbfa0def2cd6fac9302071db0bd6d0617999ecbf53f92b9398de3/multiurl-0.3.7-py3-none-any.whl", hash = "sha256:054f42974064f103be0ed55b43f0c32fc435a47dc7353a9adaffa643b99fa380", size = 21524, upload-time = "2025-07-29T11:57:03.191Z" },
 ]
 
 [[package]]
@@ -1050,6 +1448,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+]
+
+[[package]]
+name = "numcodecs"
+version = "0.16.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/8a391e7c356366224734efd24da929cc4796fff468bfb179fe1af6548535/numcodecs-0.16.5.tar.gz", hash = "sha256:0d0fb60852f84c0bd9543cc4d2ab9eefd37fc8efcc410acd4777e62a1d300318", size = 6276387, upload-time = "2025-11-21T02:49:48.986Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/cc/55420f3641a67f78392dc0bc5d02cb9eb0a9dcebf2848d1ac77253ca61fa/numcodecs-0.16.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:24e675dc8d1550cd976a99479b87d872cb142632c75cc402fea04c08c4898523", size = 1656287, upload-time = "2025-11-21T02:49:25.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6c/86644987505dcb90ba6d627d6989c27bafb0699f9fd00187e06d05ea8594/numcodecs-0.16.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:94ddfa4341d1a3ab99989d13b01b5134abb687d3dab2ead54b450aefe4ad5bd6", size = 1148899, upload-time = "2025-11-21T02:49:26.87Z" },
+    { url = "https://files.pythonhosted.org/packages/97/1e/98aaddf272552d9fef1f0296a9939d1487914a239e98678f6b20f8b0a5c8/numcodecs-0.16.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b554ab9ecf69de7ca2b6b5e8bc696bd9747559cb4dd5127bd08d7a28bec59c3a", size = 8534814, upload-time = "2025-11-21T02:49:28.547Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/53/78c98ef5c8b2b784453487f3e4d6c017b20747c58b470393e230c78d18e8/numcodecs-0.16.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad1a379a45bd3491deab8ae6548313946744f868c21d5340116977ea3be5b1d6", size = 9173471, upload-time = "2025-11-21T02:49:30.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/20/2fdec87fc7f8cec950d2b0bea603c12dc9f05b4966dc5924ba5a36a61bf6/numcodecs-0.16.5-cp312-cp312-win_amd64.whl", hash = "sha256:845a9857886ffe4a3172ba1c537ae5bcc01e65068c31cf1fce1a844bd1da050f", size = 801412, upload-time = "2025-11-21T02:49:32.123Z" },
 ]
 
 [[package]]
@@ -1194,6 +1609,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "opencv-python"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
@@ -1266,19 +1690,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d4/de/53e0bcf53d13e005bd8c92e7855142494f41171b34c2536b86187474184d/parso-0.8.5.tar.gz", hash = "sha256:034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a", size = 401205, upload-time = "2025-08-23T15:15:28.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl", hash = "sha256:646204b5ee239c396d040b90f9e272e9a8017c630092bf59980beb62fd033887", size = 106668, upload-time = "2025-08-23T15:15:25.663Z" },
-]
-
-[[package]]
-name = "partd"
-version = "1.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "locket" },
-    { name = "toolz" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/3a/3f06f34820a31257ddcabdfafc2672c5816be79c7e353b02c1f318daa7d4/partd-1.4.2.tar.gz", hash = "sha256:d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c", size = 21029, upload-time = "2024-05-06T19:51:41.945Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl", hash = "sha256:978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f", size = 18905, upload-time = "2024-05-06T19:51:39.271Z" },
 ]
 
 [[package]]
@@ -1401,6 +1812,57 @@ wheels = [
 ]
 
 [[package]]
+name = "propcache"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442, upload-time = "2025-10-08T19:49:02.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/0f/f17b1b2b221d5ca28b4b876e8bb046ac40466513960646bda8e1853cdfa2/propcache-0.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e153e9cd40cc8945138822807139367f256f89c6810c2634a4f6902b52d3b4e2", size = 80061, upload-time = "2025-10-08T19:46:46.075Z" },
+    { url = "https://files.pythonhosted.org/packages/76/47/8ccf75935f51448ba9a16a71b783eb7ef6b9ee60f5d14c7f8a8a79fbeed7/propcache-0.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cd547953428f7abb73c5ad82cbb32109566204260d98e41e5dfdc682eb7f8403", size = 46037, upload-time = "2025-10-08T19:46:47.23Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/b6/5c9a0e42df4d00bfb4a3cbbe5cf9f54260300c88a0e9af1f47ca5ce17ac0/propcache-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f048da1b4f243fc44f205dfd320933a951b8d89e0afd4c7cacc762a8b9165207", size = 47324, upload-time = "2025-10-08T19:46:48.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d3/6c7ee328b39a81ee877c962469f1e795f9db87f925251efeb0545e0020d0/propcache-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ec17c65562a827bba85e3872ead335f95405ea1674860d96483a02f5c698fa72", size = 225505, upload-time = "2025-10-08T19:46:50.055Z" },
+    { url = "https://files.pythonhosted.org/packages/01/5d/1c53f4563490b1d06a684742cc6076ef944bc6457df6051b7d1a877c057b/propcache-0.4.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:405aac25c6394ef275dee4c709be43745d36674b223ba4eb7144bf4d691b7367", size = 230242, upload-time = "2025-10-08T19:46:51.815Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/ce4620633b0e2422207c3cb774a0ee61cac13abc6217763a7b9e2e3f4a12/propcache-0.4.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0013cb6f8dde4b2a2f66903b8ba740bdfe378c943c4377a200551ceb27f379e4", size = 238474, upload-time = "2025-10-08T19:46:53.208Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/3aae6835b8e5f44ea6a68348ad90f78134047b503765087be2f9912140ea/propcache-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15932ab57837c3368b024473a525e25d316d8353016e7cc0e5ba9eb343fbb1cf", size = 221575, upload-time = "2025-10-08T19:46:54.511Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a5/8a5e8678bcc9d3a1a15b9a29165640d64762d424a16af543f00629c87338/propcache-0.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:031dce78b9dc099f4c29785d9cf5577a3faf9ebf74ecbd3c856a7b92768c3df3", size = 216736, upload-time = "2025-10-08T19:46:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/63/b7b215eddeac83ca1c6b934f89d09a625aa9ee4ba158338854c87210cc36/propcache-0.4.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ab08df6c9a035bee56e31af99be621526bd237bea9f32def431c656b29e41778", size = 213019, upload-time = "2025-10-08T19:46:57.595Z" },
+    { url = "https://files.pythonhosted.org/packages/57/74/f580099a58c8af587cac7ba19ee7cb418506342fbbe2d4a4401661cca886/propcache-0.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4d7af63f9f93fe593afbf104c21b3b15868efb2c21d07d8732c0c4287e66b6a6", size = 220376, upload-time = "2025-10-08T19:46:59.067Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ee/542f1313aff7eaf19c2bb758c5d0560d2683dac001a1c96d0774af799843/propcache-0.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cfc27c945f422e8b5071b6e93169679e4eb5bf73bbcbf1ba3ae3a83d2f78ebd9", size = 226988, upload-time = "2025-10-08T19:47:00.544Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/18/9c6b015dd9c6930f6ce2229e1f02fb35298b847f2087ea2b436a5bfa7287/propcache-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:35c3277624a080cc6ec6f847cbbbb5b49affa3598c4535a0a4682a697aaa5c75", size = 215615, upload-time = "2025-10-08T19:47:01.968Z" },
+    { url = "https://files.pythonhosted.org/packages/80/9e/e7b85720b98c45a45e1fca6a177024934dc9bc5f4d5dd04207f216fc33ed/propcache-0.4.1-cp312-cp312-win32.whl", hash = "sha256:671538c2262dadb5ba6395e26c1731e1d52534bfe9ae56d0b5573ce539266aa8", size = 38066, upload-time = "2025-10-08T19:47:03.503Z" },
+    { url = "https://files.pythonhosted.org/packages/54/09/d19cff2a5aaac632ec8fc03737b223597b1e347416934c1b3a7df079784c/propcache-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:cb2d222e72399fcf5890d1d5cc1060857b9b236adff2792ff48ca2dfd46c81db", size = 41655, upload-time = "2025-10-08T19:47:04.973Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ab/6b5c191bb5de08036a8c697b265d4ca76148efb10fa162f14af14fb5f076/propcache-0.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:204483131fb222bdaaeeea9f9e6c6ed0cac32731f75dfc1d4a567fc1926477c1", size = 37789, upload-time = "2025-10-08T19:47:06.077Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/02/8832cde80e7380c600fbf55090b6ab7b62bd6825dbedde6d6657c15a1f8e/proto_plus-1.27.1.tar.gz", hash = "sha256:912a7460446625b792f6448bade9e55cd4e41e6ac10e27009ef71a7f317fa147", size = 56929, upload-time = "2026-02-02T17:34:49.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/79/ac273cbbf744691821a9cca88957257f41afe271637794975ca090b9588b/proto_plus-1.27.1-py3-none-any.whl", hash = "sha256:e4643061f3a4d0de092d62aa4ad09fa4756b2cbb89d4627f3985018216f9fefc", size = 50480, upload-time = "2026-02-02T17:34:47.339Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
+    { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "7.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1430,6 +1892,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1612,6 +2095,34 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "rfc3339-validator"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1664,7 +2175,6 @@ source = { editable = "." }
 dependencies = [
     { name = "borb" },
     { name = "cma" },
-    { name = "dask" },
     { name = "fastapi" },
     { name = "h3" },
     { name = "jax", extra = ["cuda"] },
@@ -1676,6 +2186,7 @@ dependencies = [
     { name = "pandas" },
     { name = "perlin-numpy" },
     { name = "pytest" },
+    { name = "scipy" },
     { name = "seaborn" },
     { name = "shapely" },
     { name = "statsmodels" },
@@ -1688,6 +2199,13 @@ dependencies = [
 [package.optional-dependencies]
 cuda = [
     { name = "jax", extra = ["cuda"] },
+]
+era5-cds = [
+    { name = "cdsapi" },
+]
+era5-gcs = [
+    { name = "gcsfs" },
+    { name = "zarr" },
 ]
 
 [package.dev-dependencies]
@@ -1702,20 +2220,22 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "borb", url = "https://files.pythonhosted.org/packages/7a/4e/b193d894ffb0fde0f773b0476d8b041528302fa86bccf2cc8006c79404e4/borb-3.0.1.tar.gz" },
+    { name = "cdsapi", marker = "extra == 'era5-cds'", specifier = ">=0.7.0" },
     { name = "cma", specifier = ">=4.0.0" },
-    { name = "dask", specifier = ">=2026.1.2" },
     { name = "fastapi" },
+    { name = "gcsfs", marker = "extra == 'era5-gcs'", specifier = ">=2024.1.0" },
     { name = "h3", specifier = "==4.0.0b2" },
     { name = "jax", extras = ["cuda"], specifier = "==0.8.1" },
     { name = "jax", extras = ["cuda"], marker = "extra == 'cuda'", specifier = "==0.8.1" },
     { name = "jaxlib", specifier = "==0.8.1" },
     { name = "jupyter-server", specifier = ">=2.17.0" },
     { name = "matplotlib", specifier = ">=3.9.2" },
-    { name = "netcdf4", specifier = ">=1.7.4" },
+    { name = "netcdf4", specifier = ">=1.6.0" },
     { name = "opencv-python", specifier = ">=4.13.0.92" },
     { name = "pandas" },
     { name = "perlin-numpy", specifier = ">=0.0.1" },
     { name = "pytest", specifier = ">=8.3.2" },
+    { name = "scipy", specifier = ">=1.12.0" },
     { name = "seaborn", specifier = ">=0.13.2" },
     { name = "shapely", specifier = ">=2.0.6" },
     { name = "statsmodels", specifier = ">=0.14.6" },
@@ -1723,8 +2243,9 @@ requires-dist = [
     { name = "typer-slim" },
     { name = "uvicorn" },
     { name = "xarray", specifier = ">=2024.11.0" },
+    { name = "zarr", marker = "extra == 'era5-gcs'", specifier = ">=2.17.0" },
 ]
-provides-extras = ["cuda"]
+provides-extras = ["cuda", "era5-cds", "era5-gcs"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1756,6 +2277,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/89/33e675dccff11a06d4d85dbb4d1865f878d5020cbb69b2c1e7b2d3f82562/rpds_py-0.28.0-cp312-cp312-win32.whl", hash = "sha256:d15431e334fba488b081d47f30f091e5d03c18527c325386091f31718952fe08", size = 216954, upload-time = "2025-10-22T22:22:24.105Z" },
     { url = "https://files.pythonhosted.org/packages/af/36/45f6ebb3210887e8ee6dbf1bc710ae8400bb417ce165aaf3024b8360d999/rpds_py-0.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:a410542d61fc54710f750d3764380b53bf09e8c4edbf2f9141a82aa774a04f7c", size = 227844, upload-time = "2025-10-22T22:22:25.551Z" },
     { url = "https://files.pythonhosted.org/packages/57/91/f3fb250d7e73de71080f9a221d19bd6a1c1eb0d12a1ea26513f6c1052ad6/rpds_py-0.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:1f0cfd1c69e2d14f8c892b893997fa9a60d890a0c8a603e88dca4955f26d1edd", size = 217624, upload-time = "2025-10-22T22:22:26.914Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]
@@ -1967,15 +2500,6 @@ wheels = [
 ]
 
 [[package]]
-name = "toolz"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
-]
-
-[[package]]
 name = "tornado"
 version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1992,6 +2516,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/59/593bd0f40f7355806bf6573b47b8c22f8e1374c9b6fd03114bd6b7a3dcfd/tornado-6.5.2-cp39-abi3-win32.whl", hash = "sha256:c6f29e94d9b37a95013bb669616352ddb82e3bfe8326fccee50583caebc8a5f0", size = 445023, upload-time = "2025-08-08T18:26:56.677Z" },
     { url = "https://files.pythonhosted.org/packages/c7/2a/f609b420c2f564a748a2d80ebfb2ee02a73ca80223af712fca591386cafb/tornado-6.5.2-cp39-abi3-win_amd64.whl", hash = "sha256:e56a5af51cc30dd2cae649429af65ca2f6571da29504a07995175df14c18f35f", size = 445427, upload-time = "2025-08-08T18:26:57.91Z" },
     { url = "https://files.pythonhosted.org/packages/5e/4f/e1f65e8f8c76d73658b33d33b81eed4322fb5085350e4328d5c956f0c8f9/tornado-6.5.2-cp39-abi3-win_arm64.whl", hash = "sha256:d6c33dc3672e3a1f3618eb63b7ef4683a7688e7b9e6e8f0d9aa5726360a004af", size = 444456, upload-time = "2025-08-08T18:26:59.207Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]
@@ -2071,6 +2607,15 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.38.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2145,4 +2690,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ce/f5dd613ddd0b3f839c59e6c2fa20c62469bf671bf4c92a12b09dc0972326/xarray-2025.10.1.tar.gz", hash = "sha256:3c2b5ad7389825bd624ada5ff26b01ac54b1aae72e2fe0d724d81d40a2bf5785", size = 3058736, upload-time = "2025-10-07T20:25:56.708Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl", hash = "sha256:a4e699433b87a7fac340951bc36648645eeef72bdd915ff055ac2fd99865a73d", size = 1365202, upload-time = "2025-10-07T20:25:54.964Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/8a/94615bc31022f711add374097ad4144d569e95ff3c38d39215d07ac153a0/yarl-1.23.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1932b6b8bba8d0160a9d1078aae5838a66039e8832d41d2992daa9a3a08f7860", size = 124737, upload-time = "2026-03-01T22:05:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/6f/c6554045d59d64052698add01226bc867b52fe4a12373415d7991fdca95d/yarl-1.23.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:411225bae281f114067578891bc75534cfb3d92a3b4dfef7a6ca78ba354e6069", size = 87029, upload-time = "2026-03-01T22:05:14.376Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/725ecc166d53438bc88f76822ed4b1e3b10756e790bafd7b523fe97c322d/yarl-1.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:13a563739ae600a631c36ce096615fe307f131344588b0bc0daec108cdb47b25", size = 86310, upload-time = "2026-03-01T22:05:15.71Z" },
+    { url = "https://files.pythonhosted.org/packages/99/30/58260ed98e6ff7f90ba84442c1ddd758c9170d70327394a6227b310cd60f/yarl-1.23.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cbf44c5cb4a7633d078788e1b56387e3d3cf2b8139a3be38040b22d6c3221c8", size = 97587, upload-time = "2026-03-01T22:05:17.384Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0a/8b08aac08b50682e65759f7f8dde98ae8168f72487e7357a5d684c581ef9/yarl-1.23.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:53ad387048f6f09a8969631e4de3f1bf70c50e93545d64af4f751b2498755072", size = 92528, upload-time = "2026-03-01T22:05:18.804Z" },
+    { url = "https://files.pythonhosted.org/packages/52/07/0b7179101fe5f8385ec6c6bb5d0cb9f76bd9fb4a769591ab6fb5cdbfc69a/yarl-1.23.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4a59ba56f340334766f3a4442e0efd0af895fae9e2b204741ef885c446b3a1a8", size = 105339, upload-time = "2026-03-01T22:05:20.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8a/36d82869ab5ec829ca8574dfcb92b51286fcfb1e9c7a73659616362dc880/yarl-1.23.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:803a3c3ce4acc62eaf01eaca1208dcf0783025ef27572c3336502b9c232005e7", size = 105061, upload-time = "2026-03-01T22:05:22.268Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3d2bff8f37f8d0f96c7ec554d16945050d54462d6e95414babaa18bfafc7f51", size = 100132, upload-time = "2026-03-01T22:05:23.638Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/9c89acf82f08a52cb52d6d39454f8d18af15f9d386a23795389d1d423823/yarl-1.23.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c75eb09e8d55bceb4367e83496ff8ef2bc7ea6960efb38e978e8073ea59ecb67", size = 99289, upload-time = "2026-03-01T22:05:25.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/54/5b0db00d2cb056922356104468019c0a132e89c8d3ab67d8ede9f4483d2a/yarl-1.23.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:877b0738624280e34c55680d6054a307aa94f7d52fa0e3034a9cc6e790871da7", size = 96950, upload-time = "2026-03-01T22:05:27.318Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/10fa93811fd439341fad7e0718a86aca0de9548023bbb403668d6555acab/yarl-1.23.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b5405bb8f0e783a988172993cfc627e4d9d00432d6bbac65a923041edacf997d", size = 93960, upload-time = "2026-03-01T22:05:28.738Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d2/8ae2e6cd77d0805f4526e30ec43b6f9a3dfc542d401ac4990d178e4bf0cf/yarl-1.23.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c3a3598a832590c5a3ce56ab5576361b5688c12cb1d39429cf5dba30b510760", size = 104703, upload-time = "2026-03-01T22:05:30.438Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/0c/b3ceacf82c3fe21183ce35fa2acf5320af003d52bc1fcf5915077681142e/yarl-1.23.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8419ebd326430d1cbb7efb5292330a2cf39114e82df5cc3d83c9a0d5ebeaf2f2", size = 98325, upload-time = "2026-03-01T22:05:31.835Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e0/12900edd28bdab91a69bd2554b85ad7b151f64e8b521fe16f9ad2f56477a/yarl-1.23.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:be61f6fff406ca40e3b1d84716fde398fc08bc63dd96d15f3a14230a0973ed86", size = 105067, upload-time = "2026-03-01T22:05:33.358Z" },
+    { url = "https://files.pythonhosted.org/packages/15/61/74bb1182cf79c9bbe4eb6b1f14a57a22d7a0be5e9cedf8e2d5c2086474c3/yarl-1.23.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3ceb13c5c858d01321b5d9bb65e4cf37a92169ea470b70fec6f236b2c9dd7e34", size = 100285, upload-time = "2026-03-01T22:05:35.4Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7f/cd5ef733f2550de6241bd8bd8c3febc78158b9d75f197d9c7baa113436af/yarl-1.23.0-cp312-cp312-win32.whl", hash = "sha256:fffc45637bcd6538de8b85f51e3df3223e4ad89bccbfca0481c08c7fc8b7ed7d", size = 82359, upload-time = "2026-03-01T22:05:36.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/be/25216a49daeeb7af2bec0db22d5e7df08ed1d7c9f65d78b14f3b74fd72fc/yarl-1.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:f69f57305656a4852f2a7203efc661d8c042e6cc67f7acd97d8667fb448a426e", size = 87674, upload-time = "2026-03-01T22:05:38.171Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/35/aeab955d6c425b227d5b7247eafb24f2653fedc32f95373a001af5dfeb9e/yarl-1.23.0-cp312-cp312-win_arm64.whl", hash = "sha256:6e87a6e8735b44816e7db0b2fbc9686932df473c826b0d9743148432e10bb9b9", size = 81879, upload-time = "2026-03-01T22:05:40.006Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "zarr"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "donfig" },
+    { name = "google-crc32c" },
+    { name = "numcodecs" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/76/7fa87f57c112c7b9c82f0a730f8b6f333e792574812872e2cd45ab604199/zarr-3.1.5.tar.gz", hash = "sha256:fbe0c79675a40c996de7ca08e80a1c0a20537bd4a9f43418b6d101395c0bba2b", size = 366825, upload-time = "2025-11-21T14:06:01.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/15/bb13b4913ef95ad5448490821eee4671d0e67673342e4d4070854e5fe081/zarr-3.1.5-py3-none-any.whl", hash = "sha256:29cd905afb6235b94c09decda4258c888fcb79bb6c862ef7c0b8fe009b5c8563", size = 284067, upload-time = "2025-11-21T14:05:59.235Z" },
 ]


### PR DESCRIPTION
This PR is simply a style fix. It is meant to refactor small pieces of the code to keep a consistent style. Following that goal, I include a set of copilot instructions to ensure future prompts take into account these rules.

## Summary
Merge `fix/make_hooks` into `swopp` with commit-ready fixes for hooks and test stability.

### Included commits
- chore(scripts): fix lint docs and shebang executables
- chore(era5): resolve hooks and typing across weather stack
- docs: add repository copilot instructions

### Validation
- `make hooks` passes
- `make test` passes (`194 passed`, `711 skipped` due to optional `swopp3_performance_model` wheel)
