### PR TITLE
Fail fast when SWOPP3 weather data is missing instead of silently producing GC routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,37 @@ uv run scripts/era5_benchmark.py --departure 2023-01-08T00:00:00
 See `scripts/download_era5.py --help` and `scripts/era5_benchmark.py --help`
 for all available options.
 
+### SWOPP3 ERA5 pipeline
+
+The default SWOPP3 competition pipeline is:
+
+```bash
+uv run scripts/download_era5.py
+uv run scripts/swopp3_run.py
+```
+
+These two commands line up without extra path flags. The downloader writes the
+four default 2024 files that `scripts/swopp3_run.py` expects:
+
+```text
+data/era5/era5_wind_atlantic_2024.nc
+data/era5/era5_waves_atlantic_2024.nc
+data/era5/era5_wind_pacific_2024.nc
+data/era5/era5_waves_pacific_2024.nc
+```
+
+`scripts/swopp3_run.py` validates these files before running any case. If one
+or more inputs are missing, it exits immediately with a precise error message
+instead of silently substituting a great-circle route or running without
+weather data. This is intentional:
+
+- GC cases still require wind and wave data for SWOPP3 energy evaluation.
+- Optimised cases require wind data for the CMA-ES vectorfield and wind/wave
+  data for the final SWOPP3 energy evaluation.
+
+If you download a different year or only one corridor, pass matching
+`--wind-path*` and `--wave-path*` options to `scripts/swopp3_run.py`.
+
 ## Reproduce the results (paper)
 
 To reproduce the results from the paper, run the following command:

--- a/routetools/swopp3_runner.py
+++ b/routetools/swopp3_runner.py
@@ -211,6 +211,8 @@ def run_optimised_departure(
 
     The CMA-ES optimizer minimises travel cost through the wind field.
     Energy is then evaluated post-hoc with the SWOPP3 performance model.
+    Missing optimisation inputs are treated as an error; this function does
+    not fall back to a great-circle route.
 
     Parameters
     ----------
@@ -220,8 +222,8 @@ def run_optimised_departure(
         Departure time (UTC).
     vectorfield : FieldClosure, optional
         Vector field for the CMA-ES cost function.  For SWOPP3 this is
-        typically the ERA5 wind field.  If ``None``, assumes zero-field
-        and falls back to a great-circle route.
+        typically the ERA5 wind field.  If ``None``, this function raises
+        ``ValueError`` instead of falling back to a great-circle route.
     windfield, wavefield : FieldClosure, optional
         Pre-loaded closures for energy evaluation.
     land : Land, optional
@@ -236,6 +238,13 @@ def run_optimised_departure(
     Returns
     -------
     DepartureResult
+
+    Raises
+    ------
+    ValueError
+        If ``vectorfield`` is ``None``. Optimised departures require an ERA5
+        wind-derived vector field so CMA-ES cannot silently degrade to a
+        great-circle route.
     """
     case = SWOPP3_CASES[case_id]
     src, dst = case_endpoints(case_id)
@@ -302,8 +311,11 @@ def run_optimised_departure(
             **defaults,
         )
     else:
-        # No vectorfield → fall back to great circle
-        curve = great_circle_route(src, dst, n_points=n_points)
+        # No vectorfield → raise error
+        raise ValueError(
+            "Optimised departure requires a vectorfield for CMA-ES.  "
+            "Provide a vectorfield or use run_gc_departure for a great-circle route.",
+        )
 
     distance_nm = sailed_distance_nm(curve)
 
@@ -378,7 +390,8 @@ def run_case(
         each departure.  If ``None``, offset = 0 (suitable only when each
         departure loads its own field with ``departure_time``).
     **cmaes_kwargs
-        Extra arguments for CMA-ES (optimised cases only).
+        Extra arguments for CMA-ES (optimised cases only). Optimised cases
+        require ``vectorfield`` to be provided.
 
     Returns
     -------

--- a/scripts/download_era5.py
+++ b/scripts/download_era5.py
@@ -34,7 +34,16 @@ Downloaded files are stored in ``data/era5/`` by default::
     ├── era5_wind_pacific_2024.nc
     └── era5_waves_pacific_2024.nc
 
-These can then be loaded via::
+These filenames are the defaults consumed by ``scripts/swopp3_run.py``. A new
+user can therefore run the full SWOPP3 pipeline without overriding any paths::
+
+    uv run scripts/download_era5.py
+    uv run scripts/swopp3_run.py
+
+If you download a different year or only one corridor, ``scripts/swopp3_run.py``
+must be given matching ``--wind-path*`` and ``--wave-path*`` options.
+
+The downloaded files can also be loaded programmatically via::
 
     from routetools.era5 import load_era5_windfield, load_era5_wavefield
 

--- a/scripts/swopp3_plot_routes.py
+++ b/scripts/swopp3_plot_routes.py
@@ -550,7 +550,7 @@ def plot_distance_vs_energy(
 @app.command()
 def main(
     input_dir: Path = typer.Option(  # noqa: B008
-        "output/swopp3_rise",
+        "output/swopp3",
         "--input-dir",
         "-i",
         help="Directory containing SWOPP3 output CSVs.",

--- a/scripts/swopp3_run.py
+++ b/scripts/swopp3_run.py
@@ -130,12 +130,18 @@ def main(
     wind_path: Path | None = typer.Option(  # noqa: B008
         None,
         "--wind-path",
-        help="Path to ERA5 wind NetCDF (single corridor, used for all cases).",
+        help=(
+            "Path to ERA5 wind NetCDF used for all selected corridors. "
+            "Overrides the built-in corridor defaults when provided."
+        ),
     ),
     wave_path: Path | None = typer.Option(  # noqa: B008
         None,
         "--wave-path",
-        help="Path to ERA5 wave NetCDF (single corridor, used for all cases).",
+        help=(
+            "Path to ERA5 wave NetCDF used for all selected corridors. "
+            "Overrides the built-in corridor defaults when provided."
+        ),
     ),
     wind_path_atlantic: Path | None = typer.Option(  # noqa: B008
         "data/era5/era5_wind_atlantic_2024.nc",
@@ -231,7 +237,6 @@ def main(
     typer.echo(f"Running {len(case_ids)} case(s) × {len(departures)} departure(s)")
 
     # ---- Build per-corridor field map ----
-    # Resolve which wind/wave paths to use for each corridor.
     corridor_wind: dict[str, Path] = {}
     corridor_wave: dict[str, Path] = {}
 
@@ -244,13 +249,14 @@ def main(
     if wave_path_pacific is not None:
         corridor_wave["pacific"] = wave_path_pacific
 
-    # --wind-path / --wave-path act as fallback for all corridors
+    # Shared paths intentionally override the corridor defaults so the
+    # simplest one-flag workflow still works for single-corridor runs.
     if wind_path is not None:
-        corridor_wind.setdefault("atlantic", wind_path)
-        corridor_wind.setdefault("pacific", wind_path)
+        corridor_wind["atlantic"] = wind_path
+        corridor_wind["pacific"] = wind_path
     if wave_path is not None:
-        corridor_wave.setdefault("atlantic", wave_path)
-        corridor_wave.setdefault("pacific", wave_path)
+        corridor_wave["atlantic"] = wave_path
+        corridor_wave["pacific"] = wave_path
 
     try:
         _validate_required_data_paths(case_ids, corridor_wind, corridor_wave)

--- a/scripts/swopp3_run.py
+++ b/scripts/swopp3_run.py
@@ -3,39 +3,114 @@ r"""Run SWOPP3 cases — CLI entry-point.
 
 Usage
 -----
-Run all 8 cases (GC only, no ERA5 data required):
+Default pipeline for the full 2024 SWOPP3 dataset:
 
-    python scripts/swopp3_run.py --strategy gc --output-dir output/swopp3
+    uv run scripts/download_era5.py
+    uv run scripts/swopp3_run.py
 
-Run Atlantic cases with ERA5 data:
+The defaults in this script expect the four NetCDF files written by
+``scripts/download_era5.py`` for year 2024. If any required file is missing,
+the command fails before execution and explains exactly which datasets are
+missing and why they are required.
 
-    python scripts/swopp3_run.py \\
-        --cases AGC_WPS AGC_noWPS \\
-        --wind-path data/era5/era5_wind_atlantic_2024.nc \\
-        --wave-path data/era5/era5_waves_atlantic_2024.nc \\
+Run all 8 cases with explicit per-corridor paths:
+
+    uv run scripts/swopp3_run.py \
+        --wind-path-atlantic data/era5/era5_wind_atlantic_2024.nc \
+        --wave-path-atlantic data/era5/era5_waves_atlantic_2024.nc \
+        --wind-path-pacific  data/era5/era5_wind_pacific_2024.nc  \
+        --wave-path-pacific  data/era5/era5_waves_pacific_2024.nc  \
         --output-dir output/swopp3
 
-Run all 8 cases with per-corridor ERA5 data:
+Run only Atlantic cases after downloading Atlantic data:
 
-    python scripts/swopp3_run.py \\
-        --wind-path-atlantic data/era5/era5_wind_atlantic_2024.nc \\
-        --wave-path-atlantic data/era5/era5_waves_atlantic_2024.nc \\
-        --wind-path-pacific  data/era5/era5_wind_pacific_2024.nc  \\
-        --wave-path-pacific  data/era5/era5_waves_pacific_2024.nc  \\
+    uv run scripts/swopp3_run.py \
+        --cases AGC_WPS AGC_noWPS \
+        --wind-path data/era5/era5_wind_atlantic_2024.nc \
+        --wave-path data/era5/era5_waves_atlantic_2024.nc \
         --output-dir output/swopp3
 
 Run only the first 3 departures (quick test):
 
-    python scripts/swopp3_run.py --max-departures 3 --output-dir output/swopp3
+    uv run scripts/swopp3_run.py --max-departures 3 --output-dir output/swopp3
 """
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 
 import typer
+import xarray as xr
 
-app = typer.Typer(help="SWOPP3 competition runner.")
+from routetools.era5.loader import (
+    load_dataset_epoch,
+    load_era5_vectorfield,
+    load_era5_wavefield,
+    load_era5_windfield,
+    load_natural_earth_land_mask,
+)
+from routetools.swopp3 import SWOPP3_CASES, departures_2024
+from routetools.swopp3_runner import FieldClosure, run_case
+
+app = typer.Typer(
+    help=(
+        "SWOPP3 competition runner. Expects ERA5 files produced by "
+        "scripts/download_era5.py unless explicit paths are provided."
+    )
+)
+
+
+def _selected_corridors(case_ids: list[str]) -> list[str]:
+    """Return the sorted set of route corridors required by ``case_ids``."""
+    return sorted({str(SWOPP3_CASES[cid]["route"]) for cid in case_ids})
+
+
+def _validate_required_data_paths(
+    case_ids: list[str],
+    corridor_wind: dict[str, Path],
+    corridor_wave: dict[str, Path],
+) -> None:
+    """Fail fast when the ERA5 inputs required by the selected cases are missing."""
+    required_corridors = _selected_corridors(case_ids)
+    missing: list[str] = []
+
+    for corridor in required_corridors:
+        wind = corridor_wind.get(corridor)
+        wave = corridor_wave.get(corridor)
+
+        if wind is None:
+            missing.append(f"{corridor} wind dataset path is not configured")
+        elif not Path(wind).exists():
+            missing.append(f"{corridor} wind dataset not found: {wind}")
+
+        if wave is None:
+            missing.append(f"{corridor} wave dataset path is not configured")
+        elif not Path(wave).exists():
+            missing.append(f"{corridor} wave dataset not found: {wave}")
+
+    if not missing:
+        return
+
+    corridor_list = ", ".join(required_corridors)
+    missing_lines = "\n".join(f"- {item}" for item in missing)
+    raise FileNotFoundError(
+        "SWOPP3 input validation failed.\n\n"
+        f"Selected cases require ERA5 datasets for corridor(s): {corridor_list}.\n"
+        "This CLI requires weather data for every selected case:\n"
+        "- GC cases use wind and wave data during SWOPP3 energy evaluation.\n"
+        "- Optimised cases use wind data to build the CMA-ES vectorfield "
+        "and use wind/wave data during energy evaluation.\n"
+        "- Missing ERA5 files are a hard error; there is no fallback "
+        "to GC or no-weather mode.\n\n"
+        f"Missing inputs:\n{missing_lines}\n\n"
+        "Fix:\n"
+        "- Run `uv run scripts/download_era5.py` to download the default "
+        "2024 Atlantic and Pacific datasets, then rerun "
+        "`uv run scripts/swopp3_run.py`.\n"
+        "- If you downloaded a different year or only one corridor, "
+        "pass matching `--wind-path*` and `--wave-path*` options."
+    )
 
 
 @app.command()
@@ -63,24 +138,36 @@ def main(
         help="Path to ERA5 wave NetCDF (single corridor, used for all cases).",
     ),
     wind_path_atlantic: Path | None = typer.Option(  # noqa: B008
-        None,
+        "data/era5/era5_wind_atlantic_2024.nc",
         "--wind-path-atlantic",
-        help="Path to ERA5 wind NetCDF for Atlantic corridor.",
+        help=(
+            "Path to ERA5 wind NetCDF for Atlantic corridor. Defaults to the "
+            "file written by scripts/download_era5.py for year 2024."
+        ),
     ),
     wave_path_atlantic: Path | None = typer.Option(  # noqa: B008
-        None,
+        "data/era5/era5_waves_atlantic_2024.nc",
         "--wave-path-atlantic",
-        help="Path to ERA5 wave NetCDF for Atlantic corridor.",
+        help=(
+            "Path to ERA5 wave NetCDF for Atlantic corridor. Defaults to the "
+            "file written by scripts/download_era5.py for year 2024."
+        ),
     ),
     wind_path_pacific: Path | None = typer.Option(  # noqa: B008
-        None,
+        "data/era5/era5_wind_pacific_2024.nc",
         "--wind-path-pacific",
-        help="Path to ERA5 wind NetCDF for Pacific corridor.",
+        help=(
+            "Path to ERA5 wind NetCDF for Pacific corridor. Defaults to the "
+            "file written by scripts/download_era5.py for year 2024."
+        ),
     ),
     wave_path_pacific: Path | None = typer.Option(  # noqa: B008
-        None,
+        "data/era5/era5_waves_pacific_2024.nc",
         "--wave-path-pacific",
-        help="Path to ERA5 wave NetCDF for Pacific corridor.",
+        help=(
+            "Path to ERA5 wave NetCDF for Pacific corridor. Defaults to the "
+            "file written by scripts/download_era5.py for year 2024."
+        ),
     ),
     output_dir: Path = typer.Option(  # noqa: B008
         "output/swopp3",
@@ -111,10 +198,13 @@ def main(
         help="Suppress progress output.",
     ),
 ) -> None:
-    """Run SWOPP3 competition cases."""
-    from routetools.swopp3 import SWOPP3_CASES, departures_2024
-    from routetools.swopp3_runner import run_case
+    """Run SWOPP3 competition cases.
 
+    The default invocation expects the 2024 ERA5 files produced by
+    ``scripts/download_era5.py``. The command validates those inputs before
+    loading any corridor and exits with a precise message if a required file
+    is missing.
+    """
     # ---- Select cases ----
     if cases is not None:
         case_ids = cases
@@ -142,8 +232,8 @@ def main(
 
     # ---- Build per-corridor field map ----
     # Resolve which wind/wave paths to use for each corridor.
-    corridor_wind = {}
-    corridor_wave = {}
+    corridor_wind: dict[str, Path] = {}
+    corridor_wave: dict[str, Path] = {}
 
     if wind_path_atlantic is not None:
         corridor_wind["atlantic"] = wind_path_atlantic
@@ -162,56 +252,52 @@ def main(
         corridor_wave.setdefault("atlantic", wave_path)
         corridor_wave.setdefault("pacific", wave_path)
 
-    # ---- Load fields per corridor (cache so we load each file once) ----
-    from routetools.era5.loader import (
-        load_dataset_epoch,
-        load_era5_vectorfield,
-        load_era5_wavefield,
-        load_era5_windfield,
-        load_natural_earth_land_mask,
-    )
+    try:
+        _validate_required_data_paths(case_ids, corridor_wind, corridor_wave)
+    except FileNotFoundError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from exc
 
-    _loaded_wind: dict[str, tuple] = {}  # corridor -> (windfield, epoch)
-    _loaded_wave: dict[str, tuple] = {}  # corridor -> (wavefield, epoch)
-    _loaded_vf: dict[str, object] = {}  # corridor -> vectorfield
+    # ---- Load fields per corridor (cache so we load each file once) ----
+
+    _loaded_wind: dict[str, tuple[FieldClosure, datetime]] = {}
+    _loaded_wave: dict[str, tuple[FieldClosure, datetime]] = {}
+    _loaded_vf: dict[str, FieldClosure] = {}  # corridor -> vectorfield
     _loaded_land: dict[str, object] = {}  # corridor -> Land
 
-    def _get_wind(corridor: str):
-        """Return (windfield_closure, dataset_epoch) for corridor, or (None, None)."""
+    def _get_wind(corridor: str) -> tuple[FieldClosure, datetime]:
+        """Return (windfield_closure, dataset_epoch) for corridor."""
         if corridor in _loaded_wind:
             return _loaded_wind[corridor]
         wp = corridor_wind.get(corridor)
         if wp is None:
-            _loaded_wind[corridor] = (None, None)
-            return None, None
+            raise ValueError(f"No wind path available for corridor '{corridor}'")
         typer.echo(f"Loading wind field for {corridor} from {wp} …")
         epoch = load_dataset_epoch(wp)
         wf = load_era5_windfield(wp)
         _loaded_wind[corridor] = (wf, epoch)
         return wf, epoch
 
-    def _get_vectorfield(corridor: str):
-        """Return vectorfield closure for corridor, or None."""
+    def _get_vectorfield(corridor: str) -> FieldClosure:
+        """Return vectorfield closure for corridor."""
         if corridor in _loaded_vf:
             return _loaded_vf[corridor]
         wp = corridor_wind.get(corridor)
         if wp is None:
-            _loaded_vf[corridor] = None
-            return None
+            raise ValueError(f"No wind path available for corridor '{corridor}'")
         # Reuse the wind-load epoch but build a vectorfield
         typer.echo(f"Loading vectorfield for {corridor} from {wp} …")
         vf = load_era5_vectorfield(wp)
         _loaded_vf[corridor] = vf
         return vf
 
-    def _get_wave(corridor: str):
-        """Return (wavefield_closure, dataset_epoch) for corridor, or (None, None)."""
+    def _get_wave(corridor: str) -> tuple[FieldClosure, datetime]:
+        """Return (wavefield_closure, dataset_epoch) for corridor."""
         if corridor in _loaded_wave:
             return _loaded_wave[corridor]
         wp = corridor_wave.get(corridor)
         if wp is None:
-            _loaded_wave[corridor] = (None, None)
-            return None, None
+            raise ValueError(f"No wave path available for corridor '{corridor}'")
         typer.echo(f"Loading wave field for {corridor} from {wp} …")
         epoch = load_dataset_epoch(wp)
         wvf = load_era5_wavefield(wp)
@@ -225,9 +311,7 @@ def main(
         # Determine corridor extent from the ERA5 wave or wind file
         wp = corridor_wave.get(corridor) or corridor_wind.get(corridor)
         if wp is None:
-            _loaded_land[corridor] = None
-            return None
-        import xarray as xr
+            raise ValueError(f"No wind/wave path available for corridor '{corridor}'")
 
         with xr.open_dataset(wp) as ds:
             for cname in ("longitude", "lon"):
@@ -270,7 +354,7 @@ def main(
 
         # Use the wind field epoch as canonical dataset epoch (both fields
         # share the same 2024-01-01 epoch from the ERA5 download).
-        dataset_epoch = wind_epoch or wave_epoch
+        dataset_epoch = wind_epoch
 
         results = run_case(
             cid,

--- a/scripts/swopp3_run.py
+++ b/scripts/swopp3_run.py
@@ -39,19 +39,12 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import typer
-import xarray as xr
 
-from routetools.era5.loader import (
-    load_dataset_epoch,
-    load_era5_vectorfield,
-    load_era5_wavefield,
-    load_era5_windfield,
-    load_natural_earth_land_mask,
-)
-from routetools.swopp3 import SWOPP3_CASES, departures_2024
-from routetools.swopp3_runner import FieldClosure, run_case
+if TYPE_CHECKING:
+    from routetools.swopp3_runner import FieldClosure
 
 app = typer.Typer(
     help=(
@@ -63,6 +56,8 @@ app = typer.Typer(
 
 def _selected_corridors(case_ids: list[str]) -> list[str]:
     """Return the sorted set of route corridors required by ``case_ids``."""
+    from routetools.swopp3 import SWOPP3_CASES
+
     return sorted({str(SWOPP3_CASES[cid]["route"]) for cid in case_ids})
 
 
@@ -211,6 +206,18 @@ def main(
     loading any corridor and exits with a precise message if a required file
     is missing.
     """
+    import xarray as xr
+
+    from routetools.era5.loader import (
+        load_dataset_epoch,
+        load_era5_vectorfield,
+        load_era5_wavefield,
+        load_era5_windfield,
+        load_natural_earth_land_mask,
+    )
+    from routetools.swopp3 import SWOPP3_CASES, departures_2024
+    from routetools.swopp3_runner import run_case
+
     # ---- Select cases ----
     if cases is not None:
         case_ids = cases

--- a/tests/test_swopp3_run.py
+++ b/tests/test_swopp3_run.py
@@ -17,7 +17,50 @@ def _load_swopp3_run_module():
     return module
 
 
-_validate_required_data_paths = _load_swopp3_run_module()._validate_required_data_paths
+_swopp3_run = _load_swopp3_run_module()
+_validate_required_data_paths = _swopp3_run._validate_required_data_paths
+
+
+def test_shared_cli_paths_override_default_corridor_paths(monkeypatch):
+    """Shared CLI paths should override the built-in corridor defaults."""
+
+    class StopCli(Exception):
+        pass
+
+    captured: dict[str, dict[str, Path]] = {}
+
+    def fake_validate(case_ids, corridor_wind, corridor_wave):
+        captured["wind"] = corridor_wind.copy()
+        captured["wave"] = corridor_wave.copy()
+        raise StopCli()
+
+    monkeypatch.setattr(_swopp3_run, "_validate_required_data_paths", fake_validate)
+
+    with pytest.raises(StopCli):
+        _swopp3_run.main(
+            cases=["AGC_WPS", "PGC_WPS"],
+            strategy=None,
+            wind_path=Path("shared_wind.nc"),
+            wave_path=Path("shared_wave.nc"),
+            wind_path_atlantic=Path("data/era5/era5_wind_atlantic_2024.nc"),
+            wave_path_atlantic=Path("data/era5/era5_waves_atlantic_2024.nc"),
+            wind_path_pacific=Path("data/era5/era5_wind_pacific_2024.nc"),
+            wave_path_pacific=Path("data/era5/era5_waves_pacific_2024.nc"),
+            output_dir=Path("output/swopp3"),
+            submission=1,
+            n_points=100,
+            max_departures=1,
+            quiet=True,
+        )
+
+    assert captured["wind"] == {
+        "atlantic": Path("shared_wind.nc"),
+        "pacific": Path("shared_wind.nc"),
+    }
+    assert captured["wave"] == {
+        "atlantic": Path("shared_wave.nc"),
+        "pacific": Path("shared_wave.nc"),
+    }
 
 
 def test_validate_required_data_paths_reports_missing_files(tmp_path: Path):

--- a/tests/test_swopp3_run.py
+++ b/tests/test_swopp3_run.py
@@ -1,0 +1,56 @@
+"""Tests for the SWOPP3 CLI input-validation helpers."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_swopp3_run_module():
+    """Load the CLI module directly from scripts/swopp3_run.py."""
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "swopp3_run.py"
+    spec = importlib.util.spec_from_file_location("swopp3_run", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module spec for {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_validate_required_data_paths = _load_swopp3_run_module()._validate_required_data_paths
+
+
+def test_validate_required_data_paths_reports_missing_files(tmp_path: Path):
+    """Validation error should explain which datasets are missing and why."""
+    wind_path = tmp_path / "era5_wind_atlantic_2024.nc"
+    wave_path = tmp_path / "era5_waves_atlantic_2024.nc"
+
+    with pytest.raises(
+        FileNotFoundError,
+        match="SWOPP3 input validation failed",
+    ) as exc_info:
+        _validate_required_data_paths(
+            ["AGC_WPS"],
+            {"atlantic": wind_path},
+            {"atlantic": wave_path},
+        )
+
+    message = str(exc_info.value)
+    assert str(wind_path) in message
+    assert str(wave_path) in message
+    assert "there is no fallback to GC or no-weather mode" in message
+    assert "uv run scripts/download_era5.py" in message
+
+
+def test_validate_required_data_paths_accepts_existing_files(tmp_path: Path):
+    """Validation should pass when the required files already exist."""
+    wind_path = tmp_path / "era5_wind_atlantic_2024.nc"
+    wave_path = tmp_path / "era5_waves_atlantic_2024.nc"
+    wind_path.touch()
+    wave_path.touch()
+
+    _validate_required_data_paths(
+        ["AGC_WPS"],
+        {"atlantic": wind_path},
+        {"atlantic": wave_path},
+    )

--- a/tests/test_swopp3_runner.py
+++ b/tests/test_swopp3_runner.py
@@ -206,15 +206,13 @@ class TestRunGCDeparture:
 
 
 # ---------------------------------------------------------------------------
-# run_optimised_departure  (without vectorfield → GC fallback)
+# run_optimised_departure
 # ---------------------------------------------------------------------------
 class TestRunOptimisedDeparture:
-    def test_fallback_without_vectorfield(self):
-        """Without a vectorfield, should fall back to GC route."""
-        result = run_optimised_departure("AO_WPS", _DEP, n_points=20)
-        assert isinstance(result, DepartureResult)
-        assert result.curve.shape == (20, 2)
-        assert result.energy_mwh > 0
+    def test_requires_vectorfield(self):
+        """Optimised departures should fail fast when vectorfield is missing."""
+        with pytest.raises(ValueError, match="requires a vectorfield"):
+            run_optimised_departure("AO_WPS", _DEP, n_points=20)
 
     def test_vectorfield_defaults_to_windfield_for_rise_cost(self, monkeypatch):
         """When windfield is missing, vectorfield should feed RISE energy cost."""
@@ -300,12 +298,14 @@ class TestRunCase:
         fb_files = list(fb_dir.glob("*.csv"))
         assert len(fb_files) == 2
 
-    def test_optimised_fallback_case(self, tmp_path: Path):
-        """Optimised case without vectorfield → GC fallback, with output."""
+    def test_optimised_case_with_vectorfield(self, tmp_path: Path):
+        """Optimised case writes output when the required vectorfield is provided."""
         deps = [_DEP]
         results = run_case(
             "AO_WPS",
             deps,
+            vectorfield=_zero_windfield,
+            windfield=_zero_windfield,
             output_dir=tmp_path,
             submission=1,
             n_points=20,
@@ -315,14 +315,29 @@ class TestRunCase:
         fa = tmp_path / "IEUniversity-1-AO_WPS.csv"
         assert fa.exists()
 
+    def test_optimised_case_requires_vectorfield(self):
+        """Optimised cases should fail fast instead of silently degrading to GC."""
+        with pytest.raises(ValueError, match="requires a vectorfield"):
+            run_case(
+                "AO_WPS",
+                [_DEP],
+                n_points=20,
+                verbose=False,
+            )
+
     def test_all_cases_runnable(self):
         """Smoke test: every case can run with 1 departure."""
         for case_id in SWOPP3_CASES:
+            kwargs = {}
+            if SWOPP3_CASES[case_id]["strategy"] == "optimised":
+                kwargs["vectorfield"] = _zero_windfield
+                kwargs["windfield"] = _zero_windfield
             results = run_case(
                 case_id,
                 [_DEP],
                 n_points=10,
                 verbose=False,
+                **kwargs,
             )
             assert len(results) == 1
             assert results[0].energy_mwh > 0


### PR DESCRIPTION
## Goal

Fix the SWOPP3 failure mode where the runner would continue and silently emit great-circle style results when the required weather inputs were missing. The intended behaviour is to fail early and explain precisely which ERA5 datasets are required, so a new user can follow the default pipeline from `download_era5` to `swopp3` without hidden fallbacks or extra tweaks.

## Problem

Previously, the optimized SWOPP3 path could run without the required weather/vector data and degrade silently into GC-like output. That made the pipeline look successful even though the optimized route had not actually been evaluated with the expected inputs.

## What changed

- make optimized SWOPP3 runs fail fast when `vectorfield` data is missing instead of falling back silently
- add CLI-level validation in `scripts/swopp3_run.py` for the default ERA5 wind and wave files before execution starts
- raise precise `FileNotFoundError` messages that list the missing files and point users to `uv run scripts/download_era5.py`
- document the default two-step workflow in the README and script help so the expected pipeline is explicit
- align runner and CLI tests with the fail-fast behaviour
- update the plotting script default input directory to match the runner output directory

## Why this is better

A missing-data run should be an explicit failure, not a silent behaviour change. This makes the SWOPP3 pipeline safer to use, easier to debug, and much clearer for new users who expect `download_era5 -> swopp3` to work as the documented default path.

## Validation

- `make hooks`
- `make test`
