### PR TITLE
Update FMS

### DIFF
--- a/routetools/cost.py
+++ b/routetools/cost.py
@@ -15,6 +15,12 @@ from routetools._cost.haversine import (
 )
 from routetools._cost.waves import wave_adjusted_speed
 from routetools.land import Land, move_curve_away_from_land
+from routetools.weather import (
+    DEFAULT_HS_LIMIT,
+    DEFAULT_TWS_LIMIT,
+    wave_penalty_smooth,
+    wind_penalty_smooth,
+)
 
 try:
     from routetools.performance import predict_power_batch, predict_power_jax
@@ -729,6 +735,92 @@ def cost_function_rise(
     energy_mwh = jnp.sum(power_kw, axis=1) * dt_h / 1000.0
 
     return energy_mwh
+
+
+def cost_function_rise_penalized(
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ],
+    curve: jnp.ndarray,
+    travel_time: float,
+    wavefield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
+    wps: bool = False,
+    time_offset: float = 0.0,
+    wave_penalty_weight: float = 0.0,
+    wind_penalty_weight: float = 0.0,
+    hs_limit: float = DEFAULT_HS_LIMIT,
+    tws_limit: float = DEFAULT_TWS_LIMIT,
+) -> jnp.ndarray:
+    """Compute RISE energy with penalties for high wind/wave conditions.
+
+    This is a variant of cost_function_rise that adds penalty terms to the
+    energy cost for segments with high wind speeds or wave heights.  The
+    penalties are linear in the segment's maximum wind speed and wave height,
+    scaled by the provided penalty factors.
+
+    Parameters
+    ----------
+    windfield : Callable
+        ``(lon, lat, t) -> (u10, v10)`` where ``u10, v10`` are wind
+        components in m/s.  ``t`` is in the same unit as *travel_time*
+        (hours for ERA5).
+    curve : jnp.ndarray
+        Batch of trajectories, shape ``(B, L, 2)`` with ``(lon, lat)``
+        in degrees. Coordinate order must match the wind/wave fields.
+    travel_time : float
+        Fixed total passage time (hours).
+    wavefield : Callable, optional
+        ``(lon, lat, t) -> (hs, mwd)`` where ``hs`` is significant wave
+        height in metres and ``mwd`` is mean wave direction (degrees
+        from North).
+    wps : bool
+        Whether wingsails are deployed.
+    time_offset : float
+        Departure offset in hours from the field's time origin.
+    wave_penalty_weight : float
+        Multiplier for the smooth wave-height penalty term.
+    wind_penalty_weight : float
+        Multiplier for the smooth wind-speed penalty term.
+    hs_limit : float
+        Wave-height threshold in metres used by the smooth penalty.
+    tws_limit : float
+        Wind-speed threshold in m/s used by the smooth penalty.
+    """
+    cost = cost_function_rise(
+        windfield=windfield,
+        curve=curve,
+        travel_time=travel_time,
+        wavefield=wavefield,
+        wps=wps,
+        time_offset=time_offset,
+    )
+
+    cost_wave = jnp.zeros_like(cost)
+    if wavefield is not None and wave_penalty_weight > 0:
+        cost_wave = wave_penalty_smooth(
+            curve,
+            wavefield,
+            hs_limit=hs_limit,
+            weight=wave_penalty_weight,
+            travel_time=travel_time,
+            time_offset=time_offset,
+        )
+
+    cost_wind = jnp.zeros_like(cost)
+    if wind_penalty_weight > 0:
+        cost_wind = wind_penalty_smooth(
+            curve,
+            windfield,
+            tws_limit=tws_limit,
+            weight=wind_penalty_weight,
+            travel_time=travel_time,
+            time_offset=time_offset,
+        )
+
+    return cost + cost_wave + cost_wind
 
 
 def interpolate_to_constant_cost(

--- a/routetools/era5/loader.py
+++ b/routetools/era5/loader.py
@@ -42,6 +42,15 @@ logger = logging.getLogger(__name__)
 # ── helpers ───────────────────────────────────────────────────────────────
 
 
+def _to_numpy_datetime64(
+    value: datetime | str | np.datetime64,
+) -> np.datetime64:
+    """Normalize supported datetime inputs to ``numpy.datetime64``."""
+    if isinstance(value, np.datetime64):
+        return value
+    return np.datetime64(value)
+
+
 def _load_dataset(path: str | Path) -> xr.Dataset:
     """Open a NetCDF file with xarray.
 
@@ -111,6 +120,32 @@ def _get_coord_name(ds: xr.Dataset, candidates: list[str]) -> str:
     )
 
 
+def _slice_dataset_time(
+    ds: xr.Dataset,
+    *,
+    time_start: datetime | str | np.datetime64 | None = None,
+    time_end: datetime | str | np.datetime64 | None = None,
+) -> xr.Dataset:
+    """Return a dataset sliced to the requested time window."""
+    if time_start is None and time_end is None:
+        return ds
+
+    time_name = _get_coord_name(ds, ["time", "valid_time"])
+    start_np = None if time_start is None else _to_numpy_datetime64(time_start)
+    end_np = None if time_end is None else _to_numpy_datetime64(time_end)
+
+    if start_np is not None and end_np is not None and end_np < start_np:
+        raise ValueError("time_end must be greater than or equal to time_start")
+
+    sliced = ds.sel({time_name: slice(start_np, end_np)})
+    if sliced.sizes.get(time_name, 0) == 0:
+        raise ValueError(
+            "Requested ERA5 time window is empty: "
+            f"start={time_start!s}, end={time_end!s}"
+        )
+    return sliced
+
+
 def _prepare_grid(
     ds: xr.Dataset,
     departure_time: datetime | str | np.datetime64 | None = None,
@@ -178,7 +213,12 @@ def _prepare_grid(
     }
 
 
-def load_dataset_epoch(path: str | Path | Sequence[str | Path]) -> datetime:
+def load_dataset_epoch(
+    path: str | Path | Sequence[str | Path],
+    *,
+    time_start: datetime | str | np.datetime64 | None = None,
+    time_end: datetime | str | np.datetime64 | None = None,
+) -> datetime:
     """Return the first ERA5 timestamp as a naive UTC datetime.
 
     Parameters
@@ -192,7 +232,11 @@ def load_dataset_epoch(path: str | Path | Sequence[str | Path]) -> datetime:
     datetime
         First dataset timestamp as timezone-naive UTC datetime.
     """
-    ds = _load_datasets(path)
+    ds = _slice_dataset_time(
+        _load_datasets(path),
+        time_start=time_start,
+        time_end=time_end,
+    )
     try:
         time_name = _get_coord_name(ds, ["time", "valid_time"])
         epoch_np = ds[time_name].values[0]
@@ -304,6 +348,8 @@ def load_era5_windfield(
     path: str | Path | Sequence[str | Path],
     departure_time: datetime | str | np.datetime64 | None = None,
     voyage_hours: float | None = None,
+    time_start: datetime | str | np.datetime64 | None = None,
+    time_end: datetime | str | np.datetime64 | None = None,
     order: int = 1,
     u_var: str | None = None,
     v_var: str | None = None,
@@ -329,6 +375,10 @@ def load_era5_windfield(
     voyage_hours : float, optional
         Expected voyage duration in hours.  If provided and the dataset does
         not cover the full voyage, a warning is logged.
+    time_start, time_end : datetime or str or np.datetime64, optional
+        Inclusive time window to load from the underlying ERA5 dataset before
+        converting it to JAX arrays.  Use this to cap memory to a rolling
+        subset of the full timeline.
     order : int
         Interpolation order (1 = linear, default).
     u_var : str, optional
@@ -341,7 +391,11 @@ def load_era5_windfield(
     Callable
         ``(lon, lat, t) -> (u10, v10)`` with ``.is_time_variant = True``.
     """
-    ds = _load_datasets(path)
+    ds = _slice_dataset_time(
+        _load_datasets(path),
+        time_start=time_start,
+        time_end=time_end,
+    )
 
     # Auto-detect variable names
     if u_var is None:
@@ -423,6 +477,8 @@ def load_era5_vectorfield(
     path: str | Path | Sequence[str | Path],
     departure_time: datetime | str | np.datetime64 | None = None,
     voyage_hours: float | None = None,
+    time_start: datetime | str | np.datetime64 | None = None,
+    time_end: datetime | str | np.datetime64 | None = None,
     order: int = 1,
     u_var: str | None = None,
     v_var: str | None = None,
@@ -445,6 +501,8 @@ def load_era5_vectorfield(
         path,
         departure_time=departure_time,
         voyage_hours=voyage_hours,
+        time_start=time_start,
+        time_end=time_end,
         order=order,
         u_var=u_var,
         v_var=v_var,
@@ -455,6 +513,8 @@ def load_era5_wavefield(
     path: str | Path | Sequence[str | Path],
     departure_time: datetime | str | np.datetime64 | None = None,
     voyage_hours: float | None = None,
+    time_start: datetime | str | np.datetime64 | None = None,
+    time_end: datetime | str | np.datetime64 | None = None,
     order: int = 1,
     hs_var: str | None = None,
     dir_var: str | None = None,
@@ -480,6 +540,9 @@ def load_era5_wavefield(
     voyage_hours : float, optional
         Expected voyage duration in hours.  If provided and the dataset does
         not cover the full voyage, a warning is logged.
+    time_start, time_end : datetime or str or np.datetime64, optional
+        Inclusive time window to load from the underlying ERA5 dataset before
+        converting it to JAX arrays.
     order : int
         Interpolation order (1 = linear, default).
     hs_var : str, optional
@@ -492,7 +555,11 @@ def load_era5_wavefield(
     Callable
         ``(lon, lat, t) -> (hs, mwd)``.
     """
-    ds = _load_datasets(path)
+    ds = _slice_dataset_time(
+        _load_datasets(path),
+        time_start=time_start,
+        time_end=time_end,
+    )
 
     # Auto-detect variable names
     if hs_var is None:

--- a/routetools/fms.py
+++ b/routetools/fms.py
@@ -1,6 +1,31 @@
+"""Finite-difference route refinement utilities.
+
+This module implements the FMS post-processing stage used after CMA-ES. Given
+an initial route, `optimize_fms` repeatedly solves local Euler-Lagrange style
+updates for the interior waypoints, applies land and optional hard weather
+constraints, and tracks the best route found across iterations. It supports
+both the built-in physics cost and custom objective callables, including the
+SWOPP3 RISE energy objective forwarded through `costfun` and `costfun_kwargs`.
+
+The file also contains the custom-cost caching helpers introduced for the
+SWOPP3 speedup work. Those helpers memoize the travel-time evaluator and solver
+stack when the custom objective and forwarded kwargs are hashable, avoiding a
+fresh JAX build for every departure while preserving the same numerical update
+rule.
+
+New in this workflow is the optional `snapshot_callback` hook on
+`optimize_fms`. The callback receives one dictionary per iteration with the
+current routes, current costs, best-so-far routes, best-so-far costs, and the
+early-stop counters. This makes the refinement loop observable for animation
+and debugging, while keeping the normal API and solver behavior unchanged when
+the hook is not used.
+"""
+
+import inspect
 import time
 from collections.abc import Callable
-from typing import Any
+from functools import lru_cache
+from typing import Any, Protocol
 
 import jax
 import jax.numpy as jnp
@@ -11,6 +36,268 @@ from jax import grad, jacfwd, jacrev, jit, vmap
 from routetools.cost import cost_function
 from routetools.land import Land
 from routetools.vectorfield import vectorfield_fourvortices
+from routetools.weather import (
+    DEFAULT_HS_LIMIT,
+    DEFAULT_TWS_LIMIT,
+)
+from routetools.weather import (
+    weather_penalty as _weather_penalty,
+)
+
+
+class FmsCustomCostPositional(Protocol):
+    """Custom FMS cost that takes the curve as a positional argument."""
+
+    def __call__(self, curve: jnp.ndarray, /, **kwargs: Any) -> jnp.ndarray:
+        """Evaluate a batch of routes."""
+
+
+class FmsCustomCostKeyword(Protocol):
+    """Custom FMS cost that takes the curve as a keyword argument."""
+
+    def __call__(self, *, curve: jnp.ndarray, **kwargs: Any) -> jnp.ndarray:
+        """Evaluate a batch of routes."""
+
+
+type FmsCustomCostFunction = FmsCustomCostPositional | FmsCustomCostKeyword
+type FmsCostFunction = Callable[..., jnp.ndarray] | FmsCustomCostFunction
+type FmsSnapshot = dict[str, Any]
+type FmsSnapshotCallback = Callable[[FmsSnapshot], None]
+
+
+def _sorted_costfun_kwargs_items(
+    costfun_kwargs: dict[str, Any],
+) -> tuple[tuple[str, Any], ...] | None:
+    """Return a hashable representation of custom cost kwargs when possible."""
+    try:
+        return tuple(sorted(costfun_kwargs.items()))
+    except TypeError:
+        return None
+
+
+@lru_cache(maxsize=32)
+def _build_custom_evaluate_cost(
+    user_costfun: FmsCostFunction,
+    costfun_kwargs_items: tuple[tuple[str, Any], ...],
+    custom_cost_accepts_kwargs: bool,
+    custom_cost_accepts_curve_keyword: bool,
+    custom_cost_parameter_names: tuple[str, ...],
+    weight_l1: float,
+    weight_l2: float,
+    spherical_correction: bool,
+) -> Callable[..., jnp.ndarray]:
+    """Build a reusable custom cost wrapper for FMS."""
+    resolved_costfun_kwargs = dict(costfun_kwargs_items)
+    parameter_names = set(custom_cost_parameter_names)
+
+    def _evaluate_cost(
+        curve_eval: jnp.ndarray,
+        *,
+        travel_stw_eval: float | None = None,
+        travel_time_eval: float | None = None,
+        time_offset_eval: float = 0.0,
+    ) -> jnp.ndarray:
+        cost_kwargs = {
+            **resolved_costfun_kwargs,
+            "travel_stw": travel_stw_eval,
+            "travel_time": travel_time_eval,
+            "weight_l1": weight_l1,
+            "weight_l2": weight_l2,
+            "spherical_correction": spherical_correction,
+            "time_offset": time_offset_eval,
+        }
+        if not custom_cost_accepts_kwargs:
+            cost_kwargs = {
+                name: value
+                for name, value in cost_kwargs.items()
+                if name in parameter_names
+            }
+        if custom_cost_accepts_curve_keyword:
+            return user_costfun(curve=curve_eval, **cost_kwargs)
+        return user_costfun(curve_eval, **cost_kwargs)
+
+    return _evaluate_cost
+
+
+@lru_cache(maxsize=32)
+def _build_travel_time_custom_solver(
+    evaluate_cost: Callable[..., jnp.ndarray],
+    damping: float,
+    h: float,
+) -> Callable[[jnp.ndarray, jnp.ndarray, jnp.ndarray], jnp.ndarray]:
+    """Build a reusable travel-time FMS solver for cacheable custom costs."""
+
+    def lagrangian(
+        q0: jnp.ndarray,
+        q1: jnp.ndarray,
+        segment_time_offset: float,
+    ) -> jnp.ndarray:
+        q = jnp.vstack([q0, q1])[None, ...]
+        lag = evaluate_cost(
+            q,
+            travel_time_eval=h,
+            time_offset_eval=segment_time_offset,
+        )
+        return jnp.sum(h * lag)
+
+    d1ld = grad(lagrangian, argnums=0)
+    d2ld = grad(lagrangian, argnums=1)
+    d11ld = hessian(lagrangian, argnums=0)
+    d22ld = hessian(lagrangian, argnums=1)
+
+    @jit  # type: ignore[misc]
+    def jacobian(
+        qkm1: jnp.ndarray,
+        qk: jnp.ndarray,
+        qkp1: jnp.ndarray,
+        left_time_offset: float,
+        right_time_offset: float,
+    ) -> jnp.ndarray:
+        b = -d2ld(qkm1, qk, left_time_offset) - d1ld(
+            qk,
+            qkp1,
+            right_time_offset,
+        )
+        a = d22ld(qkm1, qk, left_time_offset) + d11ld(
+            qk,
+            qkp1,
+            right_time_offset,
+        )
+        q: jnp.ndarray = jnp.linalg.solve(a, b)
+        return jnp.nan_to_num(q)
+
+    jac_vectorized = vmap(jacobian, in_axes=(0, 0, 0, 0, 0), out_axes=(0))
+
+    @jit  # type: ignore[misc]
+    def solve_equation(
+        curve: jnp.ndarray,
+        segment_time_offsets: jnp.ndarray,
+        q_max: jnp.ndarray,
+    ) -> jnp.ndarray:
+        curve_new = jnp.copy(curve)
+        q = jac_vectorized(
+            curve[:-2],
+            curve[1:-1],
+            curve[2:],
+            segment_time_offsets[:-1],
+            segment_time_offsets[1:],
+        )
+        dq = (1 - damping) * q
+        dq = jnp.clip(dq, -q_max, q_max)
+        return curve_new.at[1:-1].set(dq + curve[1:-1])
+
+    return jit(vmap(solve_equation, in_axes=(0, None, None), out_axes=(0)))
+
+
+def _weather_violation_mask(
+    curve: jnp.ndarray,
+    *,
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
+    wavefield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
+    enforce_weather_limits: bool = False,
+    tws_limit: float = DEFAULT_TWS_LIMIT,
+    hs_limit: float = DEFAULT_HS_LIMIT,
+    travel_stw: float | None = None,
+    travel_time: float | None = None,
+    spherical_correction: bool = False,
+    time_offset: float = 0.0,
+) -> jnp.ndarray:
+    """Return a per-route mask for weather-limit violations."""
+    if not enforce_weather_limits or (windfield is None and wavefield is None):
+        return jnp.zeros(curve.shape[0], dtype=bool)
+
+    return (
+        _weather_penalty(
+            curve,
+            windfield=windfield,
+            wavefield=wavefield,
+            tws_limit=tws_limit,
+            hs_limit=hs_limit,
+            penalty=1.0,
+            travel_stw=travel_stw,
+            travel_time=travel_time,
+            spherical_correction=spherical_correction,
+            time_offset=time_offset,
+        )
+        > 0
+    )
+
+
+def _apply_curve_constraints(
+    curve: jnp.ndarray,
+    curve_old: jnp.ndarray,
+    *,
+    land: Land | None = None,
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
+    wavefield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
+    enforce_weather_limits: bool = False,
+    tws_limit: float = DEFAULT_TWS_LIMIT,
+    hs_limit: float = DEFAULT_HS_LIMIT,
+    travel_stw: float | None = None,
+    travel_time: float | None = None,
+    spherical_correction: bool = False,
+    time_offset: float = 0.0,
+    penalty: float = 0.0,
+) -> jnp.ndarray:
+    """Reject updates that newly become invalid and keep previous valid states.
+
+    Land updates are reverted point-wise only when a previously valid waypoint
+    becomes invalid. Waypoints that were already invalid are allowed to keep
+    moving, so FMS can escape an initially invalid route. Weather updates are
+    reverted per route only when a previously weather-feasible route becomes
+    weather-infeasible. Routes that were already weather-invalid are allowed to
+    keep moving, so FMS can escape an initially violating route.
+    """
+    curve_constrained = curve
+
+    if land is not None and penalty > 0:
+        is_land_old = land(curve_old) > 0
+        is_land_new = land(curve_constrained) > 0
+        newly_invalid = (~is_land_old) & is_land_new
+        curve_constrained = jnp.where(
+            newly_invalid[..., None],
+            curve_old,
+            curve_constrained,
+        )
+
+    weather_invalid_old = _weather_violation_mask(
+        curve_old,
+        windfield=windfield,
+        wavefield=wavefield,
+        enforce_weather_limits=enforce_weather_limits,
+        tws_limit=tws_limit,
+        hs_limit=hs_limit,
+        travel_stw=travel_stw,
+        travel_time=travel_time,
+        spherical_correction=spherical_correction,
+        time_offset=time_offset,
+    )
+    weather_invalid_new = _weather_violation_mask(
+        curve_constrained,
+        windfield=windfield,
+        wavefield=wavefield,
+        enforce_weather_limits=enforce_weather_limits,
+        tws_limit=tws_limit,
+        hs_limit=hs_limit,
+        travel_stw=travel_stw,
+        travel_time=travel_time,
+        spherical_correction=spherical_correction,
+        time_offset=time_offset,
+    )
+    newly_weather_invalid = (~weather_invalid_old) & weather_invalid_new
+    return jnp.where(newly_weather_invalid[:, None, None], curve_old, curve_constrained)
 
 
 def random_piecewise_curve(
@@ -118,6 +405,10 @@ def optimize_fms(
     dst: jnp.ndarray | None = None,
     curve: jnp.ndarray | None = None,
     land: Land | None = None,
+    windfield: Callable[
+        [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
+    ]
+    | None = None,
     wavefield: Callable[
         [jnp.ndarray, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray]
     ]
@@ -133,9 +424,15 @@ def optimize_fms(
     weight_l1: float = 1.0,
     weight_l2: float = 0.0,
     spherical_correction: bool = False,
-    costfun: Callable | None = None,
+    costfun: FmsCostFunction | None = None,
+    costfun_kwargs: dict[str, Any] | None = None,
     seed: int = 0,
     verbose: bool = True,
+    snapshot_callback: FmsSnapshotCallback | None = None,
+    time_offset: float = 0.0,
+    enforce_weather_limits: bool = False,
+    tws_limit: float = DEFAULT_TWS_LIMIT,
+    hs_limit: float = DEFAULT_HS_LIMIT,
 ) -> tuple[jnp.ndarray, dict[str, Any]]:
     """
     Optimize a curve using the FMS algorithm.
@@ -155,6 +452,8 @@ def optimize_fms(
         Curve to optimize, shape L x 2, by default None
     land_function : Callable[[jnp.ndarray], jnp.ndarray] | None, optional
         Land function, by default None
+    windfield : Callable, optional
+        Wind field closure used to enforce route weather limits.
     num_curves : int, optional
         Number of curves to optimize, only used when initial curves are not provided,
         by default 10
@@ -177,12 +476,45 @@ def optimize_fms(
         Weight for the L2 norm in the combined cost. Default is 0.0.
     spherical_correction : bool, optional
         Whether to apply spherical correction, by default False
-    costfun : Callable | None, optional
-        Custom cost function, by default None
+    costfun : FmsCostFunction | None, optional
+        Cost function used by FMS for both motion and best-route tracking.
+
+        Two modes are supported.
+
+        1. ``None`` or ``routetools.cost.cost_function``:
+           FMS uses the built-in default cost and injects ``vectorfield``,
+           ``wavefield``, travel parameters, weights, and spherical correction.
+
+        2. Custom closure, like CMA-ES ``cost_fn``:
+           the closure may capture any required vector, wind, or wave fields
+           internally, or they may be supplied via ``costfun_kwargs``.
+           FMS forwards the route plus generic travel context,
+           namely ``travel_stw``, ``travel_time``, ``weight_l1``,
+           ``weight_l2``, ``spherical_correction``, and ``time_offset``.
+           The route may be accepted either positionally
+           (``costfun(curve, ...)``) or by keyword (``costfun(curve=..., ...)``).
+    costfun_kwargs : dict[str, Any] | None, optional
+        Extra keyword arguments forwarded to a custom ``costfun`` on every
+        evaluation. Ignored when using the built-in default cost.
     seed : int, optional
         Random seed for reproducibility, by default 0
     verbose : bool, optional
         Print optimization progress, by default True
+    snapshot_callback : callable, optional
+        Called after every FMS iteration with the current routes, their costs,
+        and the best-so-far routes/costs. Default is ``None``.
+    time_offset : float, optional
+        Offset added to segment timestamps before querying time-variant
+        fields, by default 0.0
+    enforce_weather_limits : bool, optional
+        Reject only FMS updates that newly violate the configured weather
+        limits. Already-violating routes may keep moving so FMS can escape an
+        initially infeasible route. By default False.
+    tws_limit : float, optional
+        Maximum allowed true wind speed in m/s when weather limits are enforced.
+    hs_limit : float, optional
+        Maximum allowed significant wave height in m when weather limits are
+        enforced.
 
     Returns
     -------
@@ -205,39 +537,123 @@ def optimize_fms(
         raise ValueError("Input curve must be 2D (L x 2) or 3D (B x L x 2)")
     assert curve.shape[-1] == 2, "Last dimension must be 2 (X, Y)"
 
-    # If land is provided, ensure that no points are on land at initialization
-    if land is not None and penalty > 0:
-        is_land = land(curve) > 0
-        if is_land.any():
-            # List the indices in land
-            indices_in_land = jnp.argwhere(is_land).tolist()
-            raise ValueError(
-                "[ERROR] Initial curve has points on land at indices: "
-                f"{indices_in_land} "
-                "Please provide a valid curve for FMS."
+    # Normalize costfun to the internal call signature used by _evaluate_cost.
+    user_costfun = cost_function if costfun is None else costfun
+    use_builtin_costfun = user_costfun is cost_function
+    resolved_costfun_kwargs = {} if costfun_kwargs is None else dict(costfun_kwargs)
+    costfun_kwargs_items: tuple[tuple[str, Any], ...] | None = None
+
+    if use_builtin_costfun and resolved_costfun_kwargs:
+        raise ValueError("costfun_kwargs requires a custom costfun")
+
+    custom_cost_signature: inspect.Signature | None = None
+    custom_cost_accepts_kwargs = False
+    custom_cost_accepts_curve_keyword = False
+    custom_cost_parameter_names: set[str] = set()
+    if not use_builtin_costfun:
+        try:
+            custom_cost_signature = inspect.signature(user_costfun)
+        except (TypeError, ValueError):
+            custom_cost_signature = None
+        if custom_cost_signature is not None:
+            custom_cost_parameter_names = set(custom_cost_signature.parameters)
+            custom_cost_accepts_kwargs = any(
+                parameter.kind == inspect.Parameter.VAR_KEYWORD
+                for parameter in custom_cost_signature.parameters.values()
+            )
+            custom_cost_accepts_curve_keyword = (
+                "curve" in custom_cost_parameter_names or custom_cost_accepts_kwargs
             )
 
-    # Define cost function
-    if costfun is None:
-        costfun = cost_function
+    if use_builtin_costfun:
+
+        def _evaluate_cost(
+            curve_eval: jnp.ndarray,
+            *,
+            travel_stw_eval: float | None = None,
+            travel_time_eval: float | None = None,
+            time_offset_eval: float = 0.0,
+        ) -> jnp.ndarray:
+            return user_costfun(
+                vectorfield=vectorfield,
+                curve=curve_eval,
+                wavefield=wavefield,
+                travel_stw=travel_stw_eval,
+                travel_time=travel_time_eval,
+                weight_l1=weight_l1,
+                weight_l2=weight_l2,
+                spherical_correction=spherical_correction,
+                time_offset=time_offset_eval,
+            )
+    else:
+        costfun_kwargs_items = _sorted_costfun_kwargs_items(resolved_costfun_kwargs)
+        custom_cost_parameter_names_tuple = tuple(sorted(custom_cost_parameter_names))
+
+        if costfun_kwargs_items is not None:
+            _evaluate_cost = _build_custom_evaluate_cost(
+                user_costfun,
+                costfun_kwargs_items,
+                custom_cost_accepts_kwargs,
+                custom_cost_accepts_curve_keyword,
+                custom_cost_parameter_names_tuple,
+                weight_l1,
+                weight_l2,
+                spherical_correction,
+            )
+        else:
+
+            def _evaluate_cost(
+                curve_eval: jnp.ndarray,
+                *,
+                travel_stw_eval: float | None = None,
+                travel_time_eval: float | None = None,
+                time_offset_eval: float = 0.0,
+            ) -> jnp.ndarray:
+                cost_kwargs = {
+                    **resolved_costfun_kwargs,
+                    "travel_stw": travel_stw_eval,
+                    "travel_time": travel_time_eval,
+                    "weight_l1": weight_l1,
+                    "weight_l2": weight_l2,
+                    "spherical_correction": spherical_correction,
+                    "time_offset": time_offset_eval,
+                }
+                if not custom_cost_accepts_kwargs:
+                    cost_kwargs = {
+                        name: value
+                        for name, value in cost_kwargs.items()
+                        if name in custom_cost_parameter_names
+                    }
+                if custom_cost_accepts_curve_keyword:
+                    return user_costfun(curve=curve_eval, **cost_kwargs)
+                return user_costfun(curve_eval, **cost_kwargs)
 
     # Initialize lagrangians
     if travel_stw is not None:
         # Average distance between points
         d = jnp.mean(jnp.linalg.norm(curve[:, 1:] - curve[:, :-1], axis=-1))
         h = float(d / travel_stw)
+        # NOTE: segment_time_offsets is derived from the initial route geometry
+        # and remains fixed throughout the optimization.  As the route evolves,
+        # the actual per-segment travel times change, so the time offsets become
+        # approximate.  This is acceptable for weakly time-variant fields but
+        # may introduce drift for strongly time-variant fields over many fevals.
+        segment_time_offsets = jnp.asarray(
+            time_offset + jnp.arange(curve.shape[1] - 1) * h,
+            dtype=jnp.float32,
+        )
 
-        def lagrangian(q0: jnp.ndarray, q1: jnp.ndarray) -> jnp.ndarray:
+        def lagrangian(
+            q0: jnp.ndarray,
+            q1: jnp.ndarray,
+            segment_time_offset: float,
+        ) -> jnp.ndarray:
             # Stack q0 and q1 to form array of shape (1, 2, 2)
             q = jnp.vstack([q0, q1])[None, ...]
-            lag = costfun(
-                vectorfield=vectorfield,
-                curve=q,
-                wavefield=wavefield,
-                travel_stw=travel_stw,
-                weight_l1=weight_l1,
-                weight_l2=weight_l2,
-                spherical_correction=spherical_correction,
+            lag = _evaluate_cost(
+                q,
+                travel_stw_eval=travel_stw,
+                time_offset_eval=segment_time_offset,
             )
             ld = jnp.sum(h * lag**2)
             # Do note: The original formula used q0, q1 to compute l1, l2 and then
@@ -247,62 +663,148 @@ def optimize_fms(
 
     elif travel_time is not None:
         assert travel_time > 0, "Travel time must be positive"
-        h = float(travel_time / curve.shape[1])
+        h = float(travel_time / (curve.shape[1] - 1))
+        segment_time_offsets = jnp.asarray(
+            time_offset + jnp.arange(curve.shape[1] - 1) * h,
+            dtype=jnp.float32,
+        )
 
-        def lagrangian(q0: jnp.ndarray, q1: jnp.ndarray) -> jnp.ndarray:
-            # Stack q0 and q1 to form array of shape (1, 2, 2)
-            q = jnp.vstack([q0, q1])[None, ...]
-            lag = costfun(
-                vectorfield=vectorfield,
-                curve=q,
-                wavefield=wavefield,
-                travel_time=h,
-                weight_l1=weight_l1,
-                weight_l2=weight_l2,
-                spherical_correction=spherical_correction,
+        q_max = jnp.mean(jnp.linalg.norm(curve[:, 1:] - curve[:, :-1], axis=-1))
+
+        if not use_builtin_costfun and costfun_kwargs_items is not None:
+            cached_solve_vectorized = _build_travel_time_custom_solver(
+                _evaluate_cost,
+                damping,
+                h,
             )
-            ld = jnp.sum(h * lag)
-            # Do note: The original formula used q0, q1 to compute l1, l2 and then
-            # took the average of (l1 + l2) / 2
-            # We simplified that without loss of generality
-            return ld
+
+            def solve_vectorized(curve_eval: jnp.ndarray) -> jnp.ndarray:
+                return cached_solve_vectorized(
+                    curve_eval,
+                    segment_time_offsets,
+                    q_max,
+                )
+        else:
+
+            def lagrangian(
+                q0: jnp.ndarray,
+                q1: jnp.ndarray,
+                segment_time_offset: float,
+            ) -> jnp.ndarray:
+                # Stack q0 and q1 to form array of shape (1, 2, 2)
+                q = jnp.vstack([q0, q1])[None, ...]
+                lag = _evaluate_cost(
+                    q,
+                    travel_time_eval=h,
+                    time_offset_eval=segment_time_offset,
+                )
+                ld = jnp.sum(h * lag)
+                # Do note: The original formula used q0, q1 to compute l1, l2 and then
+                # took the average of (l1 + l2) / 2
+                # We simplified that without loss of generality
+                return ld
+
+            d1ld = grad(lagrangian, argnums=0)
+            d2ld = grad(lagrangian, argnums=1)
+            d11ld = hessian(lagrangian, argnums=0)
+            d22ld = hessian(lagrangian, argnums=1)
+
+            @jit  # type: ignore[misc]
+            def jacobian(
+                qkm1: jnp.ndarray,
+                qk: jnp.ndarray,
+                qkp1: jnp.ndarray,
+                left_time_offset: float,
+                right_time_offset: float,
+            ) -> jnp.ndarray:
+                b = -d2ld(qkm1, qk, left_time_offset) - d1ld(
+                    qk,
+                    qkp1,
+                    right_time_offset,
+                )
+                a = d22ld(qkm1, qk, left_time_offset) + d11ld(
+                    qk,
+                    qkp1,
+                    right_time_offset,
+                )
+                q: jnp.ndarray = jnp.linalg.solve(a, b)
+                return jnp.nan_to_num(q)
+
+            jac_vectorized = vmap(jacobian, in_axes=(0, 0, 0, 0, 0), out_axes=(0))
+
+            @jit  # type: ignore[misc]
+            def solve_equation(curve: jnp.ndarray) -> jnp.ndarray:
+                curve_new = jnp.copy(curve)
+                q = jac_vectorized(
+                    curve[:-2],
+                    curve[1:-1],
+                    curve[2:],
+                    segment_time_offsets[:-1],
+                    segment_time_offsets[1:],
+                )
+                dq = (1 - damping) * q
+                # Clip updates to prevent divergence when the route is still
+                # far from a locally optimal path.
+                dq = jnp.clip(dq, -q_max, q_max)
+                return curve_new.at[1:-1].set(dq + curve[1:-1])
+
+            solve_vectorized = vmap(solve_equation, in_axes=(0), out_axes=(0))
 
     else:
         raise ValueError("Either travel_stw or travel_time must be provided")
 
-    d1ld = grad(lagrangian, argnums=0)
-    d2ld = grad(lagrangian, argnums=1)
-    d11ld = hessian(lagrangian, argnums=0)
-    d22ld = hessian(lagrangian, argnums=1)
+    if travel_stw is not None:
+        d1ld = grad(lagrangian, argnums=0)
+        d2ld = grad(lagrangian, argnums=1)
+        d11ld = hessian(lagrangian, argnums=0)
+        d22ld = hessian(lagrangian, argnums=1)
 
-    @jit  # type: ignore[misc]
-    def jacobian(qkm1: jnp.ndarray, qk: jnp.ndarray, qkp1: jnp.ndarray) -> jnp.ndarray:
-        b = -d2ld(qkm1, qk) - d1ld(qk, qkp1)
-        a = d22ld(qkm1, qk) + d11ld(qk, qkp1)
-        q: jnp.ndarray = jnp.linalg.solve(a, b)
-        return jnp.nan_to_num(q)
+        @jit  # type: ignore[misc]
+        def jacobian(
+            qkm1: jnp.ndarray,
+            qk: jnp.ndarray,
+            qkp1: jnp.ndarray,
+            left_time_offset: float,
+            right_time_offset: float,
+        ) -> jnp.ndarray:
+            b = -d2ld(qkm1, qk, left_time_offset) - d1ld(
+                qk,
+                qkp1,
+                right_time_offset,
+            )
+            a = d22ld(qkm1, qk, left_time_offset) + d11ld(
+                qk,
+                qkp1,
+                right_time_offset,
+            )
+            q: jnp.ndarray = jnp.linalg.solve(a, b)
+            return jnp.nan_to_num(q)
 
-    jac_vectorized = vmap(jacobian, in_axes=(0, 0, 0), out_axes=(0))
+        jac_vectorized = vmap(jacobian, in_axes=(0, 0, 0, 0, 0), out_axes=(0))
 
-    @jit  # type: ignore[misc]
-    def solve_equation(curve: jnp.ndarray) -> jnp.ndarray:
-        curve_new = jnp.copy(curve)
-        q = jac_vectorized(curve[:-2], curve[1:-1], curve[2:])
-        return curve_new.at[1:-1].set((1 - damping) * q + curve[1:-1])
+        q_max = jnp.mean(jnp.linalg.norm(curve[:, 1:] - curve[:, :-1], axis=-1))
 
-    solve_vectorized: Callable[[jnp.ndarray], jnp.ndarray] = vmap(
-        solve_equation, in_axes=(0), out_axes=(0)
-    )
+        @jit  # type: ignore[misc]
+        def solve_equation(curve: jnp.ndarray) -> jnp.ndarray:
+            curve_new = jnp.copy(curve)
+            q = jac_vectorized(
+                curve[:-2],
+                curve[1:-1],
+                curve[2:],
+                segment_time_offsets[:-1],
+                segment_time_offsets[1:],
+            )
+            dq = (1 - damping) * q
+            dq = jnp.clip(dq, -q_max, q_max)
+            return curve_new.at[1:-1].set(dq + curve[1:-1])
 
-    cost_now = costfun(
-        vectorfield=vectorfield,
-        curve=curve,
-        wavefield=wavefield,
-        travel_stw=travel_stw,
-        travel_time=travel_time,
-        weight_l1=weight_l1,
-        weight_l2=weight_l2,
-        spherical_correction=spherical_correction,
+        solve_vectorized = vmap(solve_equation, in_axes=(0), out_axes=(0))
+
+    cost_now = _evaluate_cost(
+        curve,
+        travel_stw_eval=travel_stw,
+        travel_time_eval=travel_time,
+        time_offset_eval=time_offset,
     )
     cost_best = cost_now.copy()
     curve_best = curve.copy()
@@ -313,23 +815,33 @@ def optimize_fms(
     while (idx < maxfevals) & (early_stop < patience).any():
         curve_old = curve.copy()
         curve = solve_vectorized(curve)
-        # Replace points on land with previous iteration
-        if land is not None and penalty > 0:
-            is_land = land(curve) > 0
-            curve = jnp.where(is_land[..., None], curve_old, curve)
-        cost_now = costfun(
-            vectorfield=vectorfield,
-            curve=curve,
+        curve = _apply_curve_constraints(
+            curve,
+            curve_old,
+            land=land,
+            windfield=windfield,
             wavefield=wavefield,
+            enforce_weather_limits=enforce_weather_limits,
+            tws_limit=tws_limit,
+            hs_limit=hs_limit,
             travel_stw=travel_stw,
             travel_time=travel_time,
-            weight_l1=weight_l1,
-            weight_l2=weight_l2,
             spherical_correction=spherical_correction,
+            time_offset=time_offset,
+            penalty=penalty,
+        )
+        cost_now = _evaluate_cost(
+            curve,
+            travel_stw_eval=travel_stw,
+            travel_time_eval=travel_time,
+            time_offset_eval=time_offset,
         )
 
-        # Update early stopping counter
-        early_stop += jnp.where(cost_now >= cost_best, 1, 0)
+        # Update early stopping counter.
+        # Only count stagnation once a feasible (finite-cost) solution exists;
+        # while cost_best is still inf the optimizer is still searching.
+        has_feasible_best = jnp.isfinite(cost_best)
+        early_stop += jnp.where(has_feasible_best & (cost_now >= cost_best), 1, 0)
         early_stop = jnp.where(cost_best > cost_now, 0, early_stop)
 
         # Store best solution
@@ -338,13 +850,24 @@ def optimize_fms(
         curve_best = jnp.where(improved[:, None, None], curve, curve_best)
 
         idx += 1
+        if snapshot_callback is not None:
+            snapshot_callback(
+                {
+                    "iteration": idx,
+                    "curve": curve,
+                    "cost": cost_now,
+                    "best_curve": curve_best,
+                    "best_cost": cost_best,
+                    "early_stop": early_stop,
+                }
+            )
         if verbose and (idx % 500 == 0 or idx == 1):
             print(f"FMS - Iteration {idx}, cost: {cost_now.min():.4f}")
 
     if verbose:
         print("FMS - Number of iterations:", idx)
         print("FMS - Optimization time:", time.time() - start)
-        print("FMS - Fuel cost:", cost_now.min())
+        print("FMS - Fuel cost:", cost_best.min())
 
     dict_fms = {
         "cost": cost_best.tolist(),
@@ -379,6 +902,7 @@ def main(gpu: bool = True, optimize_time: bool = False) -> None:
         travel_stw=None if optimize_time else 1,
         travel_time=10 if optimize_time else None,
         patience=50,
+        damping=0.99,
     )
 
     xmin, xmax = curve[..., 0].min(), curve[..., 0].max()

--- a/routetools/fms.py
+++ b/routetools/fms.py
@@ -229,6 +229,58 @@ def _weather_violation_mask(
     )
 
 
+def _neighbor_mask(mask: jnp.ndarray) -> jnp.ndarray:
+    """Expand a per-route boolean mask to immediate neighboring positions."""
+    left = jnp.pad(mask[:, :-1], ((0, 0), (1, 0)), constant_values=False)
+    right = jnp.pad(mask[:, 1:], ((0, 0), (0, 1)), constant_values=False)
+    return mask | left | right
+
+
+def _rollback_land_increases(
+    curve: jnp.ndarray,
+    curve_old: jnp.ndarray,
+    *,
+    land: Land,
+) -> jnp.ndarray:
+    """Rollback only local changes that increase land-invalid route positions.
+
+    The rollback is intentionally local: it reverts changed waypoints that are
+    directly implicated in newly-invalid positions while preserving unrelated
+    updates elsewhere on the route. If local rollback cannot restore a route to
+    a non-increasing land count, the full route falls back to its previous
+    iterate as a final safety check.
+    """
+    curve_constrained = curve
+    land_old = land(curve_old) > 0
+    old_counts = jnp.sum(land_old, axis=1)
+
+    for _ in range(curve.shape[1]):
+        land_new = land(curve_constrained) > 0
+        increased = jnp.sum(land_new, axis=1) > old_counts
+        if not bool(jnp.any(increased)):
+            return curve_constrained
+
+        changed = jnp.any(curve_constrained != curve_old, axis=-1)
+        newly_invalid = (~land_old) & land_new & increased[:, None]
+        revert_mask = changed & _neighbor_mask(newly_invalid) & land_new
+
+        needs_fallback_mask = increased & (~jnp.any(revert_mask, axis=1))
+        revert_mask = revert_mask | (needs_fallback_mask[:, None] & changed & land_new)
+
+        if not bool(jnp.any(revert_mask)):
+            break
+
+        curve_constrained = jnp.where(
+            revert_mask[..., None],
+            curve_old,
+            curve_constrained,
+        )
+
+    land_new = land(curve_constrained) > 0
+    increased = jnp.sum(land_new, axis=1) > old_counts
+    return jnp.where(increased[:, None, None], curve_old, curve_constrained)
+
+
 def _apply_curve_constraints(
     curve: jnp.ndarray,
     curve_old: jnp.ndarray,
@@ -263,13 +315,10 @@ def _apply_curve_constraints(
     curve_constrained = curve
 
     if land is not None and penalty > 0:
-        is_land_old = land(curve_old) > 0
-        is_land_new = land(curve_constrained) > 0
-        newly_invalid = (~is_land_old) & is_land_new
-        curve_constrained = jnp.where(
-            newly_invalid[..., None],
-            curve_old,
+        curve_constrained = _rollback_land_increases(
             curve_constrained,
+            curve_old,
+            land=land,
         )
 
     weather_invalid_old = _weather_violation_mask(
@@ -584,6 +633,7 @@ def optimize_fms(
                 weight_l2=weight_l2,
                 spherical_correction=spherical_correction,
                 time_offset=time_offset_eval,
+                **resolved_costfun_kwargs,
             )
     else:
         costfun_kwargs_items = _sorted_costfun_kwargs_items(resolved_costfun_kwargs)

--- a/routetools/fms.py
+++ b/routetools/fms.py
@@ -75,20 +75,28 @@ def _sorted_costfun_kwargs_items(
         return None
 
 
-@lru_cache(maxsize=32)
-def _build_custom_evaluate_cost(
+def _make_custom_evaluate_cost(
     user_costfun: FmsCostFunction,
-    costfun_kwargs_items: tuple[tuple[str, Any], ...],
+    resolved_costfun_kwargs: dict[str, Any],
     custom_cost_accepts_kwargs: bool,
     custom_cost_accepts_curve_keyword: bool,
-    custom_cost_parameter_names: tuple[str, ...],
+    custom_cost_parameter_names: set[str],
     weight_l1: float,
     weight_l2: float,
     spherical_correction: bool,
 ) -> Callable[..., jnp.ndarray]:
-    """Build a reusable custom cost wrapper for FMS."""
-    resolved_costfun_kwargs = dict(costfun_kwargs_items)
-    parameter_names = set(custom_cost_parameter_names)
+    """Build a custom cost wrapper for FMS (not cached).
+
+    Constructs the internal ``_evaluate_cost`` closure that normalises the
+    call to ``user_costfun``: it merges ``costfun_kwargs``, travel context,
+    and metric weights into a single ``cost_kwargs`` dict, then filters it to
+    the parameters the function actually accepts before dispatching positionally
+    or by keyword based on the inspected signature.
+    """
+    # Take a snapshot so later mutations to the caller's dict do not affect the
+    # closure.
+    captured_kwargs = dict(resolved_costfun_kwargs)
+    accepted_names = set(custom_cost_parameter_names)
 
     def _evaluate_cost(
         curve_eval: jnp.ndarray,
@@ -98,7 +106,7 @@ def _build_custom_evaluate_cost(
         time_offset_eval: float = 0.0,
     ) -> jnp.ndarray:
         cost_kwargs = {
-            **resolved_costfun_kwargs,
+            **captured_kwargs,
             "travel_stw": travel_stw_eval,
             "travel_time": travel_time_eval,
             "weight_l1": weight_l1,
@@ -110,13 +118,42 @@ def _build_custom_evaluate_cost(
             cost_kwargs = {
                 name: value
                 for name, value in cost_kwargs.items()
-                if name in parameter_names
+                if name in accepted_names
             }
         if custom_cost_accepts_curve_keyword:
             return user_costfun(curve=curve_eval, **cost_kwargs)
         return user_costfun(curve_eval, **cost_kwargs)
 
     return _evaluate_cost
+
+
+@lru_cache(maxsize=32)
+def _build_custom_evaluate_cost(
+    user_costfun: FmsCostFunction,
+    costfun_kwargs_items: tuple[tuple[str, Any], ...],
+    custom_cost_accepts_kwargs: bool,
+    custom_cost_accepts_curve_keyword: bool,
+    custom_cost_parameter_names: tuple[str, ...],
+    weight_l1: float,
+    weight_l2: float,
+    spherical_correction: bool,
+) -> Callable[..., jnp.ndarray]:
+    """Build and cache a custom cost wrapper for FMS.
+
+    Accepts only hashable arguments so the result can be memoised via
+    lru_cache. Delegates to _make_custom_evaluate_cost for the actual closure
+    construction.
+    """
+    return _make_custom_evaluate_cost(
+        user_costfun,
+        dict(costfun_kwargs_items),
+        custom_cost_accepts_kwargs,
+        custom_cost_accepts_curve_keyword,
+        set(custom_cost_parameter_names),
+        weight_l1,
+        weight_l2,
+        spherical_correction,
+    )
 
 
 @lru_cache(maxsize=32)
@@ -166,7 +203,8 @@ def _build_travel_time_custom_solver(
         q: jnp.ndarray = jnp.linalg.solve(a, b)
         return jnp.nan_to_num(q)
 
-    jac_vectorized = vmap(jacobian, in_axes=(0, 0, 0, 0, 0), out_axes=(0))
+    # Each tree-index is an integer; no need to wrap a single axis in a tuple.
+    jac_vectorized = vmap(jacobian, in_axes=(0, 0, 0, 0, 0), out_axes=0)
 
     @jit  # type: ignore[misc]
     def solve_equation(
@@ -174,7 +212,7 @@ def _build_travel_time_custom_solver(
         segment_time_offsets: jnp.ndarray,
         q_max: jnp.ndarray,
     ) -> jnp.ndarray:
-        curve_new = jnp.copy(curve)
+        # .at[].set() always returns a new array; no copy needed beforehand.
         q = jac_vectorized(
             curve[:-2],
             curve[1:-1],
@@ -184,9 +222,87 @@ def _build_travel_time_custom_solver(
         )
         dq = (1 - damping) * q
         dq = jnp.clip(dq, -q_max, q_max)
-        return curve_new.at[1:-1].set(dq + curve[1:-1])
+        return curve.at[1:-1].set(dq + curve[1:-1])
 
-    return jit(vmap(solve_equation, in_axes=(0, None, None), out_axes=(0)))
+    return jit(vmap(solve_equation, in_axes=(0, None, None), out_axes=0))
+
+
+@lru_cache(maxsize=32)
+def _build_travel_stw_custom_solver(
+    evaluate_cost: Callable[..., jnp.ndarray],
+    damping: float,
+    h: float,
+    travel_stw: float,
+) -> Callable[[jnp.ndarray, jnp.ndarray, jnp.ndarray], jnp.ndarray]:
+    """Build and cache a speed-through-water FMS solver for custom costs.
+
+    Mirrors _build_travel_time_custom_solver for the STW mode. The Lagrangian
+    squares the cost (L2 style) and passes travel_stw instead of travel_time
+    to the cost evaluator. Caching avoids a fresh JAX trace for every
+    departure that shares the same evaluator, damping, step size, and speed.
+    """
+
+    def lagrangian(
+        q0: jnp.ndarray,
+        q1: jnp.ndarray,
+        segment_time_offset: float,
+    ) -> jnp.ndarray:
+        q = jnp.vstack([q0, q1])[None, ...]
+        lag = evaluate_cost(
+            q,
+            travel_stw_eval=travel_stw,
+            time_offset_eval=segment_time_offset,
+        )
+        return jnp.sum(h * lag**2)
+
+    d1ld = grad(lagrangian, argnums=0)
+    d2ld = grad(lagrangian, argnums=1)
+    d11ld = hessian(lagrangian, argnums=0)
+    d22ld = hessian(lagrangian, argnums=1)
+
+    @jit  # type: ignore[misc]
+    def jacobian(
+        qkm1: jnp.ndarray,
+        qk: jnp.ndarray,
+        qkp1: jnp.ndarray,
+        left_time_offset: float,
+        right_time_offset: float,
+    ) -> jnp.ndarray:
+        b = -d2ld(qkm1, qk, left_time_offset) - d1ld(
+            qk,
+            qkp1,
+            right_time_offset,
+        )
+        a = d22ld(qkm1, qk, left_time_offset) + d11ld(
+            qk,
+            qkp1,
+            right_time_offset,
+        )
+        q: jnp.ndarray = jnp.linalg.solve(a, b)
+        return jnp.nan_to_num(q)
+
+    # Each tree-index is an integer; no need to wrap a single axis in a tuple.
+    jac_vectorized = vmap(jacobian, in_axes=(0, 0, 0, 0, 0), out_axes=0)
+
+    @jit  # type: ignore[misc]
+    def solve_equation(
+        curve: jnp.ndarray,
+        segment_time_offsets: jnp.ndarray,
+        q_max: jnp.ndarray,
+    ) -> jnp.ndarray:
+        # .at[].set() always returns a new array; no copy needed beforehand.
+        q = jac_vectorized(
+            curve[:-2],
+            curve[1:-1],
+            curve[2:],
+            segment_time_offsets[:-1],
+            segment_time_offsets[1:],
+        )
+        dq = (1 - damping) * q
+        dq = jnp.clip(dq, -q_max, q_max)
+        return curve.at[1:-1].set(dq + curve[1:-1])
+
+    return jit(vmap(solve_equation, in_axes=(0, None, None), out_axes=0))
 
 
 def _weather_violation_mask(
@@ -321,6 +437,12 @@ def _apply_curve_constraints(
             land=land,
         )
 
+    # Skip both mask evaluations when weather enforcement is inactive or no
+    # field is provided; _weather_violation_mask already returns zeros in that
+    # case, but calling it twice per iteration is wasteful.
+    if not enforce_weather_limits or (windfield is None and wavefield is None):
+        return curve_constrained
+
     weather_invalid_old = _weather_violation_mask(
         curve_old,
         windfield=windfield,
@@ -367,13 +489,15 @@ def random_piecewise_curve(
         Ending point of the curves.
     num_curves : int
         Number of curves to generate.
-    key : jax.random.PRNGKey
-        Random key for generating random numbers.
+    num_points : int
+        Total number of waypoints per curve.
+    seed : int
+        Integer seed for reproducible random curve generation.
 
     Returns
     -------
     jnp.ndarray
-        Generated curves with shape (num_curves, num_segments, 2).
+        Generated curves with shape (num_curves, num_points, 2).
     """
     key = jax.random.PRNGKey(seed)
     num_segments = jax.random.randint(key, (num_curves,), minval=2, maxval=5)
@@ -499,8 +623,9 @@ def optimize_fms(
         Destination point, by default None
     curve : jnp.ndarray | None, optional
         Curve to optimize, shape L x 2, by default None
-    land_function : Callable[[jnp.ndarray], jnp.ndarray] | None, optional
-        Land function, by default None
+    land : Land | None, optional
+        Land mask used to reject updates that move waypoints onto land.
+        By default None.
     windfield : Callable, optional
         Wind field closure used to enforce route weather limits.
     num_curves : int, optional
@@ -651,36 +776,22 @@ def optimize_fms(
                 spherical_correction,
             )
         else:
-
-            def _evaluate_cost(
-                curve_eval: jnp.ndarray,
-                *,
-                travel_stw_eval: float | None = None,
-                travel_time_eval: float | None = None,
-                time_offset_eval: float = 0.0,
-            ) -> jnp.ndarray:
-                cost_kwargs = {
-                    **resolved_costfun_kwargs,
-                    "travel_stw": travel_stw_eval,
-                    "travel_time": travel_time_eval,
-                    "weight_l1": weight_l1,
-                    "weight_l2": weight_l2,
-                    "spherical_correction": spherical_correction,
-                    "time_offset": time_offset_eval,
-                }
-                if not custom_cost_accepts_kwargs:
-                    cost_kwargs = {
-                        name: value
-                        for name, value in cost_kwargs.items()
-                        if name in custom_cost_parameter_names
-                    }
-                if custom_cost_accepts_curve_keyword:
-                    return user_costfun(curve=curve_eval, **cost_kwargs)
-                return user_costfun(curve_eval, **cost_kwargs)
+            # costfun_kwargs contain unhashable values so caching is not
+            # possible. Build the wrapper directly without caching.
+            _evaluate_cost = _make_custom_evaluate_cost(
+                user_costfun,
+                resolved_costfun_kwargs,
+                custom_cost_accepts_kwargs,
+                custom_cost_accepts_curve_keyword,
+                custom_cost_parameter_names,
+                weight_l1,
+                weight_l2,
+                spherical_correction,
+            )
 
     # Initialize lagrangians
     if travel_stw is not None:
-        # Average distance between points
+        # Average distance between points, used as the per-segment time step.
         d = jnp.mean(jnp.linalg.norm(curve[:, 1:] - curve[:, :-1], axis=-1))
         h = float(d / travel_stw)
         # NOTE: segment_time_offsets is derived from the initial route geometry
@@ -693,23 +804,89 @@ def optimize_fms(
             dtype=jnp.float32,
         )
 
-        def lagrangian(
-            q0: jnp.ndarray,
-            q1: jnp.ndarray,
-            segment_time_offset: float,
-        ) -> jnp.ndarray:
-            # Stack q0 and q1 to form array of shape (1, 2, 2)
-            q = jnp.vstack([q0, q1])[None, ...]
-            lag = _evaluate_cost(
-                q,
-                travel_stw_eval=travel_stw,
-                time_offset_eval=segment_time_offset,
+        q_max = jnp.mean(jnp.linalg.norm(curve[:, 1:] - curve[:, :-1], axis=-1))
+
+        if not use_builtin_costfun and costfun_kwargs_items is not None:
+            # All arguments are hashable; reuse a previously compiled solver.
+            cached_solve_vectorized = _build_travel_stw_custom_solver(
+                _evaluate_cost,
+                damping,
+                h,
+                travel_stw,
             )
-            ld = jnp.sum(h * lag**2)
-            # Do note: The original formula used q0, q1 to compute l1, l2 and then
-            # took the average of (l1**2 + l2**2) / 2
-            # We simplified that without loss of generality
-            return ld
+
+            def solve_vectorized(curve_eval: jnp.ndarray) -> jnp.ndarray:
+                return cached_solve_vectorized(
+                    curve_eval,
+                    segment_time_offsets,
+                    q_max,
+                )
+
+        else:
+
+            def lagrangian(
+                q0: jnp.ndarray,
+                q1: jnp.ndarray,
+                segment_time_offset: float,
+            ) -> jnp.ndarray:
+                # Stack q0 and q1 to form array of shape (1, 2, 2)
+                q = jnp.vstack([q0, q1])[None, ...]
+                lag = _evaluate_cost(
+                    q,
+                    travel_stw_eval=travel_stw,
+                    time_offset_eval=segment_time_offset,
+                )
+                ld = jnp.sum(h * lag**2)
+                # Do note: The original formula used q0, q1 to compute l1, l2 and then
+                # took the average of (l1**2 + l2**2) / 2
+                # We simplified that without loss of generality
+                return ld
+
+            d1ld = grad(lagrangian, argnums=0)
+            d2ld = grad(lagrangian, argnums=1)
+            d11ld = hessian(lagrangian, argnums=0)
+            d22ld = hessian(lagrangian, argnums=1)
+
+            @jit  # type: ignore[misc]
+            def jacobian(
+                qkm1: jnp.ndarray,
+                qk: jnp.ndarray,
+                qkp1: jnp.ndarray,
+                left_time_offset: float,
+                right_time_offset: float,
+            ) -> jnp.ndarray:
+                b = -d2ld(qkm1, qk, left_time_offset) - d1ld(
+                    qk,
+                    qkp1,
+                    right_time_offset,
+                )
+                a = d22ld(qkm1, qk, left_time_offset) + d11ld(
+                    qk,
+                    qkp1,
+                    right_time_offset,
+                )
+                q: jnp.ndarray = jnp.linalg.solve(a, b)
+                return jnp.nan_to_num(q)
+
+            # Each tree-index is an integer; no need to wrap a single axis in a tuple.
+            jac_vectorized = vmap(jacobian, in_axes=(0, 0, 0, 0, 0), out_axes=0)
+
+            @jit  # type: ignore[misc]
+            def solve_equation(curve: jnp.ndarray) -> jnp.ndarray:
+                q = jac_vectorized(
+                    curve[:-2],
+                    curve[1:-1],
+                    curve[2:],
+                    segment_time_offsets[:-1],
+                    segment_time_offsets[1:],
+                )
+                dq = (1 - damping) * q
+                # Clip updates to prevent divergence when the route is still
+                # far from a locally optimal path.
+                dq = jnp.clip(dq, -q_max, q_max)
+                return curve.at[1:-1].set(dq + curve[1:-1])
+
+            solve_vectorized = vmap(solve_equation, in_axes=0, out_axes=0)
 
     elif travel_time is not None:
         assert travel_time > 0, "Travel time must be positive"
@@ -780,11 +957,10 @@ def optimize_fms(
                 q: jnp.ndarray = jnp.linalg.solve(a, b)
                 return jnp.nan_to_num(q)
 
-            jac_vectorized = vmap(jacobian, in_axes=(0, 0, 0, 0, 0), out_axes=(0))
+            jac_vectorized = vmap(jacobian, in_axes=(0, 0, 0, 0, 0), out_axes=0)
 
             @jit  # type: ignore[misc]
             def solve_equation(curve: jnp.ndarray) -> jnp.ndarray:
-                curve_new = jnp.copy(curve)
                 q = jac_vectorized(
                     curve[:-2],
                     curve[1:-1],
@@ -796,59 +972,12 @@ def optimize_fms(
                 # Clip updates to prevent divergence when the route is still
                 # far from a locally optimal path.
                 dq = jnp.clip(dq, -q_max, q_max)
-                return curve_new.at[1:-1].set(dq + curve[1:-1])
+                return curve.at[1:-1].set(dq + curve[1:-1])
 
-            solve_vectorized = vmap(solve_equation, in_axes=(0), out_axes=(0))
+            solve_vectorized = vmap(solve_equation, in_axes=0, out_axes=0)
 
     else:
         raise ValueError("Either travel_stw or travel_time must be provided")
-
-    if travel_stw is not None:
-        d1ld = grad(lagrangian, argnums=0)
-        d2ld = grad(lagrangian, argnums=1)
-        d11ld = hessian(lagrangian, argnums=0)
-        d22ld = hessian(lagrangian, argnums=1)
-
-        @jit  # type: ignore[misc]
-        def jacobian(
-            qkm1: jnp.ndarray,
-            qk: jnp.ndarray,
-            qkp1: jnp.ndarray,
-            left_time_offset: float,
-            right_time_offset: float,
-        ) -> jnp.ndarray:
-            b = -d2ld(qkm1, qk, left_time_offset) - d1ld(
-                qk,
-                qkp1,
-                right_time_offset,
-            )
-            a = d22ld(qkm1, qk, left_time_offset) + d11ld(
-                qk,
-                qkp1,
-                right_time_offset,
-            )
-            q: jnp.ndarray = jnp.linalg.solve(a, b)
-            return jnp.nan_to_num(q)
-
-        jac_vectorized = vmap(jacobian, in_axes=(0, 0, 0, 0, 0), out_axes=(0))
-
-        q_max = jnp.mean(jnp.linalg.norm(curve[:, 1:] - curve[:, :-1], axis=-1))
-
-        @jit  # type: ignore[misc]
-        def solve_equation(curve: jnp.ndarray) -> jnp.ndarray:
-            curve_new = jnp.copy(curve)
-            q = jac_vectorized(
-                curve[:-2],
-                curve[1:-1],
-                curve[2:],
-                segment_time_offsets[:-1],
-                segment_time_offsets[1:],
-            )
-            dq = (1 - damping) * q
-            dq = jnp.clip(dq, -q_max, q_max)
-            return curve_new.at[1:-1].set(dq + curve[1:-1])
-
-        solve_vectorized = vmap(solve_equation, in_axes=(0), out_axes=(0))
 
     cost_now = _evaluate_cost(
         curve,

--- a/routetools/swopp3.py
+++ b/routetools/swopp3.py
@@ -63,7 +63,7 @@ ROUTE_ATLANTIC = {
     "src_port": "ESSDR",
     "dst_port": "USNYC",
     "passage_hours": 354,
-    "gc_distance_nm": 2833,
+    "gc_distance_nm": 2826,
 }
 
 ROUTE_PACIFIC = {

--- a/routetools/swopp3_runner.py
+++ b/routetools/swopp3_runner.py
@@ -25,11 +25,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any
 
 import jax.numpy as jnp
 
-from routetools.cost import cost_function_rise, evaluate_route_energy
+from routetools.cost import evaluate_route_energy
 from routetools.cost import segment_bearings_deg as _segment_bearings_deg
 from routetools.swopp3 import (
     SWOPP3_CASES,
@@ -44,12 +43,6 @@ from routetools.swopp3_output import (
     waypoint_times,
     write_file_a,
     write_file_b,
-)
-from routetools.weather import (
-    DEFAULT_HS_LIMIT,
-    DEFAULT_TWS_LIMIT,
-    weather_penalty,
-    weather_penalty_smooth,
 )
 
 logger = logging.getLogger(__name__)
@@ -69,89 +62,6 @@ FieldClosure = Callable[
     [jnp.ndarray, jnp.ndarray, jnp.ndarray],
     tuple[jnp.ndarray, jnp.ndarray],
 ]
-
-
-def _penalized_rise_cost(
-    curve: jnp.ndarray,
-    *,
-    windfield: FieldClosure,
-    wavefield: FieldClosure | None,
-    travel_time: float,
-    wps: bool,
-    spherical_correction: bool,
-    time_offset: float = 0.0,
-    tws_limit: float = DEFAULT_TWS_LIMIT,
-    hs_limit: float = DEFAULT_HS_LIMIT,
-    weather_penalty_weight: float = 0.0,
-    wind_penalty_weight: float = 0.0,
-    wave_penalty_weight: float = 0.0,
-    distance_penalty_weight: float = 0.0,
-    weather_penalty_type: str = "smooth",
-    weather_penalty_sharpness: float = 5.0,
-    land: Any | None = None,
-    land_distance_epsilon: float = 1.0,
-) -> jnp.ndarray:
-    """Return the SWOPP3 objective optimized by both CMA-ES and FMS."""
-    total_cost = cost_function_rise(
-        windfield=windfield,
-        curve=curve,
-        travel_time=travel_time,
-        wavefield=wavefield,
-        wps=wps,
-        time_offset=time_offset,
-    )
-
-    combined_weather_penalty = (
-        weather_penalty_weight + wind_penalty_weight + wave_penalty_weight
-    )
-
-    if combined_weather_penalty > 0:
-        penalty_fn = (
-            weather_penalty_smooth
-            if weather_penalty_type == "smooth"
-            else weather_penalty
-        )
-        penalty_kwargs: dict[str, Any] = {
-            "curve": curve,
-            "windfield": windfield,
-            "wavefield": wavefield,
-            "tws_limit": tws_limit,
-            "hs_limit": hs_limit,
-            "penalty": combined_weather_penalty,
-            "travel_time": travel_time,
-            "spherical_correction": spherical_correction,
-            "time_offset": time_offset,
-        }
-        if weather_penalty_type == "smooth":
-            penalty_kwargs["sharpness"] = weather_penalty_sharpness
-        elif weather_penalty_type != "hard":
-            raise ValueError("weather_penalty_type must be 'hard' or 'smooth'")
-        total_cost = total_cost + penalty_fn(**penalty_kwargs)
-
-    if land is not None and distance_penalty_weight > 0:
-        total_cost = total_cost + land.distance_penalty(
-            curve,
-            weight=distance_penalty_weight,
-            epsilon=land_distance_epsilon,
-        )
-
-    return total_cost
-
-
-def _resolve_runner_verbosity(
-    verbose: bool | None,
-    verbosity: int | None,
-    *,
-    default: int = 1,
-) -> int:
-    """Resolve backward-compatible runner verbosity settings."""
-    if verbosity is not None:
-        if verbosity not in (0, 1, 2):
-            raise ValueError("verbosity must be one of 0, 1, or 2")
-        return verbosity
-    if verbose is None:
-        return default
-    return 1 if verbose else 0
 
 
 # ---------------------------------------------------------------------------
@@ -339,14 +249,12 @@ def run_optimised_departure(
     land=None,
     departure_offset_h: float = 0.0,
     n_points: int = 100,
-    verbosity: int | None = None,
     **cmaes_kwargs,
 ) -> DepartureResult:
-    """Optimise and evaluate a single departure using CMA-ES and FMS.
+    """Optimise and evaluate a single departure using CMA-ES.
 
-    Both CMA-ES and FMS optimize the same SWOPP3 objective: RISE energy plus
-    the configured weather and land-distance penalties. Energy is then
-    evaluated post-hoc with the SWOPP3 performance model.
+    The CMA-ES optimizer minimises travel cost through the wind field.
+    Energy is then evaluated post-hoc with the SWOPP3 performance model.
     Missing optimisation inputs are treated as an error; this function does
     not fall back to a great-circle route.
 
@@ -368,9 +276,6 @@ def run_optimised_departure(
         Time offset (hours) from field origin to departure.
     n_points : int
         Number of waypoints (CMA-ES ``L`` parameter).
-    verbosity : int, optional
-        Output level. ``0`` silences routine prints, ``1`` prints runner
-        progress, and ``2`` also enables CMA-ES and FMS verbose printing.
     **cmaes_kwargs
         Additional keyword arguments passed to :func:`routetools.cmaes.optimize`.
 
@@ -388,14 +293,13 @@ def run_optimised_departure(
     case = SWOPP3_CASES[case_id]
     src, dst = case_endpoints(case_id)
     travel_time = float(case["passage_hours"])
-    resolved_verbosity = _resolve_runner_verbosity(None, verbosity)
 
     t0 = _time.time()
 
     if vectorfield is not None:
-        import warnings
-
         if windfield is None:
+            import warnings
+
             warnings.warn(
                 "vectorfield provided without windfield; defaulting "
                 "windfield to vectorfield for RISE energy cost.",
@@ -404,7 +308,7 @@ def run_optimised_departure(
             windfield = vectorfield
         # Lazy import to avoid circular dependency / heavy JAX load
         from routetools.cmaes import optimize as cmaes_optimize
-        from routetools.fms import optimize_fms
+        from routetools.cost import cost_function_rise
 
         # Initialise from the great-circle route so CMA-ES starts near
         # the geodesic.
@@ -416,206 +320,46 @@ def run_optimised_departure(
         src_opt = jnp.array([gc_init[0, 0], gc_init[0, 1]])
         dst_opt = jnp.array([gc_init[-1, 0], gc_init[-1, 1]])
 
+        # Build a RISE-based cost closure for CMA-ES.
+        # This directly minimises SWOPP3 energy (MWh) instead of the
+        # ocean-current proxy ‖SOG − wind‖².
         _wps = case["wps"]
 
-        defaults_cmaes: dict[str, Any] = dict(
+        def _rise_cost(curve_batch: jnp.ndarray) -> jnp.ndarray:
+            return cost_function_rise(
+                windfield=windfield,
+                curve=curve_batch,
+                travel_time=travel_time,
+                wavefield=wavefield,
+                wps=_wps,
+                time_offset=departure_offset_h,
+            )
+
+        defaults = dict(
             K=10,
             L=n_points,
+            travel_time=travel_time,
             curve0=gc_init,
             sigma0=0.1,
+            cost_fn=_rise_cost,
             penalty=1000,
             land_margin=2,
-            verbose=resolved_verbosity >= 2,
+            verbose=False,
             time_offset=departure_offset_h,
             windfield=windfield,
             wavefield=wavefield,
-            travel_time=travel_time,
-            spherical_correction=True,
-            weather_penalty_weight=10.0,
-            wind_penalty_weight=0.0,
-            wave_penalty_weight=0.0,
-            distance_penalty_weight=0.0,
-            tws_limit=DEFAULT_TWS_LIMIT,
-            hs_limit=DEFAULT_HS_LIMIT,
         )
-        defaults_fms = dict(
-            patience=cmaes_kwargs.pop("fms_patience", 200),
-            damping=cmaes_kwargs.pop("fms_damping", 0.95),
-            maxfevals=cmaes_kwargs.pop("fms_maxfevals", 10000),
-        )
-        weather_penalty_type = str(cmaes_kwargs.pop("weather_penalty_type", "smooth"))
-        weather_penalty_sharpness = float(
-            cmaes_kwargs.pop("weather_penalty_sharpness", 5.0)
-        )
-        land_distance_epsilon = float(cmaes_kwargs.pop("land_distance_epsilon", 1.0))
         if cmaes_kwargs.pop("cmaes_verbose", False):
             cmaes_kwargs["verbose"] = True
-        defaults_cmaes.update(cmaes_kwargs)
-        defaults_fms["verbose"] = bool(defaults_cmaes["verbose"])
+        defaults.update(cmaes_kwargs)
 
-        objective_travel_time = float(defaults_cmaes.get("travel_time", travel_time))
-        objective_time_offset = float(
-            defaults_cmaes.get("time_offset", departure_offset_h)
-        )
-        objective_spherical_correction = bool(
-            defaults_cmaes.get("spherical_correction", True)
-        )
-        tws_limit = float(defaults_cmaes.get("tws_limit", DEFAULT_TWS_LIMIT))
-        hs_limit = float(defaults_cmaes.get("hs_limit", DEFAULT_HS_LIMIT))
-        weather_penalty_weight = float(
-            defaults_cmaes.get("weather_penalty_weight", 0.0)
-        )
-        wind_penalty_weight = float(defaults_cmaes.get("wind_penalty_weight", 0.0))
-        wave_penalty_weight = float(defaults_cmaes.get("wave_penalty_weight", 0.0))
-        distance_penalty_weight = float(
-            defaults_cmaes.get("distance_penalty_weight", 0.0)
-        )
-
-        def _shared_cost(
-            curve: jnp.ndarray,
-            *,
-            travel_time: float | None = None,
-            time_offset: float | None = None,
-            spherical_correction: bool | None = None,
-            **_: Any,
-        ) -> jnp.ndarray:
-            return _penalized_rise_cost(
-                curve=curve,
-                windfield=windfield,
-                wavefield=wavefield,
-                travel_time=(
-                    objective_travel_time if travel_time is None else travel_time
-                ),
-                wps=_wps,
-                spherical_correction=(
-                    objective_spherical_correction
-                    if spherical_correction is None
-                    else spherical_correction
-                ),
-                time_offset=(
-                    objective_time_offset if time_offset is None else time_offset
-                ),
-                tws_limit=tws_limit,
-                hs_limit=hs_limit,
-                weather_penalty_weight=weather_penalty_weight,
-                wind_penalty_weight=wind_penalty_weight,
-                wave_penalty_weight=wave_penalty_weight,
-                distance_penalty_weight=distance_penalty_weight,
-                weather_penalty_type=weather_penalty_type,
-                weather_penalty_sharpness=weather_penalty_sharpness,
-                land=land,
-                land_distance_epsilon=land_distance_epsilon,
-            )
-
-        defaults_cmaes["cost_fn"] = _shared_cost
-        fms_costfun_kwargs: dict[str, Any] = {
-            "windfield": windfield,
-            "wavefield": wavefield,
-            "wps": _wps,
-            "spherical_correction": objective_spherical_correction,
-            "tws_limit": tws_limit,
-            "hs_limit": hs_limit,
-            "weather_penalty_weight": weather_penalty_weight,
-            "wind_penalty_weight": wind_penalty_weight,
-            "wave_penalty_weight": wave_penalty_weight,
-            "distance_penalty_weight": distance_penalty_weight,
-            "weather_penalty_type": weather_penalty_type,
-            "weather_penalty_sharpness": weather_penalty_sharpness,
-            "land": land,
-            "land_distance_epsilon": land_distance_epsilon,
-        }
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=r"Sampling standard deviation i=.*",
-                category=UserWarning,
-                module=r"cma\.evolution_strategy",
-            )
-            warnings.filterwarnings(
-                "ignore",
-                message=(
-                    r"\[WARNING\] The optimized curve has a higher cost "
-                    r"than the initial curve0 provided .*"
-                ),
-                category=UserWarning,
-            )
-            cmaes_t0 = _time.time()
-            curve_cmaes, _ = cmaes_optimize(
-                vectorfield=vectorfield,
-                src=src_opt,
-                dst=dst_opt,
-                land=land,
-                **defaults_cmaes,
-            )
-        cmaes_distance_nm = sailed_distance_nm(curve_cmaes)
-        energy_cmaes, max_tws_cmaes, max_hs_cmaes = evaluate_energy(
-            curve_cmaes,
-            departure,
-            case["passage_hours"],
-            wps=case["wps"],
-            windfield=windfield,
-            wavefield=wavefield,
-            departure_offset_h=departure_offset_h,
-        )
-        cmaes_comp_time_s = _time.time() - cmaes_t0
-
-        fms_t0 = _time.time()
-        curve_fms, _ = optimize_fms(
+        curve, info = cmaes_optimize(
             vectorfield=vectorfield,
-            curve=curve_cmaes,
+            src=src_opt,
+            dst=dst_opt,
             land=land,
-            windfield=windfield,
-            wavefield=wavefield,
-            travel_time=objective_travel_time,
-            spherical_correction=objective_spherical_correction,
-            time_offset=objective_time_offset,
-            enforce_weather_limits=True,
-            tws_limit=tws_limit,
-            hs_limit=hs_limit,
-            costfun=_penalized_rise_cost,
-            costfun_kwargs=fms_costfun_kwargs,
-            **defaults_fms,
+            **defaults,
         )
-        curve_fms = curve_fms[0]
-        fms_distance_nm = sailed_distance_nm(curve_fms)
-        energy_fms, max_tws_fms, max_hs_fms = evaluate_energy(
-            curve_fms,
-            departure,
-            case["passage_hours"],
-            wps=case["wps"],
-            windfield=windfield,
-            wavefield=wavefield,
-            departure_offset_h=departure_offset_h,
-        )
-        fms_comp_time_s = _time.time() - fms_t0
-
-        if resolved_verbosity >= 1:
-            print()
-            print(
-                f"    CMA-ES  E={energy_cmaes:.2f} MWh  "
-                f"d={cmaes_distance_nm:.0f} nm  "
-                f"t={cmaes_comp_time_s:.1f}s"
-            )
-            print(
-                f"    FMS     E={energy_fms:.2f} MWh  "
-                f"d={fms_distance_nm:.0f} nm  "
-                f"t={fms_comp_time_s:.1f}s"
-            )
-
-        cmaes_is_valid = max_tws_cmaes <= tws_limit and max_hs_cmaes <= hs_limit
-        fms_is_valid = max_tws_fms <= tws_limit and max_hs_fms <= hs_limit
-
-        if fms_is_valid and (not cmaes_is_valid or energy_fms < energy_cmaes):
-            curve = curve_fms
-            energy_mwh = energy_fms
-            max_tws = max_tws_fms
-            max_hs = max_hs_fms
-        else:
-            curve = curve_cmaes
-            energy_mwh = energy_cmaes
-            max_tws = max_tws_cmaes
-            max_hs = max_hs_cmaes
     else:
         # No vectorfield → raise error
         raise ValueError(
@@ -624,6 +368,16 @@ def run_optimised_departure(
         )
 
     distance_nm = sailed_distance_nm(curve)
+
+    energy_mwh, max_tws, max_hs = evaluate_energy(
+        curve,
+        departure,
+        case["passage_hours"],
+        wps=case["wps"],
+        windfield=windfield,
+        wavefield=wavefield,
+        departure_offset_h=departure_offset_h,
+    )
     comp_time = _time.time() - t0
 
     return DepartureResult(

--- a/routetools/swopp3_runner.py
+++ b/routetools/swopp3_runner.py
@@ -25,10 +25,11 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import jax.numpy as jnp
 
-from routetools.cost import evaluate_route_energy
+from routetools.cost import cost_function_rise, evaluate_route_energy
 from routetools.cost import segment_bearings_deg as _segment_bearings_deg
 from routetools.swopp3 import (
     SWOPP3_CASES,
@@ -43,6 +44,12 @@ from routetools.swopp3_output import (
     waypoint_times,
     write_file_a,
     write_file_b,
+)
+from routetools.weather import (
+    DEFAULT_HS_LIMIT,
+    DEFAULT_TWS_LIMIT,
+    weather_penalty,
+    weather_penalty_smooth,
 )
 
 logger = logging.getLogger(__name__)
@@ -62,6 +69,89 @@ FieldClosure = Callable[
     [jnp.ndarray, jnp.ndarray, jnp.ndarray],
     tuple[jnp.ndarray, jnp.ndarray],
 ]
+
+
+def _penalized_rise_cost(
+    curve: jnp.ndarray,
+    *,
+    windfield: FieldClosure,
+    wavefield: FieldClosure | None,
+    travel_time: float,
+    wps: bool,
+    spherical_correction: bool,
+    time_offset: float = 0.0,
+    tws_limit: float = DEFAULT_TWS_LIMIT,
+    hs_limit: float = DEFAULT_HS_LIMIT,
+    weather_penalty_weight: float = 0.0,
+    wind_penalty_weight: float = 0.0,
+    wave_penalty_weight: float = 0.0,
+    distance_penalty_weight: float = 0.0,
+    weather_penalty_type: str = "smooth",
+    weather_penalty_sharpness: float = 5.0,
+    land: Any | None = None,
+    land_distance_epsilon: float = 1.0,
+) -> jnp.ndarray:
+    """Return the SWOPP3 objective optimized by both CMA-ES and FMS."""
+    total_cost = cost_function_rise(
+        windfield=windfield,
+        curve=curve,
+        travel_time=travel_time,
+        wavefield=wavefield,
+        wps=wps,
+        time_offset=time_offset,
+    )
+
+    combined_weather_penalty = (
+        weather_penalty_weight + wind_penalty_weight + wave_penalty_weight
+    )
+
+    if combined_weather_penalty > 0:
+        penalty_fn = (
+            weather_penalty_smooth
+            if weather_penalty_type == "smooth"
+            else weather_penalty
+        )
+        penalty_kwargs: dict[str, Any] = {
+            "curve": curve,
+            "windfield": windfield,
+            "wavefield": wavefield,
+            "tws_limit": tws_limit,
+            "hs_limit": hs_limit,
+            "penalty": combined_weather_penalty,
+            "travel_time": travel_time,
+            "spherical_correction": spherical_correction,
+            "time_offset": time_offset,
+        }
+        if weather_penalty_type == "smooth":
+            penalty_kwargs["sharpness"] = weather_penalty_sharpness
+        elif weather_penalty_type != "hard":
+            raise ValueError("weather_penalty_type must be 'hard' or 'smooth'")
+        total_cost = total_cost + penalty_fn(**penalty_kwargs)
+
+    if land is not None and distance_penalty_weight > 0:
+        total_cost = total_cost + land.distance_penalty(
+            curve,
+            weight=distance_penalty_weight,
+            epsilon=land_distance_epsilon,
+        )
+
+    return total_cost
+
+
+def _resolve_runner_verbosity(
+    verbose: bool | None,
+    verbosity: int | None,
+    *,
+    default: int = 1,
+) -> int:
+    """Resolve backward-compatible runner verbosity settings."""
+    if verbosity is not None:
+        if verbosity not in (0, 1, 2):
+            raise ValueError("verbosity must be one of 0, 1, or 2")
+        return verbosity
+    if verbose is None:
+        return default
+    return 1 if verbose else 0
 
 
 # ---------------------------------------------------------------------------
@@ -249,12 +339,14 @@ def run_optimised_departure(
     land=None,
     departure_offset_h: float = 0.0,
     n_points: int = 100,
+    verbosity: int | None = None,
     **cmaes_kwargs,
 ) -> DepartureResult:
-    """Optimise and evaluate a single departure using CMA-ES.
+    """Optimise and evaluate a single departure using CMA-ES and FMS.
 
-    The CMA-ES optimizer minimises travel cost through the wind field.
-    Energy is then evaluated post-hoc with the SWOPP3 performance model.
+    Both CMA-ES and FMS optimize the same SWOPP3 objective: RISE energy plus
+    the configured weather and land-distance penalties. Energy is then
+    evaluated post-hoc with the SWOPP3 performance model.
     Missing optimisation inputs are treated as an error; this function does
     not fall back to a great-circle route.
 
@@ -276,6 +368,9 @@ def run_optimised_departure(
         Time offset (hours) from field origin to departure.
     n_points : int
         Number of waypoints (CMA-ES ``L`` parameter).
+    verbosity : int, optional
+        Output level. ``0`` silences routine prints, ``1`` prints runner
+        progress, and ``2`` also enables CMA-ES and FMS verbose printing.
     **cmaes_kwargs
         Additional keyword arguments passed to :func:`routetools.cmaes.optimize`.
 
@@ -293,13 +388,14 @@ def run_optimised_departure(
     case = SWOPP3_CASES[case_id]
     src, dst = case_endpoints(case_id)
     travel_time = float(case["passage_hours"])
+    resolved_verbosity = _resolve_runner_verbosity(None, verbosity)
 
     t0 = _time.time()
 
     if vectorfield is not None:
-        if windfield is None:
-            import warnings
+        import warnings
 
+        if windfield is None:
             warnings.warn(
                 "vectorfield provided without windfield; defaulting "
                 "windfield to vectorfield for RISE energy cost.",
@@ -308,7 +404,7 @@ def run_optimised_departure(
             windfield = vectorfield
         # Lazy import to avoid circular dependency / heavy JAX load
         from routetools.cmaes import optimize as cmaes_optimize
-        from routetools.cost import cost_function_rise
+        from routetools.fms import optimize_fms
 
         # Initialise from the great-circle route so CMA-ES starts near
         # the geodesic.
@@ -320,46 +416,206 @@ def run_optimised_departure(
         src_opt = jnp.array([gc_init[0, 0], gc_init[0, 1]])
         dst_opt = jnp.array([gc_init[-1, 0], gc_init[-1, 1]])
 
-        # Build a RISE-based cost closure for CMA-ES.
-        # This directly minimises SWOPP3 energy (MWh) instead of the
-        # ocean-current proxy ‖SOG − wind‖².
         _wps = case["wps"]
 
-        def _rise_cost(curve_batch: jnp.ndarray) -> jnp.ndarray:
-            return cost_function_rise(
-                windfield=windfield,
-                curve=curve_batch,
-                travel_time=travel_time,
-                wavefield=wavefield,
-                wps=_wps,
-                time_offset=departure_offset_h,
-            )
-
-        defaults = dict(
+        defaults_cmaes: dict[str, Any] = dict(
             K=10,
             L=n_points,
-            travel_time=travel_time,
             curve0=gc_init,
             sigma0=0.1,
-            cost_fn=_rise_cost,
             penalty=1000,
             land_margin=2,
-            verbose=False,
+            verbose=resolved_verbosity >= 2,
             time_offset=departure_offset_h,
             windfield=windfield,
             wavefield=wavefield,
+            travel_time=travel_time,
+            spherical_correction=True,
+            weather_penalty_weight=10.0,
+            wind_penalty_weight=0.0,
+            wave_penalty_weight=0.0,
+            distance_penalty_weight=0.0,
+            tws_limit=DEFAULT_TWS_LIMIT,
+            hs_limit=DEFAULT_HS_LIMIT,
         )
+        defaults_fms = dict(
+            patience=cmaes_kwargs.pop("fms_patience", 200),
+            damping=cmaes_kwargs.pop("fms_damping", 0.95),
+            maxfevals=cmaes_kwargs.pop("fms_maxfevals", 10000),
+        )
+        weather_penalty_type = str(cmaes_kwargs.pop("weather_penalty_type", "smooth"))
+        weather_penalty_sharpness = float(
+            cmaes_kwargs.pop("weather_penalty_sharpness", 5.0)
+        )
+        land_distance_epsilon = float(cmaes_kwargs.pop("land_distance_epsilon", 1.0))
         if cmaes_kwargs.pop("cmaes_verbose", False):
             cmaes_kwargs["verbose"] = True
-        defaults.update(cmaes_kwargs)
+        defaults_cmaes.update(cmaes_kwargs)
+        defaults_fms["verbose"] = bool(defaults_cmaes["verbose"])
 
-        curve, info = cmaes_optimize(
-            vectorfield=vectorfield,
-            src=src_opt,
-            dst=dst_opt,
-            land=land,
-            **defaults,
+        objective_travel_time = float(defaults_cmaes.get("travel_time", travel_time))
+        objective_time_offset = float(
+            defaults_cmaes.get("time_offset", departure_offset_h)
         )
+        objective_spherical_correction = bool(
+            defaults_cmaes.get("spherical_correction", True)
+        )
+        tws_limit = float(defaults_cmaes.get("tws_limit", DEFAULT_TWS_LIMIT))
+        hs_limit = float(defaults_cmaes.get("hs_limit", DEFAULT_HS_LIMIT))
+        weather_penalty_weight = float(
+            defaults_cmaes.get("weather_penalty_weight", 0.0)
+        )
+        wind_penalty_weight = float(defaults_cmaes.get("wind_penalty_weight", 0.0))
+        wave_penalty_weight = float(defaults_cmaes.get("wave_penalty_weight", 0.0))
+        distance_penalty_weight = float(
+            defaults_cmaes.get("distance_penalty_weight", 0.0)
+        )
+
+        def _shared_cost(
+            curve: jnp.ndarray,
+            *,
+            travel_time: float | None = None,
+            time_offset: float | None = None,
+            spherical_correction: bool | None = None,
+            **_: Any,
+        ) -> jnp.ndarray:
+            return _penalized_rise_cost(
+                curve=curve,
+                windfield=windfield,
+                wavefield=wavefield,
+                travel_time=(
+                    objective_travel_time if travel_time is None else travel_time
+                ),
+                wps=_wps,
+                spherical_correction=(
+                    objective_spherical_correction
+                    if spherical_correction is None
+                    else spherical_correction
+                ),
+                time_offset=(
+                    objective_time_offset if time_offset is None else time_offset
+                ),
+                tws_limit=tws_limit,
+                hs_limit=hs_limit,
+                weather_penalty_weight=weather_penalty_weight,
+                wind_penalty_weight=wind_penalty_weight,
+                wave_penalty_weight=wave_penalty_weight,
+                distance_penalty_weight=distance_penalty_weight,
+                weather_penalty_type=weather_penalty_type,
+                weather_penalty_sharpness=weather_penalty_sharpness,
+                land=land,
+                land_distance_epsilon=land_distance_epsilon,
+            )
+
+        defaults_cmaes["cost_fn"] = _shared_cost
+        fms_costfun_kwargs: dict[str, Any] = {
+            "windfield": windfield,
+            "wavefield": wavefield,
+            "wps": _wps,
+            "spherical_correction": objective_spherical_correction,
+            "tws_limit": tws_limit,
+            "hs_limit": hs_limit,
+            "weather_penalty_weight": weather_penalty_weight,
+            "wind_penalty_weight": wind_penalty_weight,
+            "wave_penalty_weight": wave_penalty_weight,
+            "distance_penalty_weight": distance_penalty_weight,
+            "weather_penalty_type": weather_penalty_type,
+            "weather_penalty_sharpness": weather_penalty_sharpness,
+            "land": land,
+            "land_distance_epsilon": land_distance_epsilon,
+        }
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"Sampling standard deviation i=.*",
+                category=UserWarning,
+                module=r"cma\.evolution_strategy",
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message=(
+                    r"\[WARNING\] The optimized curve has a higher cost "
+                    r"than the initial curve0 provided .*"
+                ),
+                category=UserWarning,
+            )
+            cmaes_t0 = _time.time()
+            curve_cmaes, _ = cmaes_optimize(
+                vectorfield=vectorfield,
+                src=src_opt,
+                dst=dst_opt,
+                land=land,
+                **defaults_cmaes,
+            )
+        cmaes_distance_nm = sailed_distance_nm(curve_cmaes)
+        energy_cmaes, max_tws_cmaes, max_hs_cmaes = evaluate_energy(
+            curve_cmaes,
+            departure,
+            case["passage_hours"],
+            wps=case["wps"],
+            windfield=windfield,
+            wavefield=wavefield,
+            departure_offset_h=departure_offset_h,
+        )
+        cmaes_comp_time_s = _time.time() - cmaes_t0
+
+        fms_t0 = _time.time()
+        curve_fms, _ = optimize_fms(
+            vectorfield=vectorfield,
+            curve=curve_cmaes,
+            land=land,
+            windfield=windfield,
+            wavefield=wavefield,
+            travel_time=objective_travel_time,
+            spherical_correction=objective_spherical_correction,
+            time_offset=objective_time_offset,
+            enforce_weather_limits=True,
+            tws_limit=tws_limit,
+            hs_limit=hs_limit,
+            costfun=_penalized_rise_cost,
+            costfun_kwargs=fms_costfun_kwargs,
+            **defaults_fms,
+        )
+        curve_fms = curve_fms[0]
+        fms_distance_nm = sailed_distance_nm(curve_fms)
+        energy_fms, max_tws_fms, max_hs_fms = evaluate_energy(
+            curve_fms,
+            departure,
+            case["passage_hours"],
+            wps=case["wps"],
+            windfield=windfield,
+            wavefield=wavefield,
+            departure_offset_h=departure_offset_h,
+        )
+        fms_comp_time_s = _time.time() - fms_t0
+
+        if resolved_verbosity >= 1:
+            print()
+            print(
+                f"    CMA-ES  E={energy_cmaes:.2f} MWh  "
+                f"d={cmaes_distance_nm:.0f} nm  "
+                f"t={cmaes_comp_time_s:.1f}s"
+            )
+            print(
+                f"    FMS     E={energy_fms:.2f} MWh  "
+                f"d={fms_distance_nm:.0f} nm  "
+                f"t={fms_comp_time_s:.1f}s"
+            )
+
+        cmaes_is_valid = max_tws_cmaes <= tws_limit and max_hs_cmaes <= hs_limit
+        fms_is_valid = max_tws_fms <= tws_limit and max_hs_fms <= hs_limit
+
+        if fms_is_valid and (not cmaes_is_valid or energy_fms < energy_cmaes):
+            curve = curve_fms
+            energy_mwh = energy_fms
+            max_tws = max_tws_fms
+            max_hs = max_hs_fms
+        else:
+            curve = curve_cmaes
+            energy_mwh = energy_cmaes
+            max_tws = max_tws_cmaes
+            max_hs = max_hs_cmaes
     else:
         # No vectorfield → raise error
         raise ValueError(
@@ -368,16 +624,6 @@ def run_optimised_departure(
         )
 
     distance_nm = sailed_distance_nm(curve)
-
-    energy_mwh, max_tws, max_hs = evaluate_energy(
-        curve,
-        departure,
-        case["passage_hours"],
-        wps=case["wps"],
-        windfield=windfield,
-        wavefield=wavefield,
-        departure_offset_h=departure_offset_h,
-    )
     comp_time = _time.time() - t0
 
     return DepartureResult(

--- a/scripts/swopp3_apply_fms.py
+++ b/scripts/swopp3_apply_fms.py
@@ -1,0 +1,716 @@
+#!/usr/bin/env python
+"""Apply FMS refinement to existing SWOPP3 route outputs.
+
+This script reads a folder produced by ``scripts/swopp3_run.py`` and writes a
+new folder with suffix ``_fms`` by default. Great-circle cases are copied as-is.
+Optimised cases are refined route-by-route with FMS; for each departure the FMS
+route is kept only when its evaluated energy is strictly lower than the energy
+of the original stored route.
+
+Usage
+-----
+Refine the default SWOPP3 output folder and write ``output/swopp3_fms``::
+
+    uv run scripts/swopp3_apply_fms.py output/swopp3
+
+Use explicit ERA5 paths for both corridors::
+
+    uv run scripts/swopp3_apply_fms.py output/swopp3 \
+        --wind-path-atlantic data/era5/era5_wind_atlantic_2024.nc \
+        --wave-path-atlantic data/era5/era5_waves_atlantic_2024.nc \
+        --wind-path-pacific  data/era5/era5_wind_pacific_2024.nc \
+        --wave-path-pacific  data/era5/era5_waves_pacific_2024.nc
+"""
+
+from __future__ import annotations
+
+import csv
+import gc
+import re
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import jax
+import jax.numpy as jnp
+import typer
+
+from routetools.cost import cost_function_rise
+from routetools.fms import optimize_fms
+from routetools.swopp3 import SWOPP3_CASES
+from routetools.swopp3_output import (
+    file_a_row,
+    resolve_file_b_path,
+    sailed_distance_nm,
+    waypoint_times,
+    write_file_a,
+    write_file_b,
+)
+from routetools.swopp3_runner import evaluate_energy
+from routetools.weather import DEFAULT_HS_LIMIT, DEFAULT_TWS_LIMIT
+
+if TYPE_CHECKING:
+    from routetools.swopp3_runner import FieldClosure
+
+
+app = typer.Typer(help="Apply FMS refinement to an existing SWOPP3 output folder.")
+
+_TEAM_FILE_RE = re.compile(r"^IEUniversity-(?P<submission>\d+)-(?P<case_id>.+)\.csv$")
+_ERA5_FILE_RE = re.compile(
+    r"^(?P<prefix>era5_[^_]+_[^_]+_)(?P<year>\d{4})(?:_(?P<suffix>\d{2}(?:-\d{2})?))?\.nc$"
+)
+_DTFMT = "%Y-%m-%d %H:%M:%S"
+_DEFAULT_ERA5_BATCH_DAYS = 183.0
+_DEFAULT_ERA5_RELOAD_MARGIN_DAYS = 20.0
+
+
+@dataclass(frozen=True)
+class CaseFile:
+    """Summary CSV metadata discovered in an input folder."""
+
+    case_id: str
+    submission: int
+    summary_path: Path
+
+
+@dataclass(frozen=True)
+class CorridorResources:
+    """Loaded weather, vectorfield, and land resources for one corridor."""
+
+    vectorfield: FieldClosure
+    windfield: FieldClosure
+    wavefield: FieldClosure
+    land: Any
+    dataset_epoch: datetime
+
+
+def _default_output_dir(input_dir: Path) -> Path:
+    """Return the default FMS output directory for an input folder."""
+    return input_dir.with_name(f"{input_dir.name}_fms")
+
+
+def _loadable_era5_paths(path: Path) -> list[Path]:
+    """Return the base ERA5 file plus any next-year continuation files."""
+    match = _ERA5_FILE_RE.match(path.name)
+    if match is None:
+        return [path]
+
+    prefix = match.group("prefix")
+    next_year = int(match.group("year")) + 1
+    exact_next_year = path.with_name(f"{prefix}{next_year}.nc")
+    if exact_next_year.exists():
+        return [path, exact_next_year]
+
+    continuation_paths = sorted(path.parent.glob(f"{prefix}{next_year}_*.nc"))
+    return [path, *continuation_paths]
+
+
+def _discover_case_files(input_dir: Path) -> list[CaseFile]:
+    """Return all valid SWOPP3 summary CSVs in an input directory."""
+    case_files: list[CaseFile] = []
+    for path in sorted(input_dir.glob("IEUniversity-*.csv")):
+        if not path.is_file():
+            continue
+        match = _TEAM_FILE_RE.match(path.name)
+        if match is None:
+            continue
+        case_id = match.group("case_id")
+        if case_id not in SWOPP3_CASES:
+            continue
+        case_files.append(
+            CaseFile(
+                case_id=case_id,
+                submission=int(match.group("submission")),
+                summary_path=path,
+            )
+        )
+    return case_files
+
+
+def _build_corridor_path_maps(
+    *,
+    wind_path: Path | None,
+    wave_path: Path | None,
+    wind_path_atlantic: Path | None,
+    wave_path_atlantic: Path | None,
+    wind_path_pacific: Path | None,
+    wave_path_pacific: Path | None,
+) -> tuple[dict[str, Path], dict[str, Path]]:
+    """Build per-corridor field path maps."""
+    corridor_wind: dict[str, Path] = {}
+    corridor_wave: dict[str, Path] = {}
+
+    if wind_path_atlantic is not None:
+        corridor_wind["atlantic"] = wind_path_atlantic
+    if wave_path_atlantic is not None:
+        corridor_wave["atlantic"] = wave_path_atlantic
+    if wind_path_pacific is not None:
+        corridor_wind["pacific"] = wind_path_pacific
+    if wave_path_pacific is not None:
+        corridor_wave["pacific"] = wave_path_pacific
+
+    if wind_path is not None:
+        corridor_wind["atlantic"] = wind_path
+        corridor_wind["pacific"] = wind_path
+    if wave_path is not None:
+        corridor_wave["atlantic"] = wave_path
+        corridor_wave["pacific"] = wave_path
+
+    return corridor_wind, corridor_wave
+
+
+def _validate_required_data_paths(
+    case_ids: list[str],
+    corridor_wind: dict[str, Path],
+    corridor_wave: dict[str, Path],
+) -> None:
+    """Fail fast when the required ERA5 inputs are missing."""
+    required_corridors = sorted(
+        {str(SWOPP3_CASES[case_id]["route"]) for case_id in case_ids}
+    )
+    missing: list[str] = []
+
+    for corridor in required_corridors:
+        wind = corridor_wind.get(corridor)
+        wave = corridor_wave.get(corridor)
+
+        if wind is None:
+            missing.append(f"{corridor} wind dataset path is not configured")
+        elif not Path(wind).exists():
+            missing.append(f"{corridor} wind dataset not found: {wind}")
+
+        if wave is None:
+            missing.append(f"{corridor} wave dataset path is not configured")
+        elif not Path(wave).exists():
+            missing.append(f"{corridor} wave dataset not found: {wave}")
+
+    if not missing:
+        return
+
+    corridor_list = ", ".join(required_corridors)
+    missing_lines = "\n".join(f"- {item}" for item in missing)
+    raise FileNotFoundError(
+        "SWOPP3 FMS input validation failed.\n\n"
+        f"Optimised cases require ERA5 datasets for corridor(s): {corridor_list}.\n"
+        "The FMS post-processing step uses wind data for the vectorfield and\n"
+        "uses wind and wave data to evaluate each original and refined route.\n\n"
+        f"Missing inputs:\n{missing_lines}\n\n"
+        "Fix:\n"
+        "- Run `uv run scripts/download_era5.py` to download the default "
+        "2024 datasets.\n"
+        "- Or pass matching `--wind-path*` and `--wave-path*` options."
+    )
+
+
+def _load_corridor_resources_for_cases(
+    case_ids: list[str],
+    corridor_wind: dict[str, Path],
+    corridor_wave: dict[str, Path],
+    *,
+    time_start: datetime | None = None,
+    time_end: datetime | None = None,
+    quiet: bool,
+) -> dict[str, CorridorResources]:
+    """Load weather, vectorfield, and land resources needed by optimised cases."""
+    if not case_ids:
+        return {}
+
+    import xarray as xr
+
+    from routetools.era5.loader import (
+        load_dataset_epoch,
+        load_era5_wavefield,
+        load_era5_windfield,
+        load_natural_earth_land_mask,
+    )
+
+    resources: dict[str, CorridorResources] = {}
+    corridors = sorted({str(SWOPP3_CASES[case_id]["route"]) for case_id in case_ids})
+
+    for corridor in corridors:
+        wind_path = corridor_wind[corridor]
+        wave_path = corridor_wave[corridor]
+
+        wind_paths = _loadable_era5_paths(wind_path)
+        wave_paths = _loadable_era5_paths(wave_path)
+        wind_target = wind_paths if len(wind_paths) > 1 else wind_paths[0]
+        wave_target = wave_paths if len(wave_paths) > 1 else wave_paths[0]
+
+        if not quiet:
+            typer.echo(
+                f"Loading corridor {corridor}: wind from "
+                f"{', '.join(str(path) for path in wind_paths)}"
+            )
+            typer.echo(
+                f"Loading corridor {corridor}: waves from "
+                f"{', '.join(str(path) for path in wave_paths)}"
+            )
+
+        dataset_epoch = load_dataset_epoch(
+            wind_target,
+            time_start=time_start,
+            time_end=time_end,
+        )
+        windfield = load_era5_windfield(
+            wind_target,
+            time_start=time_start,
+            time_end=time_end,
+        )
+        vectorfield = windfield
+        wavefield = load_era5_wavefield(
+            wave_target,
+            time_start=time_start,
+            time_end=time_end,
+        )
+
+        with xr.open_dataset(wave_paths[0]) as ds:
+            for lon_name in ("longitude", "lon"):
+                if lon_name in ds.coords:
+                    lons = ds[lon_name].values
+                    break
+            else:
+                raise KeyError(f"No longitude coordinate found in {wave_paths[0]}")
+
+            for lat_name in ("latitude", "lat"):
+                if lat_name in ds.coords:
+                    lats = ds[lat_name].values
+                    break
+            else:
+                raise KeyError(f"No latitude coordinate found in {wave_paths[0]}")
+
+        land = load_natural_earth_land_mask(
+            (float(lons.min()), float(lons.max())),
+            (float(lats.min()), float(lats.max())),
+        )
+
+        resources[corridor] = CorridorResources(
+            vectorfield=vectorfield,
+            windfield=windfield,
+            wavefield=wavefield,
+            land=land,
+            dataset_epoch=dataset_epoch,
+        )
+
+    return resources
+
+
+def _read_file_a_rows(summary_path: Path) -> list[dict[str, str]]:
+    """Read one SWOPP3 summary CSV as raw rows."""
+    with summary_path.open(newline="") as handle:
+        reader = csv.DictReader(handle)
+        return list(reader)
+
+
+def _read_track_curve(track_path: Path) -> jnp.ndarray:
+    """Read a SWOPP3 track CSV as a ``(L, 2)`` ``(lon, lat)`` array."""
+    lons: list[float] = []
+    lats: list[float] = []
+    with track_path.open(newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            lats.append(float(row["lat_deg"]))
+            lons.append(float(row["lon_deg"]))
+    return jnp.stack(
+        [jnp.asarray(lons, dtype=jnp.float32), jnp.asarray(lats, dtype=jnp.float32)],
+        axis=1,
+    )
+
+
+def _departure_offset_hours(departure: datetime, dataset_epoch: datetime) -> float:
+    """Return departure offset in hours relative to the dataset epoch."""
+    departure_naive = departure.replace(tzinfo=None) if departure.tzinfo else departure
+    epoch_naive = (
+        dataset_epoch.replace(tzinfo=None)
+        if hasattr(dataset_epoch, "tzinfo") and dataset_epoch.tzinfo
+        else dataset_epoch
+    )
+    return (departure_naive - epoch_naive).total_seconds() / 3600.0
+
+
+def _copy_case_outputs(case_file: CaseFile, input_dir: Path, output_dir: Path) -> None:
+    """Copy one case's summary CSV and all referenced tracks unchanged."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "tracks").mkdir(parents=True, exist_ok=True)
+    shutil.copy2(case_file.summary_path, output_dir / case_file.summary_path.name)
+
+    for row in _read_file_a_rows(case_file.summary_path):
+        filename = row["details_filename"]
+        src = resolve_file_b_path(input_dir, filename)
+        dst = output_dir / "tracks" / filename
+        shutil.copy2(src, dst)
+
+
+def _case_output_complete(case_file: CaseFile, output_dir: Path) -> bool:
+    """Return whether a case summary and all referenced tracks already exist."""
+    summary_path = output_dir / case_file.summary_path.name
+    if not summary_path.exists():
+        return False
+
+    try:
+        rows = _read_file_a_rows(summary_path)
+    except (OSError, csv.Error, KeyError):
+        return False
+
+    if not rows:
+        return False
+
+    return all(
+        (output_dir / "tracks" / row["details_filename"]).exists() for row in rows
+    )
+
+
+def _release_fms_state() -> None:
+    """Release cached JAX/FMS state between optimised cases."""
+    if hasattr(jax, "clear_caches"):
+        jax.clear_caches()
+    gc.collect()
+
+
+def _batch_window_parameters(
+    passage_hours: float,
+    era5_batch_days: float,
+    era5_reload_margin_days: float,
+) -> tuple[timedelta, timedelta]:
+    """Return batch duration and reload margin for rolling ERA5 windows."""
+    if era5_batch_days <= 0:
+        raise ValueError("era5_batch_days must be positive")
+    if era5_reload_margin_days <= 0:
+        raise ValueError("era5_reload_margin_days must be positive")
+
+    margin_hours = max(passage_hours, era5_reload_margin_days * 24.0)
+    batch_hours = max(margin_hours, era5_batch_days * 24.0)
+    return timedelta(hours=batch_hours), timedelta(hours=margin_hours)
+
+
+def apply_fms_to_outputs(
+    input_dir: Path,
+    *,
+    output_dir: Path | None = None,
+    wind_path: Path | None = None,
+    wave_path: Path | None = None,
+    wind_path_atlantic: Path | None = Path("data/era5/era5_wind_atlantic_2024.nc"),
+    wave_path_atlantic: Path | None = Path("data/era5/era5_waves_atlantic_2024.nc"),
+    wind_path_pacific: Path | None = Path("data/era5/era5_wind_pacific_2024.nc"),
+    wave_path_pacific: Path | None = Path("data/era5/era5_waves_pacific_2024.nc"),
+    fms_patience: int = 200,
+    fms_damping: float = 0.95,
+    fms_maxfevals: int = 10000,
+    era5_batch_days: float = _DEFAULT_ERA5_BATCH_DAYS,
+    era5_reload_margin_days: float = _DEFAULT_ERA5_RELOAD_MARGIN_DAYS,
+    tws_limit: float = DEFAULT_TWS_LIMIT,
+    hs_limit: float = DEFAULT_HS_LIMIT,
+    quiet: bool = False,
+) -> Path:
+    """Apply FMS to an existing SWOPP3 output folder and write a sibling folder."""
+    input_dir = Path(input_dir)
+    if not input_dir.exists():
+        raise FileNotFoundError(f"Input directory not found: {input_dir}")
+    if not input_dir.is_dir():
+        raise NotADirectoryError(f"Input path is not a directory: {input_dir}")
+
+    resolved_output_dir = (
+        _default_output_dir(input_dir) if output_dir is None else Path(output_dir)
+    )
+    if resolved_output_dir == input_dir:
+        raise ValueError("output_dir must be different from input_dir")
+
+    case_files = _discover_case_files(input_dir)
+    if not case_files:
+        raise FileNotFoundError(
+            f"No SWOPP3 summary CSV files found in input directory: {input_dir}"
+        )
+
+    optimised_case_ids = [
+        case_file.case_id
+        for case_file in case_files
+        if SWOPP3_CASES[case_file.case_id]["strategy"] == "optimised"
+    ]
+
+    corridor_wind, corridor_wave = _build_corridor_path_maps(
+        wind_path=wind_path,
+        wave_path=wave_path,
+        wind_path_atlantic=wind_path_atlantic,
+        wave_path_atlantic=wave_path_atlantic,
+        wind_path_pacific=wind_path_pacific,
+        wave_path_pacific=wave_path_pacific,
+    )
+
+    if optimised_case_ids:
+        _validate_required_data_paths(optimised_case_ids, corridor_wind, corridor_wave)
+
+    resolved_output_dir.mkdir(parents=True, exist_ok=True)
+    (resolved_output_dir / "tracks").mkdir(parents=True, exist_ok=True)
+
+    for case_file in case_files:
+        if _case_output_complete(case_file, resolved_output_dir):
+            if not quiet:
+                typer.echo(f"Skipping completed case {case_file.case_id}")
+            continue
+
+        case = SWOPP3_CASES[case_file.case_id]
+        if case["strategy"] == "gc":
+            if not quiet:
+                typer.echo(f"Copying GC case {case_file.case_id} unchanged")
+            _copy_case_outputs(case_file, input_dir, resolved_output_dir)
+            continue
+
+        corridor = str(case["route"])
+        passage_hours = float(case["passage_hours"])
+        batch_duration, reload_margin = _batch_window_parameters(
+            passage_hours,
+            era5_batch_days,
+            era5_reload_margin_days,
+        )
+        output_rows: list[dict[str, str]] = []
+        resources: CorridorResources | None = None
+        reload_after: datetime | None = None
+
+        try:
+            rows = _read_file_a_rows(case_file.summary_path)
+            for idx, row in enumerate(rows, start=1):
+                departure = datetime.strptime(row["departure_time_utc"], _DTFMT)
+                if (
+                    resources is None
+                    or reload_after is None
+                    or departure >= reload_after
+                ):
+                    if resources is not None:
+                        del resources
+                        _release_fms_state()
+
+                    batch_start = departure
+                    batch_end = batch_start + batch_duration
+                    reload_after = batch_end - reload_margin
+                    resources = _load_corridor_resources_for_cases(
+                        [case_file.case_id],
+                        corridor_wind,
+                        corridor_wave,
+                        time_start=batch_start,
+                        time_end=batch_end,
+                        quiet=quiet,
+                    )[corridor]
+                    if not quiet:
+                        typer.echo(
+                            f"Loaded {corridor} ERA5 batch for {case_file.case_id}: "
+                            f"{batch_start.strftime('%Y-%m-%d')} to "
+                            f"{batch_end.strftime('%Y-%m-%d')}"
+                        )
+
+                if resources is None:
+                    raise RuntimeError(
+                        f"Failed to load corridor resources for {case_file.case_id}"
+                    )
+
+                details_filename = row["details_filename"]
+                track_path = resolve_file_b_path(input_dir, details_filename)
+                curve_original = _read_track_curve(track_path)
+                departure_offset_h = _departure_offset_hours(
+                    departure,
+                    resources.dataset_epoch,
+                )
+
+                curve_fms_batch, _ = optimize_fms(
+                    vectorfield=resources.vectorfield,
+                    curve=curve_original,
+                    land=resources.land,
+                    windfield=resources.windfield,
+                    wavefield=resources.wavefield,
+                    penalty=1.0,
+                    travel_time=passage_hours,
+                    patience=fms_patience,
+                    damping=fms_damping,
+                    maxfevals=fms_maxfevals,
+                    spherical_correction=True,
+                    costfun=cost_function_rise,
+                    costfun_kwargs={
+                        "windfield": resources.windfield,
+                        "wavefield": resources.wavefield,
+                        "wps": bool(case["wps"]),
+                    },
+                    verbose=not quiet,
+                    time_offset=departure_offset_h,
+                    enforce_weather_limits=False,
+                    tws_limit=tws_limit,
+                    hs_limit=hs_limit,
+                )
+                curve_fms = curve_fms_batch[0]
+
+                original_energy, original_max_tws, original_max_hs = evaluate_energy(
+                    curve_original,
+                    departure,
+                    passage_hours,
+                    wps=bool(case["wps"]),
+                    windfield=resources.windfield,
+                    wavefield=resources.wavefield,
+                    departure_offset_h=departure_offset_h,
+                )
+                fms_energy, fms_max_tws, fms_max_hs = evaluate_energy(
+                    curve_fms,
+                    departure,
+                    passage_hours,
+                    wps=bool(case["wps"]),
+                    windfield=resources.windfield,
+                    wavefield=resources.wavefield,
+                    departure_offset_h=departure_offset_h,
+                )
+
+                if fms_energy < original_energy:
+                    chosen_curve = curve_fms
+                    chosen_energy = fms_energy
+                    chosen_max_tws = fms_max_tws
+                    chosen_max_hs = fms_max_hs
+                    decision = "FMS"
+                else:
+                    chosen_curve = curve_original
+                    chosen_energy = original_energy
+                    chosen_max_tws = original_max_tws
+                    chosen_max_hs = original_max_hs
+                    decision = "original"
+
+                distance_nm = sailed_distance_nm(chosen_curve)
+                write_file_b(
+                    chosen_curve,
+                    waypoint_times(chosen_curve, departure, passage_hours),
+                    resolved_output_dir / "tracks" / details_filename,
+                )
+                output_rows.append(
+                    file_a_row(
+                        departure=departure,
+                        passage_hours=passage_hours,
+                        energy_mwh=chosen_energy,
+                        max_wind_mps=chosen_max_tws,
+                        max_hs_m=chosen_max_hs,
+                        distance_nm=distance_nm,
+                        details_filename=details_filename,
+                    )
+                )
+
+                if not quiet:
+                    typer.echo(
+                        f"[{case_file.case_id}] {idx}/{len(rows)} "
+                        f"{departure.strftime('%Y-%m-%d')} "
+                        f"original={original_energy:.3f} MWh  "
+                        f"fms={fms_energy:.3f} MWh  keep={decision}"
+                    )
+
+            write_file_a(output_rows, resolved_output_dir / case_file.summary_path.name)
+        finally:
+            if resources is not None:
+                del resources
+                _release_fms_state()
+
+    if not quiet:
+        typer.echo(f"Wrote FMS-refined output folder to {resolved_output_dir}")
+    return resolved_output_dir
+
+
+@app.command()
+def main(
+    input_dir: Path = typer.Argument(  # noqa: B008
+        ..., help="Folder produced by swopp3_run.py."
+    ),
+    output_dir: Path | None = typer.Option(  # noqa: B008
+        None,
+        "--output-dir",
+        "-o",
+        help="Output directory. Default: <input-dir>_fms.",
+    ),
+    wind_path: Path | None = typer.Option(  # noqa: B008
+        None,
+        "--wind-path",
+        help="Path to ERA5 wind NetCDF used for all selected corridors.",
+    ),
+    wave_path: Path | None = typer.Option(  # noqa: B008
+        None,
+        "--wave-path",
+        help="Path to ERA5 wave NetCDF used for all selected corridors.",
+    ),
+    wind_path_atlantic: Path | None = typer.Option(  # noqa: B008
+        Path("data/era5/era5_wind_atlantic_2024.nc"),
+        "--wind-path-atlantic",
+        help="Path to ERA5 wind NetCDF for Atlantic routes.",
+    ),
+    wave_path_atlantic: Path | None = typer.Option(  # noqa: B008
+        Path("data/era5/era5_waves_atlantic_2024.nc"),
+        "--wave-path-atlantic",
+        help="Path to ERA5 wave NetCDF for Atlantic routes.",
+    ),
+    wind_path_pacific: Path | None = typer.Option(  # noqa: B008
+        Path("data/era5/era5_wind_pacific_2024.nc"),
+        "--wind-path-pacific",
+        help="Path to ERA5 wind NetCDF for Pacific routes.",
+    ),
+    wave_path_pacific: Path | None = typer.Option(  # noqa: B008
+        Path("data/era5/era5_waves_pacific_2024.nc"),
+        "--wave-path-pacific",
+        help="Path to ERA5 wave NetCDF for Pacific routes.",
+    ),
+    fms_patience: int = typer.Option(  # noqa: B008
+        200,
+        "--fms-patience",
+        help="Early-stopping patience for FMS.",
+    ),
+    fms_damping: float = typer.Option(  # noqa: B008
+        0.95,
+        "--fms-damping",
+        help="FMS damping factor.",
+    ),
+    fms_maxfevals: int = typer.Option(  # noqa: B008
+        10000,
+        "--fms-maxfevals",
+        help="Maximum FMS iterations per route.",
+    ),
+    era5_batch_days: float = typer.Option(  # noqa: B008
+        _DEFAULT_ERA5_BATCH_DAYS,
+        "--era5-batch-days",
+        help="Maximum number of days of ERA5 data to keep loaded at once.",
+    ),
+    era5_reload_margin_days: float = typer.Option(  # noqa: B008
+        _DEFAULT_ERA5_RELOAD_MARGIN_DAYS,
+        "--era5-reload-margin-days",
+        help=(
+            "Reload ERA5 data when a departure is this close to the current batch end."
+        ),
+    ),
+    tws_limit: float = typer.Option(  # noqa: B008
+        DEFAULT_TWS_LIMIT,
+        "--tws-limit",
+        help="Maximum true wind speed allowed during FMS refinement.",
+    ),
+    hs_limit: float = typer.Option(  # noqa: B008
+        DEFAULT_HS_LIMIT,
+        "--hs-limit",
+        help="Maximum significant wave height allowed during FMS refinement.",
+    ),
+    quiet: bool = typer.Option(  # noqa: B008
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress progress output.",
+    ),
+) -> None:
+    """Apply FMS to every non-GC route in an existing SWOPP3 output folder."""
+    apply_fms_to_outputs(
+        input_dir,
+        output_dir=output_dir,
+        wind_path=wind_path,
+        wave_path=wave_path,
+        wind_path_atlantic=wind_path_atlantic,
+        wave_path_atlantic=wave_path_atlantic,
+        wind_path_pacific=wind_path_pacific,
+        wave_path_pacific=wave_path_pacific,
+        fms_patience=fms_patience,
+        fms_damping=fms_damping,
+        fms_maxfevals=fms_maxfevals,
+        era5_batch_days=era5_batch_days,
+        era5_reload_margin_days=era5_reload_margin_days,
+        tws_limit=tws_limit,
+        hs_limit=hs_limit,
+        quiet=quiet,
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/swopp3_apply_fms.py
+++ b/scripts/swopp3_apply_fms.py
@@ -63,10 +63,9 @@ _DTFMT = "%Y-%m-%d %H:%M:%S"
 _DEFAULT_ERA5_BATCH_DAYS = 183.0
 _DEFAULT_ERA5_RELOAD_MARGIN_DAYS = 20.0
 
-# TODO: set to 0 for final runs, or make configurable via CLI options
-WIND_PW = 1000
-WAVE_PW = 1000
-ENFORCE_WEATHER_LIMITS = False
+# Default penalty weights forwarded to cost_function_rise_penalized.
+_DEFAULT_WIND_PENALTY_WEIGHT = 1000
+_DEFAULT_WAVE_PENALTY_WEIGHT = 1000
 
 
 @dataclass(frozen=True)
@@ -410,6 +409,9 @@ def apply_fms_to_outputs(
     era5_reload_margin_days: float = _DEFAULT_ERA5_RELOAD_MARGIN_DAYS,
     tws_limit: float = DEFAULT_TWS_LIMIT,
     hs_limit: float = DEFAULT_HS_LIMIT,
+    wind_penalty_weight: float = _DEFAULT_WIND_PENALTY_WEIGHT,
+    wave_penalty_weight: float = _DEFAULT_WAVE_PENALTY_WEIGHT,
+    enforce_weather_limits: bool = False,
     quiet: bool = False,
 ) -> Path:
     """Apply FMS to an existing SWOPP3 output folder and write a sibling folder."""
@@ -537,14 +539,14 @@ def apply_fms_to_outputs(
                         "windfield": resources.windfield,
                         "wavefield": resources.wavefield,
                         "wps": bool(case["wps"]),
-                        "wave_penalty_weight": WAVE_PW,
-                        "wind_penalty_weight": WIND_PW,
+                        "wave_penalty_weight": wave_penalty_weight,
+                        "wind_penalty_weight": wind_penalty_weight,
                         "tws_limit": tws_limit,
                         "hs_limit": hs_limit,
                     },
                     verbose=not quiet,
                     time_offset=departure_offset_h,
-                    enforce_weather_limits=ENFORCE_WEATHER_LIMITS,
+                    enforce_weather_limits=enforce_weather_limits,
                     tws_limit=tws_limit,
                     hs_limit=hs_limit,
                 )
@@ -697,6 +699,25 @@ def main(
         "--hs-limit",
         help="Maximum significant wave height allowed during FMS refinement.",
     ),
+    wind_penalty_weight: float = typer.Option(  # noqa: B008
+        _DEFAULT_WIND_PENALTY_WEIGHT,
+        "--wind-penalty-weight",
+        help="Penalty weight for wind violations in the RISE cost function.",
+    ),
+    wave_penalty_weight: float = typer.Option(  # noqa: B008
+        _DEFAULT_WAVE_PENALTY_WEIGHT,
+        "--wave-penalty-weight",
+        help="Penalty weight for wave violations in the RISE cost function.",
+    ),
+    enforce_weather_limits: bool = typer.Option(  # noqa: B008
+        False,
+        "--enforce-weather-limits/--no-enforce-weather-limits",
+        help=(
+            "Reject FMS updates that newly violate the configured weather limits. "
+            "Already-violating routes may keep moving so FMS can escape an "
+            "initially infeasible route."
+        ),
+    ),
     quiet: bool = typer.Option(  # noqa: B008
         False,
         "--quiet",
@@ -721,6 +742,9 @@ def main(
         era5_reload_margin_days=era5_reload_margin_days,
         tws_limit=tws_limit,
         hs_limit=hs_limit,
+        wind_penalty_weight=wind_penalty_weight,
+        wave_penalty_weight=wave_penalty_weight,
+        enforce_weather_limits=enforce_weather_limits,
         quiet=quiet,
     )
 

--- a/scripts/swopp3_apply_fms.py
+++ b/scripts/swopp3_apply_fms.py
@@ -3,9 +3,7 @@
 
 This script reads a folder produced by ``scripts/swopp3_run.py`` and writes a
 new folder with suffix ``_fms`` by default. Great-circle cases are copied as-is.
-Optimised cases are refined route-by-route with FMS; for each departure the FMS
-route is kept only when its evaluated energy is strictly lower than the energy
-of the original stored route.
+Optimised cases are refined route-by-route with FMS.
 
 Usage
 -----
@@ -37,7 +35,7 @@ import jax
 import jax.numpy as jnp
 import typer
 
-from routetools.cost import cost_function_rise
+from routetools.cost import cost_function_rise_penalized
 from routetools.fms import optimize_fms
 from routetools.swopp3 import SWOPP3_CASES
 from routetools.swopp3_output import (
@@ -65,6 +63,11 @@ _DTFMT = "%Y-%m-%d %H:%M:%S"
 _DEFAULT_ERA5_BATCH_DAYS = 183.0
 _DEFAULT_ERA5_RELOAD_MARGIN_DAYS = 20.0
 
+# TODO: set to 0 for final runs, or make configurable via CLI options
+WIND_PW = 1000
+WAVE_PW = 1000
+ENFORCE_WEATHER_LIMITS = False
+
 
 @dataclass(frozen=True)
 class CaseFile:
@@ -84,6 +87,12 @@ class CorridorResources:
     wavefield: FieldClosure
     land: Any
     dataset_epoch: datetime
+
+
+def _count_curve_land_violations(curve: jnp.ndarray, land: Any) -> int:
+    """Return the number of land-invalid positions for one route."""
+    curve_batch = curve if curve.ndim == 3 else curve[None, ...]
+    return int(jnp.sum(land(curve_batch) > 0))
 
 
 def _default_output_dir(input_dir: Path) -> Path:
@@ -523,19 +532,35 @@ def apply_fms_to_outputs(
                     damping=fms_damping,
                     maxfevals=fms_maxfevals,
                     spherical_correction=True,
-                    costfun=cost_function_rise,
+                    costfun=cost_function_rise_penalized,
                     costfun_kwargs={
                         "windfield": resources.windfield,
                         "wavefield": resources.wavefield,
                         "wps": bool(case["wps"]),
+                        "wave_penalty_weight": WAVE_PW,
+                        "wind_penalty_weight": WIND_PW,
+                        "tws_limit": tws_limit,
+                        "hs_limit": hs_limit,
                     },
                     verbose=not quiet,
                     time_offset=departure_offset_h,
-                    enforce_weather_limits=False,
+                    enforce_weather_limits=ENFORCE_WEATHER_LIMITS,
                     tws_limit=tws_limit,
                     hs_limit=hs_limit,
                 )
                 curve_fms = curve_fms_batch[0]
+
+                original_land_violations = _count_curve_land_violations(
+                    curve_original,
+                    resources.land,
+                )
+                fms_land_violations = _count_curve_land_violations(
+                    curve_fms,
+                    resources.land,
+                )
+                if fms_land_violations > original_land_violations:
+                    curve_fms = curve_original
+                    fms_land_violations = original_land_violations
 
                 original_energy, original_max_tws, original_max_hs = evaluate_energy(
                     curve_original,
@@ -556,32 +581,19 @@ def apply_fms_to_outputs(
                     departure_offset_h=departure_offset_h,
                 )
 
-                if fms_energy < original_energy:
-                    chosen_curve = curve_fms
-                    chosen_energy = fms_energy
-                    chosen_max_tws = fms_max_tws
-                    chosen_max_hs = fms_max_hs
-                    decision = "FMS"
-                else:
-                    chosen_curve = curve_original
-                    chosen_energy = original_energy
-                    chosen_max_tws = original_max_tws
-                    chosen_max_hs = original_max_hs
-                    decision = "original"
-
-                distance_nm = sailed_distance_nm(chosen_curve)
+                distance_nm = sailed_distance_nm(curve_fms)
                 write_file_b(
-                    chosen_curve,
-                    waypoint_times(chosen_curve, departure, passage_hours),
+                    curve_fms,
+                    waypoint_times(curve_fms, departure, passage_hours),
                     resolved_output_dir / "tracks" / details_filename,
                 )
                 output_rows.append(
                     file_a_row(
                         departure=departure,
                         passage_hours=passage_hours,
-                        energy_mwh=chosen_energy,
-                        max_wind_mps=chosen_max_tws,
-                        max_hs_m=chosen_max_hs,
+                        energy_mwh=fms_energy,
+                        max_wind_mps=fms_max_tws,
+                        max_hs_m=fms_max_hs,
                         distance_nm=distance_nm,
                         details_filename=details_filename,
                     )
@@ -592,7 +604,8 @@ def apply_fms_to_outputs(
                         f"[{case_file.case_id}] {idx}/{len(rows)} "
                         f"{departure.strftime('%Y-%m-%d')} "
                         f"original={original_energy:.3f} MWh  "
-                        f"fms={fms_energy:.3f} MWh  keep={decision}"
+                        f"fms={fms_energy:.3f} MWh  "
+                        f"land={original_land_violations}->{fms_land_violations}"
                     )
 
             write_file_a(output_rows, resolved_output_dir / case_file.summary_path.name)

--- a/tests/test_fms.py
+++ b/tests/test_fms.py
@@ -1,0 +1,309 @@
+"""Tests for routetools.fms constraint handling."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from routetools.fms import _apply_curve_constraints, optimize_fms
+from routetools.vectorfield import vectorfield_fourvortices
+
+
+def _curve() -> jnp.ndarray:
+    return jnp.array([[[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]]], dtype=jnp.float32)
+
+
+def _violating_windfield(lon, lat, t):
+    return jnp.full_like(lon, 25.0), jnp.zeros_like(lon)
+
+
+def _banded_windfield(lon, lat, t):
+    tws = jnp.where(lat > 0.25, 25.0, 5.0)
+    return tws, jnp.zeros_like(lon)
+
+
+class _BandLand:
+    def __call__(self, curve):
+        x = curve[..., 0]
+        y = curve[..., 1]
+        return ((x > 0.75) & (x < 1.25) & (y > 0.25)).astype(jnp.int32)
+
+
+class TestApplyCurveConstraints:
+    def test_no_land_passes_curve_through(self):
+        """Without land, the updated curve is returned unchanged."""
+        curve_old = _curve()
+        curve_new = curve_old + jnp.array([[[0.0, 0.0], [0.0, 1.0], [0.0, 0.0]]])
+
+        constrained = _apply_curve_constraints(curve_new, curve_old)
+
+        assert jnp.allclose(constrained, curve_new)
+
+    def test_newly_invalid_weather_route_is_rolled_back(self):
+        """A newly weather-invalid route should revert to the prior route."""
+        curve_old = _curve()
+        curve_new = curve_old + jnp.array([[[0.0, 0.0], [0.0, 1.0], [0.0, 0.0]]])
+
+        constrained = _apply_curve_constraints(
+            curve_new,
+            curve_old,
+            windfield=_banded_windfield,
+            enforce_weather_limits=True,
+            travel_time=2.0,
+        )
+
+        assert jnp.allclose(constrained, curve_old)
+
+    def test_still_invalid_weather_route_keeps_new_value(self):
+        """An already weather-invalid route should keep moving."""
+        curve_old = _curve() + jnp.array([[[0.0, 0.0], [0.0, 1.0], [0.0, 0.0]]])
+        curve_new = curve_old + jnp.array([[[0.0, 0.0], [0.0, -0.1], [0.0, 0.0]]])
+
+        constrained = _apply_curve_constraints(
+            curve_new,
+            curve_old,
+            windfield=_violating_windfield,
+            enforce_weather_limits=True,
+            travel_time=2.0,
+        )
+
+        assert jnp.allclose(constrained, curve_new)
+
+    def test_newly_invalid_land_waypoint_is_rolled_back(self):
+        """A valid waypoint that moves onto land should revert to the old value."""
+        land = _BandLand()
+        curve_old = _curve()
+        curve_new = curve_old + jnp.array([[[0.0, 0.0], [0.0, 0.5], [0.0, 0.0]]])
+
+        constrained = _apply_curve_constraints(
+            curve_new,
+            curve_old,
+            land=land,
+            penalty=1.0,
+        )
+
+        assert jnp.allclose(constrained, curve_old)
+
+    def test_still_invalid_land_waypoint_keeps_new_value(self):
+        """An already-invalid waypoint should keep moving even if still invalid."""
+        land = _BandLand()
+        curve_old = _curve() + jnp.array([[[0.0, 0.0], [0.0, 0.5], [0.0, 0.0]]])
+        curve_new = curve_old + jnp.array([[[0.0, 0.0], [0.0, -0.1], [0.0, 0.0]]])
+
+        constrained = _apply_curve_constraints(
+            curve_new,
+            curve_old,
+            land=land,
+            penalty=1.0,
+        )
+
+        assert jnp.allclose(constrained, curve_new)
+
+
+class TestOptimizeFmsWeatherLimits:
+    def test_fms_escapes_violating_initial_route(self):
+        """When the initial route violates weather, FMS should still keep moving.
+
+        Newly-invalid updates are rejected, but already-invalid routes are allowed
+        to evolve so the solver can escape the violation.
+        """
+        src = jnp.array([0.0, 0.0])
+        dst = jnp.array([6.0, 2.0])
+
+        call_count = {"n": 0}
+
+        def counting_violating_windfield(lon, lat, t):
+            call_count["n"] += 1
+            return jnp.full_like(lon, 25.0), jnp.zeros_like(lon)
+
+        _, info = optimize_fms(
+            vectorfield_fourvortices,
+            src=src,
+            dst=dst,
+            num_curves=1,
+            num_points=10,
+            travel_time=5.0,
+            maxfevals=20,
+            patience=5,
+            verbose=False,
+            enforce_weather_limits=True,
+            windfield=counting_violating_windfield,
+        )
+
+        assert info["niter"] > 0
+        assert call_count["n"] > 0
+
+    @pytest.mark.parametrize("enforce", [False, True])
+    def test_fms_runs_without_weather_fields(self, enforce):
+        """optimize_fms must not raise when enforce_weather_limits=True but no
+        windfield/wavefield is given."""
+        src = jnp.array([0.0, 0.0])
+        dst = jnp.array([6.0, 2.0])
+
+        _, info = optimize_fms(
+            vectorfield_fourvortices,
+            src=src,
+            dst=dst,
+            num_curves=1,
+            num_points=10,
+            travel_time=5.0,
+            maxfevals=5,
+            patience=3,
+            verbose=False,
+            enforce_weather_limits=enforce,
+        )
+
+        assert info["niter"] <= 5
+
+    def test_custom_costfun_can_capture_fields_internally(self):
+        """Custom FMS cost closures should work without vectorfield injection."""
+        src = jnp.array([0.0, 0.0])
+        dst = jnp.array([6.0, 2.0])
+
+        def custom_cost(curve):
+            return jnp.sum((curve[:, 1:, :] - curve[:, :-1, :]) ** 2, axis=(1, 2))
+
+        _, info = optimize_fms(
+            vectorfield_fourvortices,
+            src=src,
+            dst=dst,
+            num_curves=1,
+            num_points=10,
+            travel_time=5.0,
+            maxfevals=2,
+            patience=2,
+            verbose=False,
+            costfun=custom_cost,
+        )
+
+        assert info["niter"] <= 2
+
+    def test_custom_costfun_accepts_explicit_kwargs(self):
+        """Custom FMS costs should receive forwarded explicit kwargs."""
+        src = jnp.array([0.0, 0.0])
+        dst = jnp.array([6.0, 2.0])
+        seen: dict[str, float] = {}
+
+        def custom_cost(*, curve, travel_time=None, scale=1.0, **kwargs):
+            seen["scale"] = scale
+            return scale * jnp.sum(
+                (curve[:, 1:, :] - curve[:, :-1, :]) ** 2,
+                axis=(1, 2),
+            )
+
+        _, info = optimize_fms(
+            vectorfield_fourvortices,
+            src=src,
+            dst=dst,
+            num_curves=1,
+            num_points=10,
+            travel_time=5.0,
+            maxfevals=2,
+            patience=2,
+            verbose=False,
+            costfun=custom_cost,
+            costfun_kwargs={"scale": 2.5},
+        )
+
+        assert info["niter"] <= 2
+        assert seen["scale"] == pytest.approx(2.5)
+
+    def test_fms_snapshot_callback_receives_current_and_best_routes(self):
+        """FMS snapshot callback should expose current and best-so-far routes."""
+        snapshots: list[dict[str, object]] = []
+
+        def zero_field(lon, lat, t):
+            return jnp.zeros_like(lon), jnp.zeros_like(lat)
+
+        curve_init = jnp.array(
+            [[[0.0, 0.0], [1.0, 0.5], [2.0, 0.0]]],
+            dtype=jnp.float32,
+        )
+
+        _, info = optimize_fms(
+            zero_field,
+            curve=curve_init,
+            travel_time=2.0,
+            damping=0.0,
+            maxfevals=3,
+            patience=3,
+            verbose=False,
+            snapshot_callback=lambda snapshot: snapshots.append(
+                {
+                    "iteration": snapshot["iteration"],
+                    "curve_shape": tuple(snapshot["curve"].shape),
+                    "cost_shape": tuple(snapshot["cost"].shape),
+                    "best_curve_shape": tuple(snapshot["best_curve"].shape),
+                    "best_cost_shape": tuple(snapshot["best_cost"].shape),
+                }
+            ),
+        )
+
+        assert len(snapshots) == info["niter"]
+        assert snapshots[0]["iteration"] == 1
+        assert all(item["curve_shape"] == (1, 3, 2) for item in snapshots)
+        assert all(item["cost_shape"] == (1,) for item in snapshots)
+        assert all(item["best_curve_shape"] == (1, 3, 2) for item in snapshots)
+        assert all(item["best_cost_shape"] == (1,) for item in snapshots)
+
+    def test_fms_accepts_initially_invalid_land_waypoint(self):
+        """FMS should improve an initially invalid waypoint instead of raising."""
+        land = _BandLand()
+        curve_init = jnp.array(
+            [[[0.0, 0.0], [1.0, 0.5], [2.0, 0.0]]],
+            dtype=jnp.float32,
+        )
+
+        def zero_field(lon, lat, t):
+            return jnp.zeros_like(lon), jnp.zeros_like(lat)
+
+        curve_out, info = optimize_fms(
+            zero_field,
+            curve=curve_init,
+            land=land,
+            penalty=1.0,
+            travel_time=2.0,
+            damping=0.0,
+            maxfevals=5,
+            patience=5,
+            verbose=False,
+        )
+
+        assert info["niter"] > 0
+        assert float(curve_out[0, 1, 1]) < float(curve_init[0, 1, 1])
+
+
+class TestFmsConvergence:
+    def test_sinusoid_converges_to_straight_line(self):
+        """FMS with zero wind should straighten a sinusoidal route to a straight line.
+
+        The default physics cost ‖SOG‖² (wind = 0) is minimised by the
+        shortest path, so the Euler-Lagrange equations drive every interior
+        waypoint toward the straight line connecting the two endpoints.
+
+        Convergence rate per iteration = cos(π/(L-1)).  For L=10, this is
+        ~0.940, so after 100 Jacobi steps (damping=0) the initial amplitude
+        of 0.5 is reduced to < 1e-3, well within the 0.05 tolerance.
+        """
+        n_pts = 10
+        x = jnp.linspace(0.0, 6.0, n_pts)
+        # Half-period sinusoid: y = 0 at both endpoints, peak amplitude 0.5
+        y = 0.5 * jnp.sin(jnp.pi * x / 6.0)
+        curve_init = jnp.stack([x, y], axis=-1)[None, ...]  # shape (1, n_pts, 2)
+
+        def zero_field(lon, lat, t):
+            return jnp.zeros_like(lon), jnp.zeros_like(lat)
+
+        curve_out, _ = optimize_fms(
+            zero_field,
+            curve=curve_init,
+            travel_time=6.0,
+            damping=0.0,
+            maxfevals=100,
+            patience=20,
+            verbose=False,
+        )
+
+        # All interior y-coordinates should be near 0 (straight line y = 0)
+        interior_y = curve_out[0, 1:-1, 1]
+        assert float(jnp.abs(interior_y).max()) < 0.05


### PR DESCRIPTION
## Summary
- extend the FMS engine so it can optimize SWOPP3 routes with custom costs, time-aware weather checks, safer constraint handling, and reusable JAX solver paths
- integrate that FMS workflow into the SWOPP3 toolchain, including route generation, validation, plotting, and post-processing of existing outputs
- make the FMS post-processing path usable on large ERA5 datasets by bounding loaded weather timelines and reloading rolling batches instead of materializing the full yearly corridor timeline
- round out the supporting ERA5/weather stack, documentation, tests, and CodaBench competition assets needed for the broader SWOPP3 workflow

## What Changed
- updated `routetools/fms.py` with custom-cost support, weather-limit enforcement, snapshot callbacks, damping/clipping stability improvements, and cacheable travel-time solver paths
- updated `routetools/swopp3_runner.py`, `routetools/swopp3.py`, and related SWOPP3 modules/output helpers so optimized runs can refine CMA-ES routes with FMS before final energy evaluation
- added `scripts/swopp3_apply_fms.py` to refine existing SWOPP3 outputs with FMS; it now processes optimized cases one case at a time, skips already completed case outputs, and releases cached state between cases to reduce OOM risk
- added bounded ERA5 time-window loading in `routetools/era5/loader.py` and rolling ERA5 batch reloads in `scripts/swopp3_apply_fms.py` so FMS refinement does not load the full yearly wind/wave timeline into JAX memory at once
- added and updated SWOPP3 plotting, validation, SLURM, and comparison scripts to support experimentation and inspection of outputs
- expanded the ERA5/weather toolchain with loaders, download utilities, penalty/evaluation fixes, benchmarks, and comparison utilities
- added CodaBench competition assets and supporting docs/tests across the new workflow

## Review Guide
- start with `routetools/fms.py`
- then review `routetools/swopp3_runner.py`, `routetools/swopp3.py`, and `routetools/swopp3_output.py`
- then review `scripts/swopp3_apply_fms.py`, especially the resumable execution and bounded ERA5 batch loading path
- then review `routetools/era5/loader.py` for the new time-window loading support used by the FMS post-processing workflow
- treat the remaining ERA5/weather helpers, docs, CodaBench files, and SLURM scripts as supporting changes around that core workflow

## Validation
- `make hooks`
- `make test`

## Notes
- this PR is broader than the title suggests because the branch now carries the end-to-end SWOPP3/FMS workflow against `main`
- the new FMS post-processing path is resumable at the case level: reruns skip cases whose summary CSV and referenced track files already exist
- the ERA5 loader extension is included here because it is the implementation mechanism for the FMS memory-safety fix, not an unrelated optimization