### PR TITLE
Feat/swopp3 fms land pipeline

### DIFF
--- a/routetools/era5/loader.py
+++ b/routetools/era5/loader.py
@@ -804,6 +804,7 @@ def load_era5_land_mask(
     land.interpolate = 10  # insert 10 sub-points between waypoints to catch narrow land
     land.outbounds_is_land = True
     land.penalize_segments = False
+    land.avoidance_resolution_scale = 2
     land._map_mode = "nearest"
     land._map_order = 0
 
@@ -846,6 +847,7 @@ def load_natural_earth_land_mask(
     resolution: float = 0.01,
     ne_resolution: str = "10m",
     interpolate: int = 50,
+    avoidance_resolution_scale: int = 2,
 ) -> Land:
     """Create a high-resolution land mask from Natural Earth shapefiles.
 
@@ -869,6 +871,9 @@ def load_natural_earth_land_mask(
         Number of sub-points inserted between waypoints for segment
         checking (passed to ``Land``).  Default 50 gives ~1 km spacing
         with L=100 waypoints, matching the 0.01° mask resolution.
+    avoidance_resolution_scale : int
+        Shared A* grid scale used by rerouting on the returned ``Land``
+        object. Lower values are faster and coarser.
 
     Returns
     -------
@@ -997,6 +1002,9 @@ def load_natural_earth_land_mask(
     land.interpolate = interpolate
     land.outbounds_is_land = True
     land.penalize_segments = False
+    if avoidance_resolution_scale < 1:
+        raise ValueError("avoidance_resolution_scale must be >= 1")
+    land.avoidance_resolution_scale = int(avoidance_resolution_scale)
     land._map_mode = "nearest"
     land._map_order = 0
 

--- a/routetools/land.py
+++ b/routetools/land.py
@@ -1,3 +1,4 @@
+import heapq
 from functools import partial
 from math import ceil
 
@@ -9,6 +10,29 @@ from jax.scipy.ndimage import map_coordinates
 from perlin_numpy import generate_perlin_noise_2d as pn2d
 
 from routetools._cost.haversine import haversine_meters_components
+
+DEFAULT_AVOIDANCE_RESOLUTION_SCALE = 2
+
+
+def _coerce_avoidance_resolution_scale(value: int) -> int:
+    """Validate and normalize the shared land-avoidance resolution scale."""
+    scale = int(value)
+    if scale < 1:
+        raise ValueError("avoidance_resolution_scale must be >= 1")
+    return scale
+
+
+def _resolve_avoidance_resolution_scale(land, override: int | None) -> int:
+    """Resolve the A* grid scale from an explicit override or the Land object."""
+    if override is not None:
+        return _coerce_avoidance_resolution_scale(override)
+    return _coerce_avoidance_resolution_scale(
+        getattr(
+            land,
+            "avoidance_resolution_scale",
+            DEFAULT_AVOIDANCE_RESOLUTION_SCALE,
+        )
+    )
 
 
 class Land:
@@ -27,6 +51,7 @@ class Land:
         penalize_segments: bool = True,
         map_mode: str = "nearest",
         map_order: int = 0,
+        avoidance_resolution_scale: int = DEFAULT_AVOIDANCE_RESOLUTION_SCALE,
     ):
         """Class to check if points on a curve are on land.
 
@@ -56,6 +81,9 @@ class Land:
         map_order : int, optional
             The order of the spline interpolation,
             by default 0. 0 for nearest neighbor, 1 for bilinear.
+        avoidance_resolution_scale : int, optional
+            Shared A* grid scale used by land-avoidance rerouting when no
+            per-call override is provided. Lower values are faster and coarser.
         """
         # Ensure resolution is 2D
         if resolution is None:
@@ -109,6 +137,9 @@ class Land:
         self.interpolate = interpolate
         self.outbounds_is_land = outbounds_is_land
         self.penalize_segments = penalize_segments
+        self.avoidance_resolution_scale = _coerce_avoidance_resolution_scale(
+            avoidance_resolution_scale
+        )
 
         land_indices = jnp.argwhere(self._array)
         self._lats = self.y[land_indices[:, 1]]
@@ -504,3 +535,504 @@ def move_curve_away_from_land(
                 radius += step_size
             niter += 1
     return curve_new
+
+
+def _point_is_land(point: np.ndarray, land: Land) -> bool:
+    """Return True if a single point lies on land according to ``land``."""
+    return bool(np.asarray(land(np.asarray(point, dtype=float))).item())
+
+
+def _segment_crosses_land(
+    a: np.ndarray,
+    b: np.ndarray,
+    land: Land,
+    oversample: int = 6,
+) -> bool:
+    """Return True if the segment from ``a`` to ``b`` intersects land."""
+    dx = (land.xmax - land.xmin) / max(1, land.shape[0] - 1)
+    dy = (land.ymax - land.ymin) / max(1, land.shape[1] - 1)
+    steps = max(
+        abs((b[0] - a[0]) / max(dx, 1e-12)), abs((b[1] - a[1]) / max(dy, 1e-12))
+    )
+    # Use dense sampling to avoid false negatives near complex coastlines.
+    n_samples = max(101, int(np.ceil(oversample * steps)) + 1)
+
+    samples = np.linspace(a, b, n_samples)
+    is_land = np.asarray(land(samples), dtype=bool).reshape(-1)
+    return bool(is_land[1:-1].any())
+
+
+def _build_astar_grid(
+    land: Land,
+    astar_resolution_scale: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Build an A* land-mask grid (optionally upsampled)."""
+    if astar_resolution_scale < 1:
+        raise ValueError("astar_resolution_scale must be >= 1")
+
+    is_land = np.asarray(land.array, dtype=bool)
+    if astar_resolution_scale > 1:
+        is_land = np.kron(
+            is_land,
+            np.ones((astar_resolution_scale, astar_resolution_scale), dtype=bool),
+        )
+
+    x_axis = np.linspace(land.xmin, land.xmax, is_land.shape[0])
+    y_axis = np.linspace(land.ymin, land.ymax, is_land.shape[1])
+    return is_land, x_axis, y_axis
+
+
+def _dilate_land_mask(is_land: np.ndarray, radius: int) -> np.ndarray:
+    """Dilate boolean land mask by ``radius`` cells using 8-neighbour growth."""
+    if radius <= 0:
+        return is_land
+
+    dilated = is_land.copy()
+    for _ in range(radius):
+        padded = np.pad(dilated, 1, mode="edge")
+        expanded = np.zeros_like(dilated)
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                expanded |= padded[
+                    1 + dx : 1 + dx + dilated.shape[0],
+                    1 + dy : 1 + dy + dilated.shape[1],
+                ]
+        dilated = expanded
+    return dilated
+
+
+def _point_to_cell(
+    point: np.ndarray,
+    x_axis: np.ndarray,
+    y_axis: np.ndarray,
+) -> tuple[int, int]:
+    """Map (lon, lat) to nearest A* grid index."""
+    ix = int(np.clip(np.searchsorted(x_axis, point[0]), 0, len(x_axis) - 1))
+    iy = int(np.clip(np.searchsorted(y_axis, point[1]), 0, len(y_axis) - 1))
+
+    if ix > 0 and abs(x_axis[ix - 1] - point[0]) < abs(x_axis[ix] - point[0]):
+        ix -= 1
+    if iy > 0 and abs(y_axis[iy - 1] - point[1]) < abs(y_axis[iy] - point[1]):
+        iy -= 1
+
+    return ix, iy
+
+
+def _nearest_water_cell(
+    cell: tuple[int, int],
+    water: np.ndarray,
+) -> tuple[int, int] | None:
+    """Return nearest water cell, searching outward in square rings."""
+    x0, y0 = cell
+    if water[x0, y0]:
+        return cell
+
+    max_radius = max(water.shape)
+    for radius in range(1, max_radius):
+        xmin = max(0, x0 - radius)
+        xmax = min(water.shape[0] - 1, x0 + radius)
+        ymin = max(0, y0 - radius)
+        ymax = min(water.shape[1] - 1, y0 + radius)
+
+        candidates: list[tuple[int, int]] = []
+        for ix in range(xmin, xmax + 1):
+            for iy in range(ymin, ymax + 1):
+                if ix not in (xmin, xmax) and iy not in (ymin, ymax):
+                    continue
+                if water[ix, iy]:
+                    candidates.append((ix, iy))
+
+        if candidates:
+            return min(candidates, key=lambda c: (c[0] - x0) ** 2 + (c[1] - y0) ** 2)
+
+    return None
+
+
+def _astar_cells(
+    start: tuple[int, int],
+    goal: tuple[int, int],
+    water: np.ndarray,
+) -> list[tuple[int, int]] | None:
+    """Run A* on the water grid and return the cell path from start to goal."""
+
+    def heuristic(cell: tuple[int, int]) -> float:
+        return float(np.hypot(cell[0] - goal[0], cell[1] - goal[1]))
+
+    neighbour_steps = [
+        (-1, -1, np.sqrt(2.0)),
+        (-1, 0, 1.0),
+        (-1, 1, np.sqrt(2.0)),
+        (0, -1, 1.0),
+        (0, 1, 1.0),
+        (1, -1, np.sqrt(2.0)),
+        (1, 0, 1.0),
+        (1, 1, np.sqrt(2.0)),
+    ]
+
+    open_heap: list[tuple[float, float, tuple[int, int]]] = []
+    heapq.heappush(open_heap, (heuristic(start), 0.0, start))
+    best_g: dict[tuple[int, int], float] = {start: 0.0}
+    came_from: dict[tuple[int, int], tuple[int, int]] = {}
+    closed: set[tuple[int, int]] = set()
+
+    while open_heap:
+        _, g_now, current = heapq.heappop(open_heap)
+        if current in closed:
+            continue
+
+        if current == goal:
+            path = [current]
+            while current in came_from:
+                current = came_from[current]
+                path.append(current)
+            return path[::-1]
+
+        closed.add(current)
+
+        for dx, dy, move_cost in neighbour_steps:
+            nx = current[0] + dx
+            ny = current[1] + dy
+            if nx < 0 or ny < 0 or nx >= water.shape[0] or ny >= water.shape[1]:
+                continue
+            if not water[nx, ny]:
+                continue
+
+            neighbour = (nx, ny)
+            tentative_g = g_now + move_cost
+            if tentative_g >= best_g.get(neighbour, np.inf):
+                continue
+
+            best_g[neighbour] = tentative_g
+            came_from[neighbour] = current
+            heapq.heappush(
+                open_heap,
+                (tentative_g + heuristic(neighbour), tentative_g, neighbour),
+            )
+
+    return None
+
+
+def _resample_polyline(polyline: np.ndarray, n_points: int) -> np.ndarray:
+    """Resample a polyline to exactly ``n_points`` interior waypoints."""
+    if n_points <= 0:
+        return np.empty((0, 2), dtype=float)
+
+    if len(polyline) < 2:
+        return np.repeat(polyline[[0]], n_points, axis=0)
+
+    seg_len = np.linalg.norm(np.diff(polyline, axis=0), axis=1)
+    cumulative = np.concatenate([[0.0], np.cumsum(seg_len)])
+    total = float(cumulative[-1])
+    if total <= 0:
+        return np.repeat(polyline[[0]], n_points, axis=0)
+
+    targets = np.linspace(0.0, total, n_points + 2)[1:-1]
+    out = np.empty((n_points, 2), dtype=float)
+
+    j = 1
+    for i, target in enumerate(targets):
+        while j < len(cumulative) and cumulative[j] < target:
+            j += 1
+        if j >= len(cumulative):
+            out[i] = polyline[-1]
+            continue
+
+        left = j - 1
+        right = j
+        d0 = cumulative[left]
+        d1 = cumulative[right]
+        if d1 <= d0:
+            out[i] = polyline[right]
+            continue
+
+        alpha = (target - d0) / (d1 - d0)
+        out[i] = (1.0 - alpha) * polyline[left] + alpha * polyline[right]
+
+    return out
+
+
+def _polyline_crosses_land(polyline: np.ndarray, land: Land) -> bool:
+    """Return True when any segment of ``polyline`` crosses land."""
+    for i in range(len(polyline) - 1):
+        if _segment_crosses_land(polyline[i], polyline[i + 1], land):
+            return True
+    return False
+
+
+def route_crossing_segment_indices(
+    route: np.ndarray,
+    land: Land,
+    *,
+    allow_start_land: bool = False,
+    allow_end_land: bool = False,
+    oversample: int = 6,
+) -> list[int]:
+    """Return indices of route segments that intersect land.
+
+    Parameters
+    ----------
+    route : np.ndarray
+        Waypoints as an array of shape ``(N, 2)`` with ``[lon, lat]`` columns.
+    land : Land
+        Land mask used for the crossing check.
+    allow_start_land, allow_end_land : bool, optional
+        When True, ignore the first or last segment respectively if the
+        corresponding route endpoint lies on land. This is useful for port
+        endpoints that are unavoidable boundary touches.
+    oversample : int, optional
+        Oversampling factor passed through to ``_segment_crosses_land``.
+
+    Returns
+    -------
+    list[int]
+        Zero-based indices of segments whose interior intersects land.
+    """
+    route = np.asarray(route, dtype=float)
+    if route.ndim != 2 or route.shape[1] != 2:
+        raise ValueError(f"route must have shape (N, 2), got {route.shape}")
+    if not isinstance(land, Land):
+        raise TypeError("land must be an instance of routetools.land.Land")
+    if len(route) < 2:
+        return []
+
+    ignore_first = allow_start_land and _point_is_land(route[0], land)
+    ignore_last = allow_end_land and _point_is_land(route[-1], land)
+    last_segment = len(route) - 2
+
+    crossing_segments: list[int] = []
+    for idx in range(len(route) - 1):
+        if ignore_first and idx == 0:
+            continue
+        if ignore_last and idx == last_segment:
+            continue
+        if _segment_crosses_land(route[idx], route[idx + 1], land, oversample):
+            crossing_segments.append(idx)
+
+    return crossing_segments
+
+
+def route_crosses_land(
+    route: np.ndarray,
+    land: Land,
+    *,
+    allow_start_land: bool = False,
+    allow_end_land: bool = False,
+    oversample: int = 6,
+) -> bool:
+    """Return True when any route segment intersects land.
+
+    This uses the same dense segment sampling criterion as
+    ``reroute_around_land`` so downstream validation can match the rerouter's
+    notion of feasibility.
+    """
+    return bool(
+        route_crossing_segment_indices(
+            route,
+            land,
+            allow_start_land=allow_start_land,
+            allow_end_land=allow_end_land,
+            oversample=oversample,
+        )
+    )
+
+
+def _astar_segment_replacement(
+    a: np.ndarray,
+    b: np.ndarray,
+    n_removed: int,
+    is_land: np.ndarray,
+    x_axis: np.ndarray,
+    y_axis: np.ndarray,
+    land: Land,
+    max_safety_cells: int = 6,
+    allow_start_land: bool = False,
+    allow_end_land: bool = False,
+) -> np.ndarray | None:
+    """Compute A* replacement waypoints between two anchors."""
+    if n_removed <= 0:
+        return np.empty((0, 2), dtype=float)
+
+    for safety_cells in range(max_safety_cells + 1):
+        safe_land = _dilate_land_mask(is_land, safety_cells)
+        water = ~safe_land
+
+        start_cell = _nearest_water_cell(_point_to_cell(a, x_axis, y_axis), water)
+        end_cell = _nearest_water_cell(_point_to_cell(b, x_axis, y_axis), water)
+
+        if start_cell is None or end_cell is None:
+            continue
+
+        cells = _astar_cells(start_cell, end_cell, water)
+        if cells is None:
+            continue
+
+        path = np.array([[x_axis[ix], y_axis[iy]] for ix, iy in cells], dtype=float)
+        path[0] = a
+        path[-1] = b
+
+        replacement = _resample_polyline(path, n_removed)
+        candidate = np.vstack([a, replacement, b])
+        has_crossing = False
+        for i in range(len(candidate) - 1):
+            # If an endpoint is on land, the touching segment adjacent to that
+            # endpoint may be unavoidable; keep checking all interior segments.
+            if allow_start_land and i == 0:
+                continue
+            if allow_end_land and i == len(candidate) - 2:
+                continue
+            if _segment_crosses_land(candidate[i], candidate[i + 1], land):
+                has_crossing = True
+                break
+        if not has_crossing:
+            return replacement
+
+    return None
+
+
+def reroute_around_land(
+    route: np.ndarray,
+    land: Land,
+    astar_resolution_scale: int | None = None,
+    max_passes: int = 4,
+    max_anchor_expansion: int = 12,
+) -> np.ndarray:
+    """Replace land-crossing route runs using A* on a high-resolution land grid.
+
+    The function keeps the original route length and edits only runs of segments
+    that intersect land.
+
+    Parameters
+    ----------
+    route : np.ndarray
+        Waypoints as an array of shape ``(N, 2)`` with ``[lon, lat]`` columns.
+    land : Land
+        The original ``routetools.land.Land`` object used for land/water checks.
+    astar_resolution_scale : int, optional
+        Integer upsampling factor for the A* occupancy grid. When omitted, the
+        function uses ``land.avoidance_resolution_scale``. Values greater than
+        1 increase search resolution.
+    max_passes : int, optional
+        Maximum correction passes across the route. Defaults to 4.
+    max_anchor_expansion : int, optional
+        Maximum number of outward anchor-expansion attempts per crossing run.
+        Defaults to 12.
+
+    Returns
+    -------
+    np.ndarray
+        Corrected route with the same shape as ``route``.
+    """
+    route = np.asarray(route, dtype=float)
+    if route.ndim != 2 or route.shape[1] != 2:
+        raise ValueError(f"route must have shape (N, 2), got {route.shape}")
+    if not isinstance(land, Land):
+        raise TypeError("land must be an instance of routetools.land.Land")
+    astar_resolution_scale = _resolve_avoidance_resolution_scale(
+        land, astar_resolution_scale
+    )
+
+    n_points = len(route)
+    if n_points < 2:
+        return route.copy()
+
+    is_land, x_axis, y_axis = _build_astar_grid(land, astar_resolution_scale)
+    result = route.copy()
+
+    for _ in range(max_passes):
+        crossing_seg = np.zeros(n_points - 1, dtype=bool)
+        for i in range(n_points - 1):
+            crossing_seg[i] = _segment_crosses_land(result[i], result[i + 1], land)
+
+        if not crossing_seg.any():
+            break
+
+        runs: list[tuple[int, int]] = []
+        idx = 0
+        while idx < len(crossing_seg):
+            if not crossing_seg[idx]:
+                idx += 1
+                continue
+            end = idx
+            while end + 1 < len(crossing_seg) and crossing_seg[end + 1]:
+                end += 1
+            runs.append((idx, end))
+            idx = end + 1
+
+        for seg_start, seg_end in runs:
+            base_a_idx = seg_start
+            base_b_idx = seg_end + 1
+
+            while base_a_idx > 0 and _point_is_land(result[base_a_idx], land):
+                base_a_idx -= 1
+            while base_b_idx < n_points - 1 and _point_is_land(
+                result[base_b_idx], land
+            ):
+                base_b_idx += 1
+
+            if base_a_idx >= base_b_idx:
+                continue
+            base_a_is_land = _point_is_land(result[base_a_idx], land)
+            base_b_is_land = _point_is_land(result[base_b_idx], land)
+            if base_a_is_land and base_a_idx != 0:
+                continue
+            if base_b_is_land and base_b_idx != n_points - 1:
+                continue
+
+            applied = False
+            for expand in range(max_anchor_expansion + 1):
+                anchor_a_idx = max(0, base_a_idx - expand)
+                anchor_b_idx = min(n_points - 1, base_b_idx + expand)
+
+                while anchor_a_idx > 0 and _point_is_land(result[anchor_a_idx], land):
+                    anchor_a_idx -= 1
+                while anchor_b_idx < n_points - 1 and _point_is_land(
+                    result[anchor_b_idx], land
+                ):
+                    anchor_b_idx += 1
+
+                if anchor_a_idx >= anchor_b_idx:
+                    continue
+                anchor_a_is_land = _point_is_land(result[anchor_a_idx], land)
+                anchor_b_is_land = _point_is_land(result[anchor_b_idx], land)
+                allow_start_land = anchor_a_is_land and anchor_a_idx == 0
+                allow_end_land = anchor_b_is_land and anchor_b_idx == n_points - 1
+
+                if anchor_a_is_land and not allow_start_land:
+                    continue
+                if anchor_b_is_land and not allow_end_land:
+                    continue
+
+                n_removed = anchor_b_idx - anchor_a_idx - 1
+                if n_removed <= 0:
+                    continue
+
+                a = result[anchor_a_idx]
+                b = result[anchor_b_idx]
+                replacement = _astar_segment_replacement(
+                    a,
+                    b,
+                    n_removed,
+                    is_land,
+                    x_axis,
+                    y_axis,
+                    land,
+                    allow_start_land=allow_start_land,
+                    allow_end_land=allow_end_land,
+                )
+                if replacement is None:
+                    continue
+
+                result[anchor_a_idx + 1 : anchor_b_idx] = replacement
+                applied = True
+                break
+
+            if not applied:
+                n_removed = base_b_idx - base_a_idx - 1
+                if n_removed > 0:
+                    result[base_a_idx + 1 : base_b_idx] = np.linspace(
+                        result[base_a_idx],
+                        result[base_b_idx],
+                        n_removed + 2,
+                    )[1:-1]
+
+    return result

--- a/scripts/demo_land_avoidance.py
+++ b/scripts/demo_land_avoidance.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python
+"""Demo script for reroute_around_land between configurable ports.
+
+The script:
+1. Builds a great-circle route (route_gc).
+2. Reroutes it with ``reroute_around_land`` (route_land).
+3. Plots both routes and highlights waypoints that touch land.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+import numpy as np
+import typer
+
+from routetools._cost.haversine import (
+    great_circle_route,
+    haversine_meters_components,
+)
+from routetools._ports import DICT_PORTS
+from routetools.era5 import load_natural_earth_land_mask
+from routetools.fms import optimize_fms
+from routetools.land import (
+    Land,
+    reroute_around_land,
+    route_crossing_segment_indices,
+)
+from routetools.vectorfield import vectorfield_zero
+
+
+def _land_touch_mask(route: np.ndarray, land: Land) -> np.ndarray:
+    """Return boolean mask of waypoints that lie on land."""
+    return np.asarray(land._check_nointerp(jnp.asarray(route)), dtype=bool).reshape(-1)
+
+
+def _route_distance_km(route: np.ndarray) -> float:
+    """Return total route length in kilometers using haversine segments."""
+    route_jnp = jnp.asarray(route)
+    if route_jnp.shape[0] < 2:
+        return 0.0
+
+    lats = route_jnp[:, 1]
+    lons = route_jnp[:, 0]
+    dx, dy = haversine_meters_components(
+        lats[1:],
+        lons[1:],
+        lats[:-1],
+        lons[:-1],
+    )
+    dists_m = jnp.sqrt(dx**2 + dy**2)
+    return float(jnp.sum(dists_m) / 1000.0)
+
+
+def _run_fms_with_endpoint_land_handling(
+    route: np.ndarray,
+    land: Land,
+    patience: int,
+    damping: float,
+    maxfevals: int,
+) -> tuple[np.ndarray, dict[str, object]]:
+    """Run FMS and optionally strip/restore boundary points that are on land."""
+    route_in = np.asarray(route, dtype=float)
+    touch = _land_touch_mask(route_in, land)
+    land_idx = np.flatnonzero(touch)
+
+    drop_start = False
+    drop_end = False
+    if land_idx.size > 0 and np.all(np.isin(land_idx, [0, len(route_in) - 1])):
+        drop_start = bool(touch[0])
+        drop_end = bool(touch[-1])
+        if drop_start:
+            route_in = route_in[1:]
+        if drop_end:
+            route_in = route_in[:-1]
+
+    if route_in.shape[0] < 3:
+        return np.asarray(route, dtype=float), {
+            "status": "skipped",
+            "reason": "too_few_points_after_endpoint_strip",
+        }
+
+    try:
+        curve_fms, info = optimize_fms(
+            vectorfield_zero,
+            curve=jnp.asarray(route_in),
+            land=land,
+            travel_stw=1.0,
+            patience=patience,
+            damping=damping,
+            maxfevals=maxfevals,
+            spherical_correction=True,
+            verbose=False,
+        )
+        route_fms = np.asarray(curve_fms[0], dtype=float)
+    except ValueError as exc:
+        return np.asarray(route, dtype=float), {
+            "status": "skipped",
+            "reason": str(exc),
+        }
+
+    if drop_start:
+        route_fms = np.vstack([route[:1], route_fms])
+    if drop_end:
+        route_fms = np.vstack([route_fms, route[-1:]])
+
+    crossing_before_fix = route_crossing_segment_indices(
+        route_fms,
+        land,
+        allow_start_land=True,
+        allow_end_land=True,
+    )
+    post_fms_reroute_applied = bool(crossing_before_fix)
+    if post_fms_reroute_applied:
+        route_fms = reroute_around_land(route_fms, land)
+
+    crossing_after_fix = route_crossing_segment_indices(
+        route_fms,
+        land,
+        allow_start_land=True,
+        allow_end_land=True,
+    )
+
+    return route_fms, {
+        "status": "ok",
+        "drop_start": drop_start,
+        "drop_end": drop_end,
+        "niter": info.get("niter", None),
+        "post_fms_reroute_applied": post_fms_reroute_applied,
+        "segment_crossings_before_fix": len(crossing_before_fix),
+        "segment_crossings_after_fix": len(crossing_after_fix),
+    }
+
+
+def main(
+    src_port: str = "DEHAM",
+    dst_port: str = "USNYC",
+    output: Path = Path("output/demo_land_avoidance.png"),
+    n_points: int = 300,
+    land_avoidance_resolution_scale: int = 2,
+    land_resolution: float = 0.08,
+    ne_resolution: str = "50m",
+    margin_deg: float = 6.0,
+    fms_patience: int = 1000,
+    fms_damping: float = 0.5,
+    fms_maxfevals: int = 100000,
+    show: bool = False,
+) -> None:
+    """Generate and plot land-avoidance routes between two ports."""
+    t0 = time.perf_counter()
+    t_last = t0
+
+    def log_step(message: str) -> None:
+        nonlocal t_last
+        t_now = time.perf_counter()
+        dt_step = t_now - t_last
+        dt_total = t_now - t0
+        print(f"[{dt_total:7.2f}s | +{dt_step:6.2f}s] {message}")
+        t_last = t_now
+
+    log_step("Starting demo_land_avoidance run")
+
+    src_port = src_port.upper()
+    dst_port = dst_port.upper()
+
+    if src_port not in DICT_PORTS:
+        raise ValueError(
+            f"Unknown src_port '{src_port}'. Valid codes: {sorted(DICT_PORTS)}"
+        )
+    if dst_port not in DICT_PORTS:
+        raise ValueError(
+            f"Unknown dst_port '{dst_port}'. Valid codes: {sorted(DICT_PORTS)}"
+        )
+
+    log_step(f"Using corridor {src_port} -> {dst_port}")
+
+    src = jnp.array([DICT_PORTS[src_port]["lon"], DICT_PORTS[src_port]["lat"]])
+    dst = jnp.array([DICT_PORTS[dst_port]["lon"], DICT_PORTS[dst_port]["lat"]])
+
+    route_gc = np.asarray(great_circle_route(src, dst, n_points=n_points), dtype=float)
+    log_step(f"Built great-circle route with {n_points} points")
+
+    lon_min = float(np.min(route_gc[:, 0]) - margin_deg)
+    lon_max = float(np.max(route_gc[:, 0]) + margin_deg)
+    lat_min = float(max(-90.0, np.min(route_gc[:, 1]) - margin_deg))
+    lat_max = float(min(90.0, np.max(route_gc[:, 1]) + margin_deg))
+
+    land = load_natural_earth_land_mask(
+        lon_range=(lon_min, lon_max),
+        lat_range=(lat_min, lat_max),
+        resolution=land_resolution,
+        ne_resolution=ne_resolution,
+        interpolate=0,
+        avoidance_resolution_scale=land_avoidance_resolution_scale,
+    )
+    log_step(
+        "Loaded Natural Earth land mask "
+        f"({ne_resolution}, res={land_resolution}, shape={land.shape}, "
+        f"avoidance_scale={land.avoidance_resolution_scale})"
+    )
+
+    route_land = reroute_around_land(route_gc, land=land)
+    log_step(
+        "Computed rerouted path "
+        f"with land_avoidance_resolution_scale={land.avoidance_resolution_scale}"
+    )
+
+    route_fms, fms_info = _run_fms_with_endpoint_land_handling(
+        route_land,
+        land,
+        patience=fms_patience,
+        damping=fms_damping,
+        maxfevals=fms_maxfevals,
+    )
+    log_step(
+        "Ran FMS refinement "
+        f"(patience={fms_patience}, damping={fms_damping}, "
+        f"maxfevals={fms_maxfevals}, status={fms_info.get('status')})"
+    )
+
+    touch_gc = _land_touch_mask(route_gc, land)
+    touch_land = _land_touch_mask(route_land, land)
+    touch_fms = _land_touch_mask(route_fms, land)
+    crossings_gc = route_crossing_segment_indices(
+        route_gc,
+        land,
+        allow_start_land=True,
+        allow_end_land=True,
+    )
+    crossings_land = route_crossing_segment_indices(
+        route_land,
+        land,
+        allow_start_land=True,
+        allow_end_land=True,
+    )
+    crossings_fms = route_crossing_segment_indices(
+        route_fms,
+        land,
+        allow_start_land=True,
+        allow_end_land=True,
+    )
+    dist_gc_km = _route_distance_km(route_gc)
+    dist_land_km = _route_distance_km(route_land)
+    dist_fms_km = _route_distance_km(route_fms)
+    log_step("Computed route diagnostics (land touches and distances)")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    fig, ax = plt.subplots(figsize=(11, 6.5))
+    ax.contourf(
+        np.asarray(land.x),
+        np.asarray(land.y),
+        np.asarray(land.array).T,
+        levels=[0.0, 0.5, 1.0],
+        colors=["#dcefff", "#8f8f8f"],
+        alpha=0.9,
+        zorder=0,
+    )
+
+    (line_gc,) = ax.plot(
+        route_gc[:, 0],
+        route_gc[:, 1],
+        color="#1f77b4",
+        lw=2.0,
+        label=f"route_gc ({dist_gc_km:.1f} km)",
+        zorder=2,
+    )
+    (line_land,) = ax.plot(
+        route_land[:, 0],
+        route_land[:, 1],
+        color="#d62728",
+        lw=2.0,
+        label=f"route_land ({dist_land_km:.1f} km)",
+        zorder=3,
+    )
+    (line_fms,) = ax.plot(
+        route_fms[:, 0],
+        route_fms[:, 1],
+        color="#2ca02c",
+        lw=2.0,
+        label=f"route_fms ({dist_fms_km:.1f} km)",
+        zorder=4,
+    )
+
+    if touch_gc.any():
+        ax.scatter(
+            route_gc[touch_gc, 0],
+            route_gc[touch_gc, 1],
+            s=50,
+            marker=".",
+            facecolors="none",
+            edgecolors=line_gc.get_color(),
+            linewidths=1.5,
+            zorder=4,
+        )
+
+    if touch_land.any():
+        ax.scatter(
+            route_land[touch_land, 0],
+            route_land[touch_land, 1],
+            s=50,
+            marker="o",
+            facecolors="none",
+            edgecolors=line_land.get_color(),
+            linewidths=1.5,
+            zorder=5,
+        )
+
+    if touch_fms.any():
+        ax.scatter(
+            route_fms[touch_fms, 0],
+            route_fms[touch_fms, 1],
+            s=50,
+            marker=".",
+            facecolors="none",
+            edgecolors=line_fms.get_color(),
+            linewidths=1.5,
+            zorder=6,
+        )
+
+    ax.scatter(float(src[0]), float(src[1]), color="black", s=40, zorder=7)
+    ax.scatter(float(dst[0]), float(dst[1]), color="black", s=40, zorder=7)
+    ax.text(float(src[0]), float(src[1]), f" {src_port}", va="bottom", ha="left")
+    ax.text(float(dst[0]), float(dst[1]), f" {dst_port}", va="bottom", ha="left")
+
+    ax.set_xlim(lon_min, lon_max)
+    ax.set_ylim(lat_min, lat_max)
+    ax.set_xlabel("Longitude [deg]")
+    ax.set_ylabel("Latitude [deg]")
+    ax.set_title(f"Land avoidance demo: {src_port} -> {dst_port}")
+    ax.grid(True, alpha=0.25)
+    ax.legend(loc="best")
+    fig.tight_layout()
+
+    fig.savefig(output, dpi=180)
+    if show:
+        plt.show()
+    plt.close(fig)
+    log_step(f"Rendered and saved plot to {output}")
+
+    print(f"Saved plot to: {output}")
+    print(f"corridor: {src_port} -> {dst_port}")
+    print(f"route_gc distance: {dist_gc_km:.1f} km")
+    print(f"route_land distance: {dist_land_km:.1f} km")
+    print(f"route_fms distance: {dist_fms_km:.1f} km")
+    print(f"route_gc waypoint land-touch points: {int(touch_gc.sum())}")
+    print(f"route_land waypoint land-touch points: {int(touch_land.sum())}")
+    print(f"route_fms waypoint land-touch points: {int(touch_fms.sum())}")
+    print(f"route_gc segment crossings: {len(crossings_gc)}")
+    print(f"route_land segment crossings: {len(crossings_land)}")
+    print(f"route_fms segment crossings: {len(crossings_fms)}")
+    print(f"fms status: {fms_info.get('status')}")
+    if fms_info.get("status") == "ok":
+        print(
+            "fms endpoint handling: "
+            f"drop_start={fms_info.get('drop_start')}, "
+            f"drop_end={fms_info.get('drop_end')}"
+        )
+        print(f"fms iterations: {fms_info.get('niter')}")
+        print(
+            "fms post-fix crossings: "
+            f"before={fms_info.get('segment_crossings_before_fix')}, "
+            f"after={fms_info.get('segment_crossings_after_fix')}, "
+            f"reroute_applied={fms_info.get('post_fms_reroute_applied')}"
+        )
+    else:
+        print(f"fms reason: {fms_info.get('reason')}")
+
+    log_step("Run complete")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/tests/test_reroute_land.py
+++ b/tests/test_reroute_land.py
@@ -1,0 +1,232 @@
+"""Tests for reroute_around_land using a Land object and A* corrections."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import routetools.land as land_module
+from routetools.land import Land, reroute_around_land, route_crosses_land
+
+
+def _make_land(strips: list[tuple[float, float, float, float]]) -> Land:
+    """Create deterministic Land with rectangular strip obstacles."""
+    xlim = (0.0, 6.0)
+    ylim = (-2.0, 2.0)
+    resolution = (20, 20)
+
+    nx = int(np.ceil(xlim[1] - xlim[0])) * resolution[0]
+    ny = int(np.ceil(ylim[1] - ylim[0])) * resolution[1]
+    x = np.linspace(*xlim, nx)
+    y = np.linspace(*ylim, ny)
+
+    array = np.zeros((nx, ny), dtype=float)
+    for xmin, xmax, ymin, ymax in strips:
+        x_mask = (x >= xmin) & (x <= xmax)
+        y_mask = (y >= ymin) & (y <= ymax)
+        array[np.ix_(x_mask, y_mask)] = 1.0
+
+    return Land(
+        xlim=xlim,
+        ylim=ylim,
+        water_level=0.5,
+        resolution=resolution,
+        interpolate=0,
+        outbounds_is_land=True,
+        land_array=jnp.array(array),
+        penalize_segments=False,
+        map_mode="nearest",
+        map_order=0,
+    )
+
+
+def _segment_crosses_land(a: np.ndarray, b: np.ndarray, land: Land) -> bool:
+    """Dense segment check against Land object."""
+    samples = np.linspace(a, b, 200)
+    is_land = np.asarray(land(samples), dtype=bool).reshape(-1)
+    return bool(is_land[1:-1].any())
+
+
+def _route_has_land_crossing(route: np.ndarray, land: Land) -> bool:
+    """Return True if any route segment crosses land."""
+    return any(
+        _segment_crosses_land(route[i], route[i + 1], land)
+        for i in range(len(route) - 1)
+    )
+
+
+def _route_has_land_crossing_except_last(route: np.ndarray, land: Land) -> bool:
+    """Return True if any segment except the last one crosses land."""
+    return any(
+        _segment_crosses_land(route[i], route[i + 1], land)
+        for i in range(len(route) - 2)
+    )
+
+
+@pytest.fixture()
+def vertical_strip_land() -> Land:
+    """Single obstacle crossing the route center line."""
+    return _make_land([(2.0, 3.0, -1.0, 1.0)])
+
+
+@pytest.fixture()
+def route_no_crossing() -> np.ndarray:
+    """Route entirely in water, far from obstacles."""
+    return np.array([[0.0, -1.8], [1.0, -1.8], [2.0, -1.8], [3.0, -1.8], [4.0, -1.8]])
+
+
+@pytest.fixture()
+def route_crossing() -> np.ndarray:
+    """Route with two interior points inside the strip obstacle."""
+    return np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [2.2, 0.0],
+            [2.8, 0.0],
+            [4.0, 0.0],
+            [5.0, 0.0],
+        ]
+    )
+
+
+def test_no_crossing_returns_same(route_no_crossing, vertical_strip_land):
+    """Route with no land crossings must remain unchanged."""
+    result = reroute_around_land(route_no_crossing, vertical_strip_land)
+    np.testing.assert_array_equal(result, route_no_crossing)
+
+
+def test_output_same_shape(route_crossing, vertical_strip_land):
+    """Output shape must match input route shape."""
+    result = reroute_around_land(route_crossing, vertical_strip_land)
+    assert result.shape == route_crossing.shape
+
+
+def test_only_crossing_middle_is_replaced(route_crossing, vertical_strip_land):
+    """Non-crossing anchor points stay untouched; only middle points are replaced."""
+    result = reroute_around_land(route_crossing, vertical_strip_land)
+    np.testing.assert_allclose(result[0], route_crossing[0])
+    np.testing.assert_allclose(result[1], route_crossing[1])
+    np.testing.assert_allclose(result[4], route_crossing[4])
+    np.testing.assert_allclose(result[5], route_crossing[5])
+    assert not np.allclose(result[2], route_crossing[2])
+    assert not np.allclose(result[3], route_crossing[3])
+
+
+def test_astar_correction_avoids_land(route_crossing, vertical_strip_land):
+    """A* replacement yields a route with no segment crossing land."""
+    result = reroute_around_land(
+        route_crossing,
+        vertical_strip_land,
+        astar_resolution_scale=3,
+    )
+    assert not _route_has_land_crossing(result, vertical_strip_land)
+
+
+def test_multiple_crossing_runs_are_replaced():
+    """Two disjoint crossing runs are both corrected."""
+    land = _make_land([(1.0, 2.0, -1.0, 1.0), (4.0, 5.0, -1.0, 1.0)])
+    route = np.array(
+        [
+            [0.0, 0.0],
+            [0.6, 0.0],
+            [1.1, 0.0],
+            [1.4, 0.0],
+            [1.7, 0.0],
+            [2.0, 0.0],
+            [3.0, 0.0],
+            [3.6, 0.0],
+            [4.1, 0.0],
+            [4.4, 0.0],
+            [4.7, 0.0],
+            [5.0, 0.0],
+            [6.0, 0.0],
+        ]
+    )
+    result = reroute_around_land(route, land, astar_resolution_scale=3)
+    assert result.shape == route.shape
+    assert not _route_has_land_crossing(result, land)
+
+
+def test_accepts_jax_route(route_crossing, vertical_strip_land):
+    """Function should accept JAX arrays as route input."""
+    jax_route = jnp.array(route_crossing)
+    result = reroute_around_land(jax_route, vertical_strip_land)
+    assert result.shape == route_crossing.shape
+
+
+def test_invalid_land_type_raises(route_crossing):
+    """A Land object is required by the new API."""
+    with pytest.raises(TypeError, match="land must be an instance"):
+        reroute_around_land(route_crossing, land=np.zeros((2, 2)))  # type: ignore[arg-type]
+
+
+def test_all_water_land_is_noop(route_crossing):
+    """If land map is fully water, route is unchanged."""
+    land = _make_land([])
+    result = reroute_around_land(route_crossing, land)
+    np.testing.assert_array_equal(result, route_crossing)
+
+
+def test_reroute_uses_land_avoidance_resolution_by_default(
+    route_no_crossing,
+    vertical_strip_land,
+    monkeypatch,
+):
+    """Default reroute resolution should come from the Land object."""
+    captured: dict[str, int] = {}
+    original_build_astar_grid = land_module._build_astar_grid
+    vertical_strip_land.avoidance_resolution_scale = 5
+
+    def wrapped_build_astar_grid(land: Land, astar_resolution_scale: int):
+        captured["astar_resolution_scale"] = astar_resolution_scale
+        return original_build_astar_grid(land, astar_resolution_scale)
+
+    monkeypatch.setattr(land_module, "_build_astar_grid", wrapped_build_astar_grid)
+
+    reroute_around_land(route_no_crossing, vertical_strip_land)
+
+    assert captured["astar_resolution_scale"] == 5
+
+
+def test_endpoint_on_land_still_reroutes_middle_points():
+    """When destination is on land, interior points are still rerouted."""
+    land = _make_land([(4.5, 6.0, -0.5, 0.5)])
+    route = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [2.0, 0.0],
+            [3.0, 0.0],
+            [4.0, 0.0],
+            [5.0, 0.0],
+            [6.0, 0.0],
+        ]
+    )
+
+    assert bool(np.asarray(land(route[-1]), dtype=bool).item())
+
+    result = reroute_around_land(route, land, astar_resolution_scale=3)
+
+    np.testing.assert_allclose(result[0], route[0])
+    np.testing.assert_allclose(result[-1], route[-1])
+    assert not np.allclose(result[5], route[5])
+    assert not _route_has_land_crossing_except_last(result, land)
+
+
+def test_route_crosses_land_can_ignore_terminal_land_touch():
+    """Segment crossing checks should allow unavoidable endpoint land touches."""
+    land = _make_land([(5.5, 6.0, -0.5, 0.5)])
+    route = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [2.0, 0.0],
+            [3.0, 0.0],
+            [4.0, 0.0],
+            [5.0, 0.0],
+            [6.0, 0.0],
+        ]
+    )
+
+    assert route_crosses_land(route, land)
+    assert not route_crosses_land(route, land, allow_end_land=True)


### PR DESCRIPTION
This pull request introduces several improvements and new features related to land avoidance routing, as well as some code quality and testing enhancements. The most significant changes include the addition of a comprehensive demo script for land avoidance, new tests for the `reroute_around_land` function, and improvements to land mask handling. There are also minor code cleanups and import adjustments.

**Land avoidance and routing improvements:**

* Added a new demo script `scripts/demo_land_avoidance.py` that demonstrates land avoidance routing between configurable ports, including route generation, rerouting, FMS refinement, and plotting with diagnostics.
* Enhanced the `load_natural_earth_land_mask` function in `routetools/era5/loader.py` to accept an `avoidance_resolution_scale` parameter, allowing control over the resolution of the A* grid used for rerouting. Added validation for this parameter and updated docstrings accordingly. [[1]](diffhunk://#diff-aee9d300125285b059d12535e54dbdb6955be613ac6d81bdd3af3d1cafb9e225R850) [[2]](diffhunk://#diff-aee9d300125285b059d12535e54dbdb6955be613ac6d81bdd3af3d1cafb9e225R874-R876) [[3]](diffhunk://#diff-aee9d300125285b059d12535e54dbdb6955be613ac6d81bdd3af3d1cafb9e225R1005-R1007)
* Set `avoidance_resolution_scale = 2` by default in the `load_era5_land_mask` function for consistent land avoidance behavior.

**Testing improvements:**

* Added a comprehensive test suite in `tests/test_reroute_land.py` for the `reroute_around_land` function, covering various edge cases, input types, and configuration scenarios.